### PR TITLE
Allow view duplication form

### DIFF
--- a/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriber.php
+++ b/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriber.php
@@ -49,9 +49,16 @@ class ConfigReadOnlyEventSubscriber implements EventSubscriberInterface {
    */
   protected $readOnlyFormIds = [
     'config_single_import_form',
-    'system_modules',
     'system_modules_uninstall',
-    'user_admin_permissions',
+  ];
+
+  /**
+   * Form IDs that we find that can be bypassed such as views duplication.
+   *
+   * @var array
+   */
+  protected $bypassFormIds = [
+    'view_duplicate_form',
   ];
 
   /**
@@ -64,6 +71,7 @@ class ConfigReadOnlyEventSubscriber implements EventSubscriberInterface {
     $config = $config_factory->get('hs_config_readonly.settings');
     $this->excludedModules = $config->get('excluded_modules') ?: $this->excludedModules;
     $this->readOnlyFormIds = $config->get('form_ids') ?: $this->readOnlyFormIds;
+    $this->readOnlyFormIds = $config->get('bypass_form_ids') ?: $this->readOnlyFormIds;
   }
 
   /**
@@ -87,6 +95,12 @@ class ConfigReadOnlyEventSubscriber implements EventSubscriberInterface {
     // Check if the form is a ConfigFormBase or a ConfigEntityListBuilder.
     $form_object = $event->getFormState()->getFormObject();
     $mark_form_read_only = $form_object instanceof ConfigFormBase;
+
+    // Some forms are safe to allow to the user because they duplicate configs,
+    // not modify them.
+    if (in_array($form_object->getFormId(), $this->bypassFormIds)) {
+      return;
+    }
 
     if (!$mark_form_read_only) {
       $mark_form_read_only = in_array($form_object->getFormId(), $this->readOnlyFormIds);
@@ -160,6 +174,8 @@ class ConfigReadOnlyEventSubscriber implements EventSubscriberInterface {
   protected function configIsLocked($config) {
     $config = is_array($config) ? $config : [$config];
     $locked_config = $this->getLockedConfigs();
+    dpm($config);
+    dpm($locked_config);
     return !empty(array_intersect($config, $locked_config));
   }
 

--- a/docroot/modules/humsci/hs_config_readonly/src/config/schema/hs_config_readonly.schema.yml
+++ b/docroot/modules/humsci/hs_config_readonly/src/config/schema/hs_config_readonly.schema.yml
@@ -8,4 +8,6 @@ hs_config_readonly.settings:
     form_ids:
       type: sequence
       label: 'Always Blocked Form Ids'
-
+    bypass_form_ids:
+      type: sequence
+      label: 'Form IDs which should bypass locks'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- View duplication is locked right now. this opens that up and allows for additional form ids if we find any more.

# Needed By (Date)
- Thursday Morning

# Urgency
- High

# Steps to Test

1. Checkout this branch
2. sync to production
3. enable hs_config_readonly & clear caches
4. ensure you can duplicate a view

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)