### PR TITLE
feat:  add grid preview

### DIFF
--- a/docroot/themes/humsci/humsci_basic/patterns/grid/grid.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/grid/grid.ui_patterns.yml
@@ -9,7 +9,7 @@ grid:
         -
           type: pattern
           id: vertical_link_card
-          title: 'Test Title'
+          title: 'Test Title 1'
           image:
             theme: image
             uri: 'http://placecorgi.com/250x400'
@@ -17,11 +17,20 @@ grid:
         -
           type: pattern
           id: vertical_link_card
-          title: 'Test Title'
+          title: 'Test Title 2'
           image:
             theme: image
             uri: 'http://placecorgi.com/300x350'
           description: "Optional wysiwyg lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam fermentum aliquet iaculis. Cras faucibus turpis non facilisis laoreet."
+        -
+          type: pattern
+          id: vertical_link_card
+          title: 'Test Title 3'
+          image:
+            theme: image
+            uri: 'http://placecorgi.com/300x350'
+          description: "Optional wysiwyg lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam fermentum aliquet iaculis. Cras faucibus turpis non facilisis laoreet."
+        
     columns:
       label: "Number of Columns"
       type: text


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds better grid preview for the UI pattern on the `/patterns` page.

Screenshot:
<img width="1198" alt="Screen Shot 2020-01-29 at 4 23 06 PM" src="https://user-images.githubusercontent.com/12848168/73400307-e3b51d00-42b6-11ea-8b46-76d524cbe1ec.png">


## Need Review By (Date)
1/29, if possible (since it's small)

## Urgency
low

## Steps to Test
1. Check the `patterns` page to see the grid UI pattern display in a 3 column grid.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
