### PR TITLE
HSD8-477 Set initial ECK permissions on creation

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -15,6 +15,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
 use Drupal\user\Entity\Role;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_install_tasks_alter().
@@ -180,4 +181,26 @@ function su_humsci_profile_simplify_condition_forms(array &$condition_elements, 
   if (isset($condition_elements['entity_bundle:node'])) {
     unset($condition_elements['node_type']);
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function hs_field_helpers_eck_entity_type_insert(EntityInterface $entity) {
+  $eck_type = $entity->id();
+  // When a new ECK entity type is create, set initial permissions so that
+  // site builders aren't required to search for the necessary permissions.
+  user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ["view any $eck_type entities"]);
+  user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ["view any $eck_type entities"]);
+
+  user_role_grant_permissions('contributor', [
+    "create $eck_type entities",
+    "delete own $eck_type entities",
+    "edit own $eck_type entities",
+  ]);
+  user_role_grant_permissions('site_manager', [
+    "create $eck_type entities",
+    "delete any $eck_type entities",
+    "edit any $eck_type entities",
+  ]);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set initial permissions when a new ECK type is created.

# Needed By (Date)
- No rush

# Urgency
- low

# Steps to Test

1. checkout this branch
1. clear caches
1. create a new ECK type at `/admin/structure/eck`
1. verify permissions are configured for that new ECK:
    * Anonymous and Authenticated can view the ECK
    * Contributors can create and edit/delete their own
    * Site managers can create and edit/delete any


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)