### PR TITLE
STN-61 Add placeholder folders for themes we're working on

### DIFF
--- a/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
@@ -2,9 +2,9 @@ name: HumSci Airy
 type: theme
 base theme: humsci_basic
 description: A light and airy theme.
-package: Humsci
+package: 'Humanities & Sciences'
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8
 
 regions:
   page_top: 'Page top'

--- a/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
@@ -1,0 +1,18 @@
+name: HumSci Airy
+type: theme
+base theme: humsci_basic
+description: A light and airy theme.
+package: Humsci
+core: 8.x
+core_version_requirement: ^8 || ^9
+
+regions:
+  page_top: 'Page top'
+  header: Header
+  search: Search
+  menu: Menu
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  footer: Footer
+  page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_airy/humsci_airy.theme
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.theme
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the HumSci Airy theme.
+ */

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
@@ -1,0 +1,17 @@
+name: HumSci Basic
+type: theme
+description: A base for visually distinctive HumSci themes.
+package: Humsci
+core: 8.x
+core_version_requirement: ^8 || ^9
+
+regions:
+  page_top: 'Page top'
+  header: Header
+  search: Search
+  menu: Menu
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  footer: Footer
+  page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
@@ -1,9 +1,9 @@
 name: HumSci Basic
 type: theme
 description: A base for visually distinctive HumSci themes.
-package: Humsci
+package: 'Humanities & Sciences'
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8
 
 regions:
   page_top: 'Page top'

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the HumSci Basic theme.
+ */

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
@@ -2,9 +2,9 @@ name: HumSci Colorful
 type: theme
 base theme: humsci_basic
 description: A colorful and polished theme.
-package: Humsci
+package: 'Humanities & Sciences'
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8
 
 regions:
   page_top: 'Page top'

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
@@ -1,0 +1,18 @@
+name: HumSci Colorful
+type: theme
+base theme: humsci_basic
+description: A colorful and polished theme.
+package: Humsci
+core: 8.x
+core_version_requirement: ^8 || ^9
+
+regions:
+  page_top: 'Page top'
+  header: Header
+  search: Search
+  menu: Menu
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  footer: Footer
+  page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the HumSci Colorful theme.
+ */

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
@@ -2,9 +2,9 @@ name: HumSci Traditional
 type: theme
 base theme: humsci_basic
 description: A traditional theme.
-package: Humsci
+package: 'Humanities & Sciences'
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8
 
 regions:
   page_top: 'Page top'

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
@@ -1,0 +1,18 @@
+name: HumSci Traditional
+type: theme
+base theme: humsci_basic
+description: A traditional theme.
+package: Humsci
+core: 8.x
+core_version_requirement: ^8 || ^9
+
+regions:
+  page_top: 'Page top'
+  header: Header
+  search: Search
+  menu: Menu
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  footer: Footer
+  page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.theme
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.theme
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming in the HumSci Airy theme.
+ */


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This PR creates placeholder folders for each of the new themes that the H&S IT team, wants to build. These themes aren't currently functional. The purpose of this PR is to add the directories, so as to unblock other work that we expect to start doing in these directories.

<details>
  <summary>See here for an idea of how we expect these themes to fit together</summary>
  <img src="https://user-images.githubusercontent.com/1256329/70281327-cc5f2500-1788-11ea-812b-2d9fd443afa4.png" />
</details>

# Need Review By (Date)
ASAP

# Urgency
High

# Steps to Test
1. Check out this branch locally
2. Under `admin/appearance`, confirm that the new themes are available as chooseable options (HumSci Basic, HumSci Colorful, HumSci Airy, HumSci Traditional).
    - Note: these themes are not currently functional (if enabled for a site, it will produce errors)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
