### PR TITLE
HSD8-697 Add cache key for group blocks

### DIFF
--- a/docroot/modules/humsci/hs_blocks/src/Plugin/Block/GroupBlock.php
+++ b/docroot/modules/humsci/hs_blocks/src/Plugin/Block/GroupBlock.php
@@ -133,6 +133,14 @@ class GroupBlock extends BlockBase implements ContainerFactoryPluginInterface, R
     // Set the cache keys so that each block will have its own cache, even if
     // it has the same machine name on different entity displays.
     $build['#cache']['keys'] = array_keys($build['components']);
+
+    /** @var \Drupal\Core\Plugin\Context\EntityContext $entityContext */
+    $entityContext = $this->getContext('entity');
+    // Adds a cache key for each entity to make each block unique.
+    $build['#cache']['keys'][] = $entityContext->getContextData()
+      ->getValue()
+      ->id();
+
     $build['#attached']['library'][] = 'hs_blocks/group_block';
     return $build;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add the entity id as one of the cache keys so that each group block will be different for each entity.

# Needed By (Date)
- asap

# Urgency
- high

# Steps to Test
1. checkout `8.1.8-release` branch first
1. `composer install --prefer-source`
1. sync mathematics `blt drupal:sync --site=mathematics --partial`
1. export event display settings from prod and import them on your local.
   1. [on the production site](https://mathematics.stanford.edu/admin/config/development/configuration/single/export) choose "Entity view display" and then "Event content items (node.hs_event.default)"
   1. copy that and paste into your local path at `/admin/config/development/configuration/single/import` (choose "Entity view display" in the dropdown)
   1. Click "Import"
1. navigate to `/events/upcoming-events` and click on one of the events. any of them
1. notice the location in the left sidebar.
1. go back and click on another event.
1. validate it has the same location information.
1. checkout this branch & clear cache
1. repeat the steps above starting at viewing `/events/upcoming-events`
1. Validate the events have different locations.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
