### PR TITLE
Fix tag deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,9 @@ deploy_tag: &deploy_tag
   steps:
     - *add_ssh
     - *add_known_hosts
-    - attach_workspace:
-        at: .
+    - checkout
+    - restore_cache: *restore_cache
+    - run: composer install --optimize-autoloader
     - run:
         name: Deploying Tag to Acquia
         command: |
@@ -207,10 +208,7 @@ workflows:
   version: 2
   test_lint_deploy:
     jobs:
-      - run-setup:
-          filters:
-            tags:
-              only: /.*/
+      - run-setup
       - run-behat-tests-first:
           requires:
             - run-setup
@@ -247,8 +245,6 @@ workflows:
       # Tags are only created on successful code. Deploy the tag after creation.
       # This will trigger after the release is created above.
       - run-deploy-tag:
-          requires:
-            - run-setup
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,10 @@ workflows:
   version: 2
   test_lint_deploy:
     jobs:
-      - run-setup
+      - run-setup:
+          filters:
+            tags:
+              only: /.*/
       - run-behat-tests-first:
           requires:
             - run-setup


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Dont require the `run-setup` task when deploying tags. currently it doesnt work because the `run-setup` command doesn't run when a tag is created. see [CircleCi Documentation](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag) for info on that.
- Also eliminating the `run-setup` task shortens the amount of time to deploy a tag.

# Need Review By (Date)
- Tuesday 10/15 EOD

# Urgency
- high

# Steps to Test
1. Nothing to test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
