### PR TITLE
fix: add all entity view displays to config ignore

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -2,7 +2,7 @@ ignored_config_entities:
   - 'block.block.*'
   - 'config_split.config_split.not_live:status'
   - 'core.entity_form_display.node.hs_*'
-  - 'core.entity_view_display.node.hs_*.default'
+  - 'core.entity_view_display.node.hs_*'
   - 'core.extension:theme'
   - 'domain_301_redirect.settings:domain'
   - 'domain_301_redirect.settings:enabled'

--- a/config/default/core.entity_view_display.node.hs_news.hs_vertical_card.yml
+++ b/config/default/core.entity_view_display.node.hs_news.hs_vertical_card.yml
@@ -44,7 +44,7 @@ third_party_settings:
         formatter: default
         settings:
           link: true
-          wrapper: h2
+          wrapper: span
           class: ''
 id: node.hs_news.hs_vertical_card
 targetEntityType: node


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This reverts a global config change on a view mode that was not intended to affect existing sites. See details here: https://github.com/SU-HSDO/suhumsci/pull/449#discussion_r372685223

To prevent this from happening in the future, it also includes an updated config-ignore rule, which ignores global config updates to all entity view displays on existing sites. 

## Need Review By (Date)
this week

## Urgency
medium (there's a chance for regressions if a production release happens before this is merged.

## Steps to Test
1. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
