### PR TITLE
wrap views results when the view is grouped

### DIFF
--- a/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-unformatted.html.twig
+++ b/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-unformatted.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override to display a view of unformatted rows.
+ *
+ * Available variables:
+ * - title: The title of this group of rows. May be empty.
+ * - rows: A list of the view's row items.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's content.
+ * - view: The view object.
+ * - default_row_class: A flag indicating whether default classes should be
+ *   used on rows.
+ *
+ * @see template_preprocess_views_view_unformatted()
+ */
+#}
+{% if title %}
+  <h3>{{ title }}</h3>
+  {# Wrap the rows when a title is present (grouped views). #}
+  <div class="views-rows">
+{% endif %}
+{% for row in rows %}
+  {%
+    set row_classes = [
+      default_row_class ? 'views-row',
+    ]
+  %}
+  <div{{ row.attributes.addClass(row_classes) }}>
+    {{- row.content -}}
+  </div>
+{% endfor %}
+
+{% if title %}
+    </div>
+{% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Wrap view results when a grouped title is present. this helps with row classes like `decanter-width-one-fourth`.

# Needed By (Date)
- 7/17

# Urgency
- Medium

# Steps to Test
1. checkout this branch
1. `blt drupal:sync --site=shenlab --partial`
1. visit `/admin/structure/views/view/custm_custom_people?destination=/node/6`
1. change the format from "Grid" to "Unformatted List" and set the row class to be `decanter-width-one-fourth`
1. save the view and visit `/node/6` (it should take you there after saving)
1. validate the view results in the "Postdocs" group are 25% wide
1. validate in a tablet display, the items are 50% and have appropriate spacing between them and on the sides.
1. validate in mobile display the items are 100% and have appropriate spacing on the sides.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
