### PR TITLE
HSD8-115 Node Edit Protection javascript

### DIFF
--- a/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
+++ b/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
@@ -10,7 +10,7 @@
   // Flag the form has been edited.
   var edit = false;
 
-  Drupal.behaviors.nodeEditProtection = {
+  Drupal.behaviors.SuHumsciAdminNodeProtection = {
     attach: function (context, settings) {
       // Add listeners for all types of data entry.
       $("input, button, :input", context).on('blur change click dblclick keydown mousedown select submit', function (e) {

--- a/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
+++ b/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
@@ -5,10 +5,10 @@
 
 (function ($, Drupal) {
   'use strict';
+  // Allow Save Submit button.
   var save = false;
-  // Allow Submit/Edit button.
+  // Flag the form has been edited.
   var edit = false;
-  // Dirty form flag.
 
   Drupal.behaviors.nodeEditProtection = {
     attach: function (context, settings) {

--- a/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
+++ b/docroot/themes/humsci/su_humsci_admin/js/node-protection.js
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Stops page from changing when user is posting.
+ */
+
+(function ($, Drupal) {
+  'use strict';
+  var save = false;
+  // Allow Submit/Edit button.
+  var edit = false;
+  // Dirty form flag.
+
+  Drupal.behaviors.nodeEditProtection = {
+    attach: function (context, settings) {
+      // Add listeners for all types of data entry.
+      $("input, button, :input", context).on('blur change click dblclick keydown mousedown select submit', function (e) {
+        edit = true;
+        save = false;
+
+        // Node save button.
+        if ($(this).attr('value') == 'Save') {
+          save = true;
+        }
+      });
+
+      // Handle backbutton, exit etc.
+      window.onbeforeunload = function () {
+        // Add CKEditor support.
+        if (typeof (CKEDITOR) != 'undefined' && typeof (CKEDITOR.instances) != 'undefined') {
+          for (var i in CKEDITOR.instances) {
+            if (CKEDITOR.instances[i].checkDirty()) {
+              edit = true;
+              break;
+            }
+          }
+        }
+
+        if (edit && !save) {
+          return (Drupal.t("You will lose all unsaved work."));
+        }
+      }
+    }
+  };
+})(jQuery, Drupal);

--- a/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.libraries.yml
+++ b/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.libraries.yml
@@ -93,3 +93,11 @@ base:
   css:
     base:
       css/base/base.css: {}
+
+node_protection:
+  version: VERSION
+  js:
+    js/node-protection.js: {}
+  dependencies:
+    - material_admin/global-styling
+

--- a/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
+++ b/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
@@ -4,3 +4,14 @@
  * @file
  * su_humsci_admin.theme
  */
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function su_humsci_admin_preprocess_page(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name == 'entity.node.edit_form') {
+    // We add the library here because a hook_form_alter doesn't work.
+    $variables['#attached']['library'][] = 'su_humsci_admin/node_protection';
+  }
+}

--- a/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
+++ b/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
@@ -11,8 +11,16 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_form_alter().
  */
 function su_humsci_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $route_name = \Drupal::routeMatch()->getRouteName();
-  if ($route_name == 'entity.node.edit_form' || $route_name == 'node.add') {
-    $form['#attached']['library'][] = 'su_humsci_admin/node_protection';
+  /** @var \Drupal\Core\Entity\EntityTypeBundleInfo $bundle_info */
+  $bundle_info = \Drupal::service('entity_type.bundle.info');
+  $bundles = $bundle_info->getBundleInfo('node');
+
+  // Each node type has 2 different form ID's. One for creation and one for
+  // edits. We want to add the library to all node forms.
+  foreach (array_keys($bundles) as $bundle) {
+    if ($form_id == "node_{$bundle}_form" || $form == "node_{$bundle}_edit_form") {
+      $form['#attached']['library'][] = 'su_humsci_admin/node_protection';
+      break;
+    }
   }
 }

--- a/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
+++ b/docroot/themes/humsci/su_humsci_admin/su_humsci_admin.theme
@@ -5,13 +5,14 @@
  * su_humsci_admin.theme
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
- * Implements hook_preprocess_page().
+ * Implements hook_form_alter().
  */
-function su_humsci_admin_preprocess_page(&$variables) {
+function su_humsci_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $route_name = \Drupal::routeMatch()->getRouteName();
-  if ($route_name == 'entity.node.edit_form') {
-    // We add the library here because a hook_form_alter doesn't work.
-    $variables['#attached']['library'][] = 'su_humsci_admin/node_protection';
+  if ($route_name == 'entity.node.edit_form' || $route_name == 'node.add') {
+    $form['#attached']['library'][] = 'su_humsci_admin/node_protection';
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Protect the node edit form from un-intentionally leaving and loosing work.

# Needed By (Date)
- End of sprint (Aug 16th)

# Urgency
- Low

# Steps to Test

1. Checkout this branch
1. clear cache
1. Edit an existing node and click on/change any field
1. attempt to leave the page by trying to reload, clicking on another link or anything
1. validate you receive a popup notification about loosing changes
1. attempt to save the changed node and validate it saves without a popup.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)