### PR TITLE
HSD8-721 Fix validation for date ranges when in ECKs

### DIFF
--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -251,7 +251,7 @@ function hs_field_helpers_form_field_config_edit_form_validate(&$form, FormState
 function hs_field_helpers_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\WidgetBaseInterface $widget */
   $widget = $context['widget'];
-  //dpm($widget->getPluginId());
+
   switch ($widget->getPluginId()) {
     case 'daterange_datelist':
     case 'daterange_default':

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -251,7 +251,7 @@ function hs_field_helpers_form_field_config_edit_form_validate(&$form, FormState
 function hs_field_helpers_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\WidgetBaseInterface $widget */
   $widget = $context['widget'];
-
+  //dpm($widget->getPluginId());
   switch ($widget->getPluginId()) {
     case 'daterange_datelist':
     case 'daterange_default':
@@ -316,16 +316,16 @@ function hs_field_helpers_node_validate_date(array &$element, FormStateInterface
 
   foreach ($entity->getFieldDefinitions() as $field_definition) {
     if ($field_definition->getType() == 'daterange') {
-      $date = $form_state->getValue($field_definition->getName());
+      $date = $form_state->getValue($element['#parents']);
 
       // If the start value is populated but end is empty, copy the start date
       // to the end date to pass validation.
-      if (!empty($date[0]['value']) && (!$date[0]['show_end'] || empty($date[0]['end_value']))) {
-        $date[0]['end_value'] = $date[0]['value'];
-        $element['end_value']['#value']['object'] = $date[0]['end_value'];
+      if (!empty($date['value']) && (!$element['show_end']['#value'] || empty($date['end_value']))) {
+        $date['end_value'] = $date['value'];
+        $element['end_value']['#value'] = $element['value']['#value'];
 
         /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
-        $form_state->setValue($field_definition->getName(), $date);
+        $form_state->setValue($element['#parents'], $date);
       }
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed date range field validation when the field is used in an ECK on a node form.

# Need Review By (Date)
- 10/8

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. `composer install --prefer-source`
1. `blt drupal:sync --site=archaeology --partial`
1. on `/admin/structure/types/manage/hs_event/form-display` display the "Conference Sessions" field and use an "Inline Entity Form (Complex)" widget setting
1. create an event
1. in the "Conference Sessions" area enter different values for the session date field.
1. validate that it doesnt give errors when the date & times are valid.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
