### PR TITLE
HSD8-555 shortcut filter

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/css/su_humsci_profile.hide_manage.css
+++ b/docroot/profiles/humsci/su_humsci_profile/css/su_humsci_profile.hide_manage.css
@@ -1,0 +1,13 @@
+#toolbar-item-shortcuts-tray {
+  display: block;
+}
+
+#toolbar-item-administration-tray,
+#toolbar-item-administration {
+  display: none;
+}
+
+#toolbar-item-shortcuts {
+  pointer-events: none;
+  cursor: default;
+}

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -326,3 +326,11 @@ function su_humsci_profile_update_8012() {
   $block->setVisibilityConfig('request_path', $visibility);
   $block->save();
 }
+
+/**
+ * Add permission to view manage toolbar button for site managers roles.
+ */
+function su_humsci_profile_update_8014() {
+  Role::load('site_manager')->grantPermission('view toolbar manage')->save();
+  Role::load('contributor')->grantPermission('view toolbar manage')->save();
+}

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.libraries.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.libraries.yml
@@ -1,0 +1,5 @@
+hide_manage:
+  version: VERSION
+  css:
+    theme:
+      css/su_humsci_profile.hide_manage.css: {}

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.permissions.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.permissions.yml
@@ -4,3 +4,6 @@ add saml user:
 view user list:
   title: 'View User List'
   description: 'View list of all site users.'
+view toolbar manage:
+  title: 'View Toolbar Manage Button'
+  description: 'Users without this permission will be able to see Shortcuts in the toolbar, but not the full toolbar'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -174,7 +174,7 @@ function su_humsci_profile_simplify_condition_forms(array &$condition_elements, 
 /**
  * Implements hook_ENTITY_TYPE_insert().
  */
-function hs_field_helpers_eck_entity_type_insert(EntityInterface $entity) {
+function su_humsci_profile_eck_entity_type_insert(EntityInterface $entity) {
   $eck_type = $entity->id();
   // When a new ECK entity type is create, set initial permissions so that
   // site builders aren't required to search for the necessary permissions.
@@ -191,4 +191,40 @@ function hs_field_helpers_eck_entity_type_insert(EntityInterface $entity) {
     "delete any $eck_type entities",
     "edit any $eck_type entities",
   ]);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function su_humsci_profile_preprocess_menu(&$variables) {
+  if ($variables['menu_name'] != 'shortcut_menu') {
+    return;
+  }
+
+  $current_user = \Drupal::currentUser();
+  _su_humci_profile_clean_shortcut_links($variables['items'], $current_user);
+}
+
+/**
+ * Recursively remove links the current user has no access to.
+ *
+ * @param array $links
+ *   Menu links.
+ * @param \Drupal\Core\Session\AccountInterface $current_user
+ *   Current user object.
+ */
+function _su_humci_profile_clean_shortcut_links(array &$links, AccountInterface $current_user) {
+  foreach ($links as $link_id => $link_item) {
+
+    // This user doesn't have permission for this url. Remove the link.
+    if (!$link_item['url']->access($current_user)) {
+      unset($links[$link_id]);
+      continue;
+    }
+
+    // User has access to the parent menu link, but check all the children.
+    if (!empty($links[$link_id]['below'])) {
+      _su_humci_profile_clean_shortcut_links($links[$link_id]['below'], $current_user);
+    }
+  }
 }

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -228,3 +228,14 @@ function _su_humci_profile_clean_shortcut_links(array &$links, AccountInterface 
     }
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function su_humsci_profile_page_attachments(array &$attachments){
+  // Conditionally attach an asset to the page.
+  if (!\Drupal::currentUser()
+    ->hasPermission('view toolbar manage')) {
+    $attachments['#attached']['library'][] = 'su_humsci_profile/hide_manage';
+  }
+}

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -233,9 +233,10 @@ function _su_humci_profile_clean_shortcut_links(array &$links, AccountInterface 
  * Implements hook_page_attachments().
  */
 function su_humsci_profile_page_attachments(array &$attachments){
-  // Conditionally attach an asset to the page.
-  if (!\Drupal::currentUser()
-    ->hasPermission('view toolbar manage')) {
+  $current_user = \Drupal::currentUser();
+  // Hide the manage button in the toolbar if the user doesnt have permission.
+  // Also don't add the library if
+  if ($current_user->hasPermission('access toolbar') && !$current_user->hasPermission('view toolbar manage')) {
     $attachments['#attached']['library'][] = 'su_humsci_profile/hide_manage';
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove shortcut links if the user doesnt have access.
- Added permission that allows for roles to hide the "Manage" button in the toolbar

# Needed By (Date)
- Someday

# Urgency
- Low

# Steps to Test
1. checkout this branch
1. update database `drush @sitename.local updb -y`
1. add a link to an advanced admin page link `/admin/structure/views`(shortcuts can be configured at `/admin/config/user-interface/shortcut`)
1. add a user with a "Site Manager" role
1. masquerade as that user.
1. ensure you don't see the link you created for the admin page.
1. remove the permission  "View Toolbar Manage Button" from the "Site manager" role `drush @sitename.local role:perm:remove site_manager "view toolbar manage"`
1. verify you only see the shortcuts in the toolbar and not the "Manage" button
1. unmasquerade and verify you see the "Manage" button in the toolbar again.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)