### PR TITLE
HSD8-678 Map course instructor role

### DIFF
--- a/config/default/core.entity_form_display.course_collections.instructor.default.yml
+++ b/config/default/core.entity_form_display.course_collections.instructor.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - eck.eck_type.course_collections.instructor
     - field.field.course_collections.instructor.field_instructor_person
+    - field.field.course_collections.instructor.field_instructor_role
 id: course_collections.instructor.default
 targetEntityType: course_collections
 bundle: instructor
@@ -15,6 +16,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  field_instructor_role:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   title:
     type: string_textfield

--- a/config/default/core.entity_view_display.course_collections.instructor.default.yml
+++ b/config/default/core.entity_view_display.course_collections.instructor.default.yml
@@ -26,14 +26,6 @@ content:
         inline_contents: 0
     type: entity_reference_label
     region: content
-  field_instructor_role:
-    weight: 2
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   title:
     label: hidden
     type: string
@@ -45,5 +37,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_instructor_role: true
   search_api_excerpt: true
   uid: true

--- a/config/default/core.entity_view_display.course_collections.instructor.default.yml
+++ b/config/default/core.entity_view_display.course_collections.instructor.default.yml
@@ -5,11 +5,10 @@ dependencies:
   config:
     - eck.eck_type.course_collections.instructor
     - field.field.course_collections.instructor.field_instructor_person
+    - field.field.course_collections.instructor.field_instructor_role
   module:
     - field_formatter_class
     - hs_field_helpers
-    - layout_builder
-    - layout_discovery
 id: course_collections.instructor.default
 targetEntityType: course_collections
 bundle: instructor
@@ -27,6 +26,14 @@ content:
         inline_contents: 0
     type: entity_reference_label
     region: content
+  field_instructor_role:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   title:
     label: hidden
     type: string
@@ -38,4 +45,5 @@ content:
 hidden:
   changed: true
   created: true
+  search_api_excerpt: true
   uid: true

--- a/config/default/field.field.course_collections.instructor.field_instructor_role.yml
+++ b/config/default/field.field.course_collections.instructor.field_instructor_role.yml
@@ -1,0 +1,19 @@
+uuid: 54dc626f-352c-4dcb-9cdf-58403f21894c
+langcode: en
+status: true
+dependencies:
+  config:
+    - eck.eck_type.course_collections.instructor
+    - field.storage.course_collections.field_instructor_role
+id: course_collections.instructor.field_instructor_role
+field_name: field_instructor_role
+entity_type: course_collections
+bundle: instructor
+label: 'Instructor Role'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.course_collections.field_instructor_role.yml
+++ b/config/default/field.storage.course_collections.field_instructor_role.yml
@@ -1,0 +1,21 @@
+uuid: f23691cc-6944-4467-a982-f211a97d787d
+langcode: en
+status: true
+dependencies:
+  module:
+    - eck
+id: course_collections.field_instructor_role
+field_name: field_instructor_role
+entity_type: course_collections
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/migrate_plus.migration.hs_courses.yml
+++ b/config/default/migrate_plus.migration.hs_courses.yml
@@ -306,6 +306,8 @@ process:
           bundle: instructor
           value_key: title
           source: name
+          values:
+            field_instructor_role: role
     -
       plugin: flatten
 destination:

--- a/docroot/modules/humsci/hs_courses/hs_courses.module
+++ b/docroot/modules/humsci/hs_courses/hs_courses.module
@@ -13,7 +13,27 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
  */
 function hs_courses_course_collections_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
   // On the ECK entity, if the instructor person is set, use that to display.
-  if (!empty($build['field_instructor_person']['#items'])) {
+  if ($entity->get('field_instructor_person')->count()) {
     unset($build['title']);
+    return;
+  }
+
+  /** @var \Drupal\Core\Field\FieldItemList $instructor_role_list */
+  $instructor_role_list = $entity->get('field_instructor_role');
+  if ($instructor_role_list->count()) {
+    $build['title'][0]['#context']['value'] .= ' (' . $instructor_role_list->getString() . ')';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Append the instructor's role onto the link title.
+ */
+function hs_courses_preprocess_field__field_instructor_person(&$variables) {
+  /** @var \Drupal\Core\Field\FieldItemList $instructor_role_list */
+  $instructor_role_list = $variables['element']['#object']->get('field_instructor_role');
+  if ($instructor_role_list->count()) {
+    $variables['items'][0]['content']['#title'] .= ' (' . $instructor_role_list->getString() . ')';
   }
 }

--- a/docroot/modules/humsci/hs_migrate/src/Plugin/migrate/process/EntityGenerateNoLookup.php
+++ b/docroot/modules/humsci/hs_migrate/src/Plugin/migrate/process/EntityGenerateNoLookup.php
@@ -42,6 +42,9 @@ class EntityGenerateNoLookup extends EntityGenerate {
    * {@inheritdoc}
    */
   public function transform($value, MigrateExecutableInterface $migrateExecutable, Row $row, $destinationProperty) {
+    $this->row = $row;
+    $this->migrateExecutable = $migrateExecutable;
+
     // In case of subfields ('field_reference/target_id'), extract the field
     // name only.
     $parts = explode('/', $destinationProperty);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Map the instructors role into a new field (for filtering or otherwise)
- display the instructor role in parenthesis next to the instructors name.

# Needed By (Date)
- 7/31

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. `composer install --prefer-source`
1. `blt drupal:sync --site=mathematics --partial`
1. `drush @mathematics.local mim hs_courses --update`
1. view a course that has instructors such as `Calculus`
1. verify the instructor's roles populated and are displayed something like `Kimport, S. (GP)`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
