### PR TITLE
STN-60: feat:  multiple themes sass build in humsci_basic and child subtheme

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "@sparkbox/stylelint-config-sparkbox",
+  "plugins": [
+    "stylelint-scss" # plugin for SCSS specific rules
+  ],
+  "rules": {
+    "max-nesting-depth": 5
+  }
+} 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,12 +28,19 @@ module.exports = function (grunt) {
     watch: {
       css: {
         files: ['**/*.{scss,sass}'],
-        tasks: ['sass'],
+        tasks: ['sass', 'run:stylelint'], // run stylelint for humsci_basic/airy at same time after each change
         options: {
           interrupt: true
         }
       }
     },
+    run: {
+      stylelint: {
+        exec: 'npm run lint:css'
+      }
+    },
+    // if we want to use postcss, might just have to do it for our own project right now
+    // or specific gruntfiles AND package.jsons in each humsci_basic, airy, etc directory
     postcss: {
       options: {
         map: true, // inline sourcemaps
@@ -92,6 +99,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-postcss');
+  grunt.loadNpmTasks('grunt-run');
 
   grunt.registerTask('default', ['availabletasks']);
   grunt.registerTask('compile', ['sass:dist', 'postcss:dist']);

--- a/docroot/themes/humsci/humsci_airy/css/airy.css
+++ b/docroot/themes/humsci/humsci_airy/css/airy.css
@@ -1,0 +1,1 @@
+.horizontal-card{color:blue;padding:0;margin:0;border:0 none}.horizontal-card{color:pink}.horizontal-card--two{padding:0;margin:0;border:0 none}

--- a/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
@@ -5,6 +5,8 @@ description: A light and airy theme.
 package: 'Humanities & Sciences'
 core: 8.x
 core_version_requirement: ^8
+libraries:
+  - humsci_airy/base
 
 regions:
   page_top: 'Page top'

--- a/docroot/themes/humsci/humsci_airy/humsci_airy.libraries.yml
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.libraries.yml
@@ -1,0 +1,4 @@
+base:
+  css:
+    theme:
+      css/airy.css: {}

--- a/docroot/themes/humsci/humsci_airy/scss/_horizontal-card.scss
+++ b/docroot/themes/humsci/humsci_airy/scss/_horizontal-card.scss
@@ -1,0 +1,10 @@
+//Able to import base styles/mixins/variables from humsci_basic here
+@import '../../humsci_basic/scss/base.scss';
+
+.horizontal-card {
+  color: pink;
+}
+
+.horizontal-card--two {
+  @include unbuttonize;
+}

--- a/docroot/themes/humsci/humsci_airy/scss/airy.scss
+++ b/docroot/themes/humsci/humsci_airy/scss/airy.scss
@@ -1,0 +1,1 @@
+@import 'horizontal-card';

--- a/docroot/themes/humsci/humsci_basic/css/base.css
+++ b/docroot/themes/humsci/humsci_basic/css/base.css
@@ -1,0 +1,1 @@
+.horizontal-card{color:blue;padding:0;margin:0;border:0 none}

--- a/docroot/themes/humsci/humsci_basic/scss/base.scss
+++ b/docroot/themes/humsci/humsci_basic/scss/base.scss
@@ -1,0 +1,10 @@
+@mixin unbuttonize() {
+  padding: 0;
+  margin: 0;
+  border: 0 none;
+}
+
+.horizontal-card {
+  color: blue;
+  @include unbuttonize;
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,13 @@
   "scripts": {
     "watch": "grunt watch",
     "build:css": "grunt compile",
+    "lint:css": "stylelint 'docroot/themes/humsci/{humsci_basic,humsci_airy}/scss/**/*.scss' --config .stylelintrc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "browserslist": [
+    "last 2 versions",
+    "ie 11"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SU-HSDO/suhumsci.git"
@@ -23,13 +28,17 @@
   },
   "homepage": "https://github.com/SU-HSDO/suhumsci#readme",
   "devDependencies": {
+    "@sparkbox/stylelint-config-sparkbox": "^0.5.0",
     "autoprefixer": "^9.4.7",
     "bourbon": "^5.1.0",
     "decanter": "^3.0.0",
     "grunt": "^1.0.3",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.9.0",
+    "grunt-run": "^0.8.1",
     "grunt-sass": "^3.0.2",
-    "node-sass": "^4.11.0"
+    "node-sass": "^4.11.0",
+    "stylelint": "^12.0.0",
+    "stylelint-scss": "^3.13.0"
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Configures a Sass build for the Humsci Basic theme, and airy sub theme that makes use of the existing root Gruntfile tasks. I was able to import sass mixins/variable from humsci_basic into the airy sass and compile based on the use there.

- Uses Grunt to run Sass and PostCSS tasks on Sass files in the theme
- NPM scripts are setup to run the Grunt tasks (`npm run watch` and `npm run build:css` and `npm run lint:css`)
- The airy Drupal theme is configured to load its respective stylesheets

# Need Review By (Date)
_['10/30', 'asap', etc.]_

# Urgency
_['low', 'medium', 'high', etc.]_

# Steps to Test
1. _[First testing step]_
2. ...

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
