### PR TITLE
STN-56:  sass grunt build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,9 @@ module.exports = function (grunt) {
         ]
       },
       dist: {
+        // TODO: edit this glob to be: 'docroot/**/humsci/**/*.css'
+        // so that it includes all the css files.
+        // Note: be ready for a large number of file changes.
         src: [
           'docroot/**/humsci/*.css'
         ]
@@ -92,6 +95,4 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', ['availabletasks']);
   grunt.registerTask('compile', ['sass:dist', 'postcss:dist']);
-
-  grunt.registerTask('default', ['availabletasks']);
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test": "tests"
   },
   "scripts": {
+    "watch": "grunt watch",
+    "build:css": "grunt compile",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

STN-56: experiments with sass grunt build for NEW humsci_basic theme

- research: compiling scss to css works with the current grunt task in the humsci_basic theme
-research: compiling nested and imported scss to css works with the current grunt task in the humsci_basic theme
- research: compiling and using decanter mixins from scss to css works with the current grunt task in the humsci_basic theme
- feat: new scripts to package json to run in the cli
  - one for `watch`
  - one for `build:css` for building sass to css and postcss compilation too
- todo: adds todo about broken postcss task

# Steps to Test
1. Try out new npm tasks: `npm run watch` and `npm run build:css` (note that the latter will not completely work since the postcss task isn't working)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
