### PR TITLE
ARCH-314 removed bottom margin from images on vcards

### DIFF
--- a/docroot/themes/humsci/su_humsci_theme/patterns/molecules/vertical-card/css/vertical-card.css
+++ b/docroot/themes/humsci/su_humsci_theme/patterns/molecules/vertical-card/css/vertical-card.css
@@ -1,3 +1,3 @@
-.vertical-card .vertical-card__img img{width:100%;margin:0 0 .75em}.vertical-card .vertical-card__content-container{background:#fff;box-shadow:0 2px 2px 0 rgba(0,0,0,0.2);padding:.75em}.view .vertical-card .vertical-card__content-container{margin:0 0 1.5em}.vertical-card .vertical-card__content-container .vertical-card__title{margin-top:0}
+.vertical-card .vertical-card__img img{width:100%}.vertical-card .vertical-card__content-container{background:#fff;box-shadow:0 2px 2px 0 rgba(0,0,0,0.2);padding:.75em}.view .vertical-card .vertical-card__content-container{margin:0 0 1.5em}.vertical-card .vertical-card__content-container .vertical-card__title{margin-top:0}
 
 /*# sourceMappingURL=vertical-card.css.map */

--- a/docroot/themes/humsci/su_humsci_theme/patterns/molecules/vertical-card/scss/vertical-card.scss
+++ b/docroot/themes/humsci/su_humsci_theme/patterns/molecules/vertical-card/scss/vertical-card.scss
@@ -16,8 +16,6 @@
   .vertical-card__img {
     img {
       width: 100%;
-
-      @include margin(0 0 0.75em 0);
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed bottom margin from vertical card images

# Needed By (Date)
- End of sprint (8/2)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Ensure that there is no margin below images in the vertical card pattern

# Affected Projects or Products
- Archeology
- suhumsci (theme)

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ARCH-314

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)