### PR TITLE
Arch 376 views reset

### DIFF
--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.libraries.yml
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.libraries.yml
@@ -4,3 +4,10 @@ admin:
     js/hs_field_helpers.admin.js: {}
   dependencies:
     - core/jquery
+
+views_reset:
+  version: VERSION
+  js:
+    js/hs_field_helpers.views_reset.js: {}
+  dependencies:
+    - drupal.ajax

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -610,7 +610,6 @@ function hs_field_helpers_form_views_exposed_form_alter(&$form, FormStateInterfa
   // Ajax blocks using the module views_block_filter_block do not display the
   // "Reset" button after the form has been submitted. So we are going to change
   // the access and apply some javascript to help keep the ajaxy feel.
-//  $form['#attributes']['class'][] = 'ajax-form';
   $form['actions']['reset']['#access'] = TRUE;
   $form['#attached']['library'][] = 'hs_field_helpers/views_reset';
 }

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -598,3 +598,19 @@ function hs_field_helpers_execute_migration(MigrationInterface $migration, $migr
   $executable->import();
   $executed_migrations[$migration_id] = $migration_id;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function hs_field_helpers_form_views_exposed_form_alter(&$form, FormStateInterface $form_state) {
+  if (empty($form['actions']['reset'])) {
+    return;
+  }
+
+  // Ajax blocks using the module views_block_filter_block do not display the
+  // "Reset" button after the form has been submitted. So we are going to change
+  // the access and apply some javascript to help keep the ajaxy feel.
+//  $form['#attributes']['class'][] = 'ajax-form';
+  $form['actions']['reset']['#access'] = TRUE;
+  $form['#attached']['library'][] = 'hs_field_helpers/views_reset';
+}

--- a/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
+++ b/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
@@ -3,16 +3,23 @@
 
   Drupal.behaviors.hsFieldHelpersViewsReset = {
     attach: function attach(context, settings) {
-      console.log(context);
-      console.log(Drupal.views);
 
-      $.each(Drupal.views.instances, function (key, view) {
-        $(view['$exposed_form']).find('input[data-drupal-selector=edit-reset]').click(function (e) {
-          e.preventDefault();
+      $.each(Drupal.views.instances, function (key, ajaxView) {
+        ajaxView['$exposed_form'].find('input[data-drupal-selector=edit-reset]').once('views-reset').each(function () {
+          $(this).click(function (e) {
+            e.preventDefault();
 
-          $(view['$exposed_form'])[0].reset();
-          $(view['$view']).trigger('RefreshView');
-        });
+            // Reset the form and trigger chosen select fields.
+            ajaxView['$exposed_form'][0].reset();
+            $(ajaxView['$exposed_form'][0]).find('select').trigger("chosen:updated");
+
+            // Trigger('RefreshView') causes the view to reload twice. So we use
+            // a click action on the submit button after clearing all the field
+            // values. Keeping the RefreshView in case we need it later.
+            // Drupal.views.instances[key]['$view'].trigger('RefreshView');
+            $(this).siblings('input[data-drupal-selector^="edit-submit-"]').click();
+          });
+        })
       });
     }
   };

--- a/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
+++ b/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
@@ -1,0 +1,19 @@
+(function ($, Drupal) {
+  'use strict';
+
+  Drupal.behaviors.hsFieldHelpersViewsReset = {
+    attach: function attach(context, settings) {
+      console.log(context);
+      console.log(Drupal.views);
+
+      $.each(Drupal.views.instances, function (key, view) {
+        $(view['$exposed_form']).find('input[data-drupal-selector=edit-reset]').click(function (e) {
+          e.preventDefault();
+
+          $(view['$exposed_form'])[0].reset();
+          $(view['$view']).trigger('RefreshView');
+        });
+      });
+    }
+  };
+})(jQuery, Drupal);

--- a/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
+++ b/docroot/modules/humsci/hs_field_helpers/js/hs_field_helpers.views_reset.js
@@ -5,21 +5,19 @@
     attach: function attach(context, settings) {
 
       $.each(Drupal.views.instances, function (key, ajaxView) {
-        ajaxView['$exposed_form'].find('input[data-drupal-selector=edit-reset]').once('views-reset').each(function () {
-          $(this).click(function (e) {
-            e.preventDefault();
+        ajaxView['$exposed_form'].find('input[data-drupal-selector=edit-reset]').once('views-reset').click(function (e) {
+          e.preventDefault();
 
-            // Reset the form and trigger chosen select fields.
-            ajaxView['$exposed_form'][0].reset();
-            $(ajaxView['$exposed_form'][0]).find('select').trigger("chosen:updated");
+          // Reset the form and trigger chosen select fields.
+          ajaxView['$exposed_form'][0].reset();
+          $(ajaxView['$exposed_form'][0]).find('select').trigger("chosen:updated");
 
-            // Trigger('RefreshView') causes the view to reload twice. So we use
-            // a click action on the submit button after clearing all the field
-            // values. Keeping the RefreshView in case we need it later.
-            // Drupal.views.instances[key]['$view'].trigger('RefreshView');
-            $(this).siblings('input[data-drupal-selector^="edit-submit-"]').click();
-          });
-        })
+          // Trigger('RefreshView') causes the view to reload twice. So we use
+          // a click action on the submit button after clearing all the field
+          // values. Keeping the RefreshView in case we need it later.
+          // Drupal.views.instances[key]['$view'].trigger('RefreshView');
+          $(this).siblings('input[data-drupal-selector^="edit-submit-"]').click();
+        });
       });
     }
   };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add the reset button to view filters and use ajax to reset the form and results.

# Needed By (Date)
- Sept 13

# Urgency
- Hight

# Steps to Test

1. checkout this branch
1. clone archaeology with partial to keep custom views `blt drupal:sync --site=archaeology --partial`
1. view any page with a view filter.
1. ensure the reset button displays
1. ensure the reset button clears the form and reloads the view


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)