### PR TITLE
HS-113 invalidate capx content

### DIFF
--- a/docroot/modules/humsci/hs_capx/src/Form/CapxImporterDeleteForm.php
+++ b/docroot/modules/humsci/hs_capx/src/Form/CapxImporterDeleteForm.php
@@ -3,37 +3,14 @@
 namespace Drupal\hs_capx\Form;
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Builds the form to delete Capx importer entities.
  */
 class CapxImporterDeleteForm extends EntityConfirmFormBase {
-
-  /**
-   * Migration cache bin service.
-   *
-   * @var \Drupal\Core\Cache\CacheBackendInterface
-   */
-  protected $migrationCache;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static($container->get('cache.discovery_migration'));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function __construct(CacheBackendInterface $migration_cache) {
-    $this->migrationCache = $migration_cache;
-  }
 
   /**
    * {@inheritdoc}
@@ -60,11 +37,7 @@ class CapxImporterDeleteForm extends EntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->migrationCache->invalidate('migration_plugins');
-    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
-
     $this->entity->delete();
-
     drupal_set_message(
       $this->t('content @type: deleted @label.',
         [
@@ -75,6 +48,7 @@ class CapxImporterDeleteForm extends EntityConfirmFormBase {
     );
 
     $form_state->setRedirectUrl($this->getCancelUrl());
+    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
   }
 
 }

--- a/docroot/modules/humsci/hs_capx/src/Form/CapxImporterDeleteForm.php
+++ b/docroot/modules/humsci/hs_capx/src/Form/CapxImporterDeleteForm.php
@@ -2,14 +2,38 @@
 
 namespace Drupal\hs_capx\Form;
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Builds the form to delete Capx importer entities.
  */
 class CapxImporterDeleteForm extends EntityConfirmFormBase {
+
+  /**
+   * Migration cache bin service.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $migrationCache;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('cache.discovery_migration'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(CacheBackendInterface $migration_cache) {
+    $this->migrationCache = $migration_cache;
+  }
 
   /**
    * {@inheritdoc}
@@ -36,6 +60,9 @@ class CapxImporterDeleteForm extends EntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->migrationCache->invalidate('migration_plugins');
+    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
+
     $this->entity->delete();
 
     drupal_set_message(
@@ -44,7 +71,7 @@ class CapxImporterDeleteForm extends EntityConfirmFormBase {
           '@type' => $this->entity->bundle(),
           '@label' => $this->entity->label(),
         ]
-        )
+      )
     );
 
     $form_state->setRedirectUrl($this->getCancelUrl());

--- a/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
+++ b/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
@@ -3,7 +3,6 @@
 namespace Drupal\hs_capx\Form;
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityForm;
@@ -26,13 +25,6 @@ class CapxImporterForm extends EntityForm {
   protected $entityFieldManager;
 
   /**
-   * Migration cache bin service.
-   *
-   * @var \Drupal\Core\Cache\CacheBackendInterface
-   */
-  protected $migrationCache;
-
-  /**
    * Database connection service.
    *
    * @var \Drupal\Core\Database\Connection
@@ -53,7 +45,6 @@ class CapxImporterForm extends EntityForm {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('entity_field.manager'),
-      $container->get('cache.discovery_migration'),
       $container->get('database')
     );
   }
@@ -61,10 +52,9 @@ class CapxImporterForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, CacheBackendInterface $migration_cache, Connection $database) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, Connection $database) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
-    $this->migrationCache = $migration_cache;
     $this->database = $database;
   }
 
@@ -194,9 +184,6 @@ class CapxImporterForm extends EntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
-    $this->migrationCache->invalidate('migration_plugins');
-    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
-
     // Add permission to execute importer.
     $role = $this->entityTypeManager->getStorage('user_role')
       ->load('site_manager');
@@ -222,9 +209,7 @@ class CapxImporterForm extends EntityForm {
         ]));
     }
     $form_state->setRedirectUrl($importer->toUrl('collection'));
-  }
 
-  public static function invalidateTags(){
     Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
   }
 

--- a/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
+++ b/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
@@ -3,6 +3,8 @@
 namespace Drupal\hs_capx\Form;
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -24,21 +26,46 @@ class CapxImporterForm extends EntityForm {
   protected $entityFieldManager;
 
   /**
+   * Migration cache bin service.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $migrationCache;
+
+  /**
+   * Database connection service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The original entity before saving.
+   *
+   * @var \Drupal\hs_capx\Entity\CapxImporterInterface
+   */
+  protected $originalEntity;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('entity_field.manager')
+      $container->get('entity_field.manager'),
+      $container->get('cache.discovery_migration'),
+      $container->get('database')
     );
   }
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, CacheBackendInterface $migration_cache, Connection $database) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
+    $this->migrationCache = $migration_cache;
+    $this->database = $database;
   }
 
   /**
@@ -49,6 +76,7 @@ class CapxImporterForm extends EntityForm {
 
     /** @var \Drupal\hs_capx\Entity\CapxImporterInterface $importer */
     $importer = $this->entity;
