### PR TITLE
Fix block labels

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -42,6 +42,9 @@ function su_humsci_profile_post_update_8_0_4() {
 
 /**
  * Fix layout builder block display.
+ *
+ * Views exposed filter blocks started showing the view title and we need to
+ * hide them as configured.
  */
 function su_humsci_profile_post_update_8_1_0() {
   $database = \Drupal::database();

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -39,3 +39,47 @@ function su_humsci_profile_post_update_8_0_4() {
     $block->delete();
   }
 }
+
+/**
+ * Fix layout builder block display.
+ */
+function su_humsci_profile_post_update_8_1_0() {
+  $database = \Drupal::database();
+  $tables = [
+    'node__layout_builder__layout',
+    'node_revision__layout_builder__layout',
+  ];
+
+  foreach ($tables as $table) {
+    $query = $database->select($table, 'l')
+      ->fields('l')
+      ->execute();
+    while ($row = $query->fetchAssoc()) {
+      $changed_row = FALSE;
+      /** @var \Drupal\layout_builder\Section $layout_section */
+      $layout_section = unserialize($row['layout_builder__layout_section']);
+      foreach ($layout_section->getComponents() as $component) {
+        $config = $component->get('configuration');
+        if (
+          isset($config['provider']) &&
+          $config['provider'] == 'views' &&
+          $config['label'] == '' &&
+          $config['views_label'] == ''
+        ) {
+          $config['label_display'] = 0;
+          $component->setConfiguration($config);
+          $changed_row = TRUE;
+        }
+      }
+
+      if ($changed_row) {
+        $database->update($table)
+          ->fields(['layout_builder__layout_section' => serialize($layout_section)])
+          ->condition('entity_id', $row['entity_id'])
+          ->condition('revision_id', $row['revision_id'])
+          ->condition('delta', $row['delta'])
+          ->execute();
+      }
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hide view block labels in layout builder node overrides.

# Needed By (Date)
- Wednesday noon 

# Urgency
- High

# Steps to Test
1. `git checkout fix-block-labels`
1. `composer install --prefer-source`
1. `blt drupal:sync --site=archaeology --partial`
1. review `/node/1` page and ensure the exposed filter on the left does not have a block title.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)