### PR TITLE
HSD8-724 Allow overriding node status of migrated items

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -4,7 +4,7 @@ services:
   suhumsci:
 
     # Use PHP 7.2 with Apache
-    image: pookmish/drupal8ci:latest
+    image: pookmish/tugboat:latest
 
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
@@ -23,14 +23,15 @@ services:
         # Install drush-launcher
         - wget -O /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
         - chmod +x /usr/local/bin/drush
-        -
+
         # Symlink the tugboat directory to the docker image expected path.
-        - rm -rf /var/www/html
-        - ln -snf ${TUGBOAT_ROOT} /var/www/html
+        - rm -rf /var/www/localhost
+        - ln -snf ${TUGBOAT_ROOT} /var/www/localhost
+        - ln -s docroot htdocs
 
         # Copy the tugboat blt settings.
         - cp "${TUGBOAT_ROOT}/.tugboat/tugboat.blt.yml" "${TUGBOAT_ROOT}/blt/local.blt.yml"
-        -
+
         # Install/update packages managed by composer, including drush
         - composer install --no-ansi
 
@@ -40,14 +41,15 @@ services:
 
         # Copy SimpleSAMLphp configuration to prevent annoying errors.
         - vendor/bin/blt source:build:simplesamlphp-config
-      update:
-        - composer install --no-ansi
-      build:
         - drush si config_installer -y
         - drush cim -y
         - drush cim -y
         - drush user:create tugboat --password=tugboat
         - drush user:role:add administrator tugboat
+      build:
+        - composer install --no-ansi
+        - vendor/bin/blt drupal:udpate
+
     # Collection of urls to compare visual results.
     visualdiffs:
       - /

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -33,7 +33,7 @@ services:
         - cp "${TUGBOAT_ROOT}/.tugboat/tugboat.blt.yml" "${TUGBOAT_ROOT}/blt/local.blt.yml"
 
         # Install/update packages managed by composer, including drush
-        - composer install --no-ansi --no-dev
+        - composer install --no-ansi
 
         # Init the settings files.
         - vendor/bin/blt blt:init:settings
@@ -47,7 +47,7 @@ services:
         - drush user:create tugboat --password=tugboat
         - drush user:role:add administrator tugboat
       build:
-        - composer install --no-ansi --no-dev
+        - composer install --no-ansi
         - vendor/bin/blt drupal:udpate
 
     # Collection of urls to compare visual results.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -48,7 +48,7 @@ services:
         - drush user:role:add administrator tugboat
       build:
         - composer install --no-ansi
-        - vendor/bin/blt drupal:udpate
+        - vendor/bin/blt drupal:update
 
     # Collection of urls to compare visual results.
     visualdiffs:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -33,7 +33,7 @@ services:
         - cp "${TUGBOAT_ROOT}/.tugboat/tugboat.blt.yml" "${TUGBOAT_ROOT}/blt/local.blt.yml"
 
         # Install/update packages managed by composer, including drush
-        - composer install --no-ansi
+        - composer install --no-ansi --no-dev
 
         # Init the settings files.
         - vendor/bin/blt blt:init:settings
@@ -47,7 +47,7 @@ services:
         - drush user:create tugboat --password=tugboat
         - drush user:role:add administrator tugboat
       build:
-        - composer install --no-ansi
+        - composer install --no-ansi --no-dev
         - vendor/bin/blt drupal:udpate
 
     # Collection of urls to compare visual results.

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -179,5 +179,20 @@ destination:
   plugin: 'entity_reference_revisions:node'
   new_revisions: true
   force_revision: true
+  overwrite_properties:
+    - title
+    - revision_timestamp
+    - revision_translation_affected
+    - type
+    - field_hs_person_first_name
+    - field_hs_person_last_name
+    - field_hs_person_title
+    - body/value
+    - body/format
+    - field_hs_person_email
+    - field_hs_person_telephone
+    - field_hs_person_external_profile/uri
+    - field_hs_person_external_profile/title
+    - field_hs_person_image/target_id
 migration_dependencies:
   required: {  }

--- a/config/default/migrate_plus.migration.hs_courses.yml
+++ b/config/default/migrate_plus.migration.hs_courses.yml
@@ -313,5 +313,33 @@ process:
       plugin: flatten
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - type
+    - title
+    - body/value
+    - body/format
+    - field_hs_course_grading
+    - field_hs_course_code
+    - field_hs_course_code_int
+    - field_hs_course_id
+    - field_hs_course_requirements
+    - field_hs_course_section_id
+    - field_hs_course_section_number
+    - field_hs_course_subject
+    - field_hs_course_section_units
+    - field_hs_course_section_location
+    - field_hs_course_academic_career
+    - field_hs_course_academic_year
+    - field_hs_course_section_comp
+    - field_hs_course_explore_tags
+    - field_hs_course_tags
+    - field_hs_course_section_quarter
+    - field_hs_course_link
+    - field_hs_course_section_days
+    - field_hs_course_section_st_date
+    - field_hs_course_section_end_date
+    - field_hs_course_section_end_time
+    - field_hs_course_section_st_time
+    - field_hs_course_section_instruc
 migration_dependencies:
   required: {  }

--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -256,6 +256,30 @@ process:
         name: drupal_video_name
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - type
+    - title
+    - body/value
+    - body/format
+    - field_hs_event_admission/value
+    - field_hs_event_admission/format
+    - field_hs_event_contact_email
+    - field_hs_event_contact_phone
+    - field_hs_event_sponsor
+    - field_hs_event_location
+    - field_hs_event_map_link/uri
+    - field_hs_event_map_link/title
+    - field_hs_event_link/uri
+    - field_hs_event_link/title
+    - field_hs_event_date/value
+    - field_hs_event_date/end_value
+    - field_hs_event_category
+    - field_hs_event_audience
+    - field_hs_event_image/target_id
+    - field_hs_event_status
+    - field_hs_event_speaker
+    - field_hs_event_type
+    - field_hs_event_video
 migration_dependencies:
   required:
     - hs_events_image_importer

--- a/docroot/modules/humsci/hs_migrate/hs_migrate.module
+++ b/docroot/modules/humsci/hs_migrate/hs_migrate.module
@@ -71,6 +71,7 @@ function hs_migrate_entity_delete(EntityInterface $entity) {
   foreach ($migrations as $migration) {
     $destination = $migration->get('destination');
 
+    // It should always be set. but its just a safety valve - pookmish
     if (!isset($destination['plugin'])) {
       continue;
     }

--- a/docroot/modules/humsci/hs_migrate/hs_migrate.module
+++ b/docroot/modules/humsci/hs_migrate/hs_migrate.module
@@ -71,7 +71,14 @@ function hs_migrate_entity_delete(EntityInterface $entity) {
   foreach ($migrations as $migration) {
     $destination = $migration->get('destination');
 
-    if (isset($destination['plugin']) && strpos($destination['plugin'], 'entity:') !== FALSE) {
+    if (!isset($destination['plugin'])) {
+      continue;
+    }
+
+    if (
+      strpos($destination['plugin'], 'entity:') !== FALSE ||
+      strpos($destination['plugin'], 'entity_reference_revisions:') !== FALSE
+    ) {
       list(, $type) = explode(':', $destination['plugin']);
 
       if ($type == $entity->getEntityTypeId()) {
@@ -82,7 +89,6 @@ function hs_migrate_entity_delete(EntityInterface $entity) {
             ->condition('destid1', $entity->id())
             ->execute();
         }
-        return;
       }
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow users to unpublish nodes from migration and not re-publish those when migration runs again
- Fixed logic that deletes the record from the migration map table so if a node is deleted, it will be re-imported again.

# Need Review By (Date)
- 10/25

# Urgency
- Medium

# Steps to Test
1. checkout this branch
1. sync to mathematics site `blt drupal:sync --site=mathematics --partial`
1. go to `/node/17431/edit` and unpublish the node
1. run `drush @mathematics.local sqlq 'update migrate_map_hs_events_importer set hash = ""'`
1. run `drush @mathematics.local mim hs_events_importer`
1. verify `/node/17431` is still unpublished.
1. delete `/node/17431`
1. run `drush @mathematics.local mim hs_events_importer`
1. check `/admin/content` to verify the event was re-created.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