+    $this->originalEntity = clone $importer;
     $form['label'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Label'),
@@ -166,7 +194,9 @@ class CapxImporterForm extends EntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
-    Cache::invalidateTags(['migration_plugins']);
+    $this->migrationCache->invalidate('migration_plugins');
+    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
+
     // Add permission to execute importer.
     $role = $this->entityTypeManager->getStorage('user_role')
       ->load('site_manager');
@@ -186,11 +216,48 @@ class CapxImporterForm extends EntityForm {
         break;
 
       default:
+        $this->invalidateMigrationHashes();
         drupal_set_message($this->t('Saved the %label Capx importer.', [
           '%label' => $importer->label(),
         ]));
     }
     $form_state->setRedirectUrl($importer->toUrl('collection'));
+  }
+
+  public static function invalidateTags(){
+    Cache::invalidateTags(['migration_plugins', 'hs_capx_config']);
+  }
+
+  /**
+   * Invalidate migration mapper hashes to be updated on next import.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function invalidateMigrationHashes() {
+    // If the importer hasn't been executed, the table will not be created.
+    if (!$this->database->schema()->tableExists('migrate_map_hs_capx')) {
+      return;
+    }
+
+    $entity_query = $this->entityTypeManager->getStorage('node')
+      ->getQuery('OR');
+
+    // Find all node ids that art tagged with the fields. This allows us to only
+    // invalidate the hashes that are applicable.
+    foreach ($this->originalEntity->getFieldTags() as $field_name => $term_ids) {
+      foreach ($term_ids as $term_id) {
+        $entity_query->condition($field_name, $term_id);
+      }
+    }
+
+    $entity_ids = array_keys($entity_query->execute());
+    if ($entity_ids) {
+      $this->database->update('migrate_map_hs_capx')
+        ->condition('destid1', $entity_query->execute(), 'IN')
+        ->fields(['hash' => ''])
+        ->execute();
+    }
   }
 
 }

--- a/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
+++ b/docroot/modules/humsci/hs_capx/src/Form/CapxImporterForm.php
@@ -228,7 +228,7 @@ class CapxImporterForm extends EntityForm {
     $entity_query = $this->entityTypeManager->getStorage('node')
       ->getQuery('OR');
 
-    // Find all node ids that art tagged with the fields. This allows us to only
+    // Find all node ids that are tagged with the fields. This allows us to only
     // invalidate the hashes that are applicable.
     foreach ($this->originalEntity->getFieldTags() as $field_name => $term_ids) {
       foreach ($term_ids as $term_id) {

--- a/docroot/modules/humsci/hs_capx/src/Overrides/ConfigOverrides.php
+++ b/docroot/modules/humsci/hs_capx/src/Overrides/ConfigOverrides.php
@@ -143,7 +143,11 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    * {@inheritdoc}
    */
   public function getCacheableMetadata($name) {
-    return new CacheableMetadata();
+    $cacheable_data = new CacheableMetadata();
+    if ($name == 'migrate_plus.migration.hs_capx' || $name == 'migrate_plus.migration.hs_capx_images') {
+      $cacheable_data->setCacheTags(['hs_capx_config']);
+    }
+    return $cacheable_data;
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Clear caches _after_ importer entities are saved/deleted
- Invalidate migration hashes when an importer is updated. (new importers dont have anything to invalidate)
- Add cache tag to config override.

# Needed By (Date)
- 2/13

# Urgency
- High

# Steps to Test
1. checkout this branch
1. `composer install --prefer-source`
1. sync philit `blt drupal:sync --site=philit --partial`
1. roll back migrated items `drush @philit.local mr hs_capx; drush @philit.local mr hs_capx_images`
1. review the page `/admin/structure/migrate/manage/hs_capx/migrations` and take note of the "Total" number
1. delete one of the Capx importers on `/admin/structure/migrate/capx`
1. back on  `/admin/structure/migrate/manage/hs_capx/migrations` validate the "Total" has now changed.
1. import content `drush @philit.local mim hs_capx_images; drush @philit.local mim hs_capx`
1. review one of the imported profiles and take note of the taxonomy fields (maybe keep this open as a separate tab to ease review)
   * Affiliation
   * Faculty Type
   * Staff Type
   * Student Type
1. Edit one of the importers on `/admin/structure/migrate/capx` and change the tagging field settings to new terms
1. run importer `drush @philit.local mim hs_capx`
1. review that piece of content from above and ensure the new terms are represented in the respective fields.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)