### PR TITLE
Bugfix  date stacked svg arrows

### DIFF
--- a/docroot/themes/humsci/humsci_basic/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
@@ -58,11 +58,7 @@
     {% endif %}
 
     {% if url %}
-      <a href="{{ url }}" class="hb-card__decorative-link">
-        <svg aria-label="external link" xmlns="http://www.w3.org/2000/svg" width="23" height="24" viewBox="0 0 23 24">
-          <path d="M11 23l-2-2 7-7H0v-3h16L9 3l2-2 10 10 1 1-11 11z"/>
-        </svg>
-      </a>
+      <a href="{{ url }}" class="hb-card__decorative-link" aria-label="link to content"></a>
     {% endif %}
 
   </div>


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
The svg updates didn't get applied to the date-stacked-vertical-card (since they were being worked on in parallel). This update fixes that.

<img width="774" alt="Screen Shot 2020-02-11 at 6 15 19 PM" src="https://user-images.githubusercontent.com/1256329/74288525-95fad480-4cfa-11ea-9252-ed191bc94853.png">

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
low?

## Steps to Test
1. Load a page with a data stacked vertical card and the url field, and confirm that the arrow looks good.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
