### PR TITLE
Fix group block links from generating js errors

### DIFF
--- a/docroot/modules/humsci/hs_blocks/hs_blocks.links.contextual.yml
+++ b/docroot/modules/humsci/hs_blocks/hs_blocks.links.contextual.yml
@@ -1,4 +1,4 @@
-hs_blocks_block_update:
+hs_blocks.block_update:
   title: 'Configure'
   route_name: 'hs_blocks.update_block'
   group: 'hs_blocks_block'
@@ -8,7 +8,7 @@ hs_blocks_block_update:
       data-dialog-type: dialog
       data-dialog-renderer: off_canvas
 
-hs_blocks_block_remove:
+hs_blocks.block_remove:
   title: 'Remove block'
   route_name: 'hs_blocks.remove_block'
   group: 'hs_blocks_block'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix group block links in layout builder
- The data attributes have to match since contextual.js file will look at them and run an ajax call. Without the attributes matching exactly it will throw an error and cause contextual links to fail.

# Needed By (Date)
- asap

# Urgency
- high

# Steps to Test
1. checkout this branch
1. `composer install --prefer-source`
1. temporarily edit `config/envs/local/config_ignore.settings.yml`
1. add `'core.entity_view_display*'` into the `ignored_config_entities` set (this will allow you to do the following step without drush syncing the view display settings)
1. `blt drupal:sync --site=mathematics --partial`
1. visit `/admin/structure/types/manage/hs_event/display/default/layout` page
1. ensure you get contextual links on all fields, group blocks and anywhere appropriate in the layout builder
1. validate the "Add block to group" still functions correctly.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
