### PR TITLE
HSD8-722 Adjust the display of contextual links

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -22,7 +22,8 @@ use Drupal\user\RoleInterface;
 function su_humsci_profile_contextual_links_alter(array &$links, $group, array $route_parameters) {
   if ($group == 'paragraph') {
     // Paragraphs edit module clone link does not function correctly. Remove it
-    // from available links.
+    // from available links. Also remove delete to avoid unwanted delete.
+    unset($links['paragraphs_edit.delete_form']);
     unset($links['paragraphs_edit.clone_form']);
   }
 }

--- a/docroot/themes/humsci/su_humsci_theme/css/components/atoms/index.css
+++ b/docroot/themes/humsci/su_humsci_theme/css/components/atoms/index.css
@@ -1,1 +1,1 @@
-.pager{text-align:center;padding:0}.pager .pager__item{padding:0}
+.pager{text-align:center;padding:0}.pager .pager__item{padding:0}.contextual-region.paragraph .contextual{right:0px}.contextual-region.paragraph .contextual-region .contextual{right:32px}.contextual-region.paragraph .contextual-region .contextual-region .contextual{right:64px}.contextual-region.paragraph .contextual-region .contextual-region .contextual-region .contextual{right:96px}.contextual-region.paragraph .contextual-region .contextual-region .contextual-region .contextual-region .contextual{right:128px}

--- a/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/_contextual_links.scss
+++ b/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/_contextual_links.scss
@@ -4,7 +4,7 @@
 // Space them all out so we can see them all.
 $sel: '';
 @for $i from 0 through 4 {
-  $sel: if($i == 0, ".contextual-region.paragraph", selector-nest($sel, ".contextual-region")) !global;
+  $sel: if($i == 0, '.contextual-region.paragraph', selector-nest($sel, '.contextual-region')) !global;
 
   #{$sel} {
     .contextual {

--- a/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/_contextual_links.scss
+++ b/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/_contextual_links.scss
@@ -1,0 +1,14 @@
+@charset "UTF-8";
+
+// Overlapping contextual links are difficult. Different links show at the top for different users.
+// Space them all out so we can see them all.
+$sel: '';
+@for $i from 0 through 4 {
+  $sel: if($i == 0, ".contextual-region.paragraph", selector-nest($sel, ".contextual-region")) !global;
+
+  #{$sel} {
+    .contextual {
+      right: 32px * $i;
+    }
+  }
+}

--- a/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/index.scss
+++ b/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/index.scss
@@ -5,4 +5,5 @@
 //
 
 @import
-  'pager';
+  'pager',
+  'contextual_links';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove paragraph delete contextual link
- added styles to stagger overlapping contextual links.

# Need Review By (Date)
- 10/23

# Urgency
- low

# Steps to Test
1. checkout this branch
1. run `window.sessionStorage.clear();` in the console. (contextual links are heavily cached)
1. clear caches
1. create a basic page
1. add a row paragraph, and then at least one paragraph within that row
1. after saving, validate the contextual link on the paragraph does not have a "Delete" option
1. validate the paragraph inside the row display 2 contextual links (one for itself, another for the row paragraph)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
