### PR TITLE
HSD8-675 Dont remove custom permissions like "administer nodes"

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -104,6 +104,7 @@ function su_humsci_profile_form_user_admin_permissions_alter(array &$form, FormS
       foreach ($roles as $role) {
         if (isset($form['permissions'][$permission_name][$role])) {
           $form['permissions'][$permission_name][$role]['#attributes']['disabled'] = TRUE;
+          $form['permissions'][$permission_name][$role]['#value'] = $form['permissions'][$permission_name][$role]['#default_value'] ?? 0;
         }
       }
     }

--- a/tests/behat/features/global/Permissions.feature
+++ b/tests/behat/features/global/Permissions.feature
@@ -6,7 +6,7 @@ Feature: Permissions
 
   @api @safe
   Scenario: Test permission form submit
-    Given I run drush "role:add-perm site_manager 'administer nodes'"
+    Given I run drush "role-add-perm site_manager 'administer nodes'"
     Then I am logged in as a user with the "Developer" role
     And I am on "/admin/users/permissions"
     Then I press "Save permissions"

--- a/tests/behat/features/global/Permissions.feature
+++ b/tests/behat/features/global/Permissions.feature
@@ -1,0 +1,14 @@
+@global
+Feature: Permissions
+  In order to Ensure custom permissions are kept
+  As a user
+  I should be able save permissions without removing other permissions.
+
+  @api @safe
+  Scenario: Test permission form submit
+    Given I run drush "role:add-perm site_manager 'administer nodes'"
+    Then I am logged in as a user with the "Developer" role
+    And I am on "/admin/users/permissions"
+    Then I press "Save permissions"
+    Then I run drush "cget user.role.site_manager permissions"
+    And drush output should contain "administer nodes"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- disabling a field removes the value from a form submit so set the `'#value'` to the `'#default_value'` of the disabled permission.
- I added the behat tests before adding the fix, so CircleCI shows hows the fix is validated.

# Needed By (Date)
- ASAP

# Urgency
- High

# Steps to Test
1. Checkout this branch.
1. sync any site
1. add `administer nodes` to the `site_manager` role via drush `drush @youralias rap site_manager 'administer nodes'`
1. log into the site and masquerade as another administrator. You can't be user 1
1. go to permission page and just save the form with no changes
1. ensure the site_manager role still has the "administer content" permission

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
