### PR TITLE
Hsd8 480 collapse mobile items

### DIFF
--- a/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
+++ b/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
@@ -8,14 +8,22 @@
       this.menuEdgeCheck(context);
 
       // Open/close the menu from hamburger button.
-      $header.find('button.fa-bars').once().click(function () {
+      $('button.fa-bars', $header).once().click(function () {
         menuExpander(this);
       });
 
       // Open/close submenus from the plus button.
-      $header.find('button.fa-plus').once().click(function () {
-        menuExpander(this);
-        $(this).toggleClass('fa-plus').toggleClass('fa-minus');
+      $('button.fa-plus', $header).once().click(function (e) {
+        var button = this;
+        // Close all other menu items before opening this one.
+        $('button.fa-minus').each(function (i, minusButton) {
+          if (!minusButton.isEqualNode(button)) {
+            $(minusButton).click();
+          }
+        });
+
+        menuExpander(button);
+        $(button).toggleClass('fa-plus').toggleClass('fa-minus');
       });
 
       function menuExpander(theMenu) {

--- a/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
+++ b/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
@@ -14,16 +14,12 @@
 
       // Open/close submenus from the plus button.
       $('button.fa-plus', $header).once().click(function (e) {
-        var button = this;
-        // Close all other menu items before opening this one.
-        $('button.fa-minus').each(function (i, minusButton) {
-          if (!minusButton.isEqualNode(button)) {
-            $(minusButton).click();
-          }
-        });
-
-        menuExpander(button);
-        $(button).toggleClass('fa-plus').toggleClass('fa-minus');
+        // Collapase all menu items outside of the one that was clicked.
+        // This prevents overlapping submenus.
+        $(this).parent().siblings().find('.fa-minus').click();
+        $(this).siblings('ul').find('.fa-minus').click();
+        menuExpander(this);
+        $(this).toggleClass('fa-plus').toggleClass('fa-minus');
       });
 
       function menuExpander(theMenu) {

--- a/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
+++ b/docroot/themes/humsci/su_humsci_theme/js/hover_menu.js
@@ -2,18 +2,18 @@
   'use strict';
   Drupal.behaviors.HoverMenu = {
     attach: function (context, settings) {
-      var $header = $('#header');
+      var $header = $('#header', context);
 
       this.setMenu(context);
       this.menuEdgeCheck(context);
 
       // Open/close the menu from hamburger button.
-      $('button.fa-bars', $header).once().click(function () {
+      $('button.fa-bars', $header).click(function () {
         menuExpander(this);
       });
 
       // Open/close submenus from the plus button.
-      $('button.fa-plus', $header).once().click(function (e) {
+      $('button.fa-plus', $header).click(function (e) {
         // Collapase all menu items outside of the one that was clicked.
         // This prevents overlapping submenus.
         $(this).parent().siblings().find('.fa-minus').click();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Collapse other menu item when a new one is expanded
- Additional styling still required for 3rd level menus. but that is not currently shown.

# Needed By (Date)
- Wednesday

# Urgency
- Medium

# Steps to Test

1. checkout this branch
1. clear caches
1. view the site in mobile
1. ensure the mobile menu interaction is correct.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)