### PR TITLE
STN-69 : Create Global Footer for New Themes

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -47,6 +47,12 @@ function humsci_basic_preprocess_page(&$vars) {
   if ($bbv !== "none") {
     $vars['brand_bar_variant_classname'] = 'su-brand-bar--' . $bbv;
   }
+
+  // Variant setting for the global footer.
+  $gfv = theme_get_setting('global_footer_variant_classname');
+  if ($gfv !== "none") {
+    $vars['global_footer_variant_classname'] = 'su-global-footer--' . $gfv;
+  }
 }
 
 /**

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -129,6 +129,7 @@
   'components/views-field-field-hs-person',
   'components/structured-card',
   'components/brandbar',
+  'components/global-footer',
 
   // =====================================================================
   // 8. Utilities

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_global-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_global-footer.scss
@@ -1,0 +1,11 @@
+// These styles restore brand styles imported from Decanter that were overwritten by humsci_basic theme base styles.
+// Decanter Global Footer: https://decanter.stanford.edu/component/identity-global-footer/
+.hb-global-footer {
+  .su-logo .fa-ext {
+    display: none; // hide external link icon
+  }
+
+  .su-global-footer__menu--global {
+    font-weight: hb-theme-font-weight(semibold);
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/templates/components/global-footer.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/global-footer.html.twig
@@ -1,0 +1,53 @@
+{#
+  /**
+  * @file
+  * Global Footer Component.
+  *
+  * Stanford Universal Footer as defined at https://decanter.stanford.edu/component/identity-global-footer/
+  * And which complies with Stanford brand guidelines at https://identity.stanford.edu/web-mobile.html#build-something-new
+  * This component was modeled after the global footer in the Stanford Basic theme at https://github.com/SU-SWS/stanford_basic/blob/8.x-4.x/dist/templates/decanter/components/global-footer/global-footer.twig
+  * This component should be added into the footer region of your site below site-specific footer section, if any.
+  * The entire footer can be made to "stick" to the bottom of the browser window by including the @sticky-footer mixin.
+  */
+#}
+
+{% if template_path_logo is empty -%}
+  {%- set template_path_logo = "/themes/humsci/humsci_basic/templates/components/logo.html.twig" -%}
+{%- endif %}
+
+<footer class="hb-global-footer su-global-footer hb-page-width{{ modifier_class }}">
+  <div class="su-global-footer__container">
+    <div class="su-global-footer__brand">
+      {%- include humsci_basic ~ template_path_logo -%}
+    </div>
+    <div class="su-global-footer__content">
+      <nav aria-label="global footer">
+        <ul class="su-global-footer__menu su-global-footer__menu--global">
+          {# The class of hb-global-footer__link has been added to all links to prevent a:not([class]) styles in humsci_basic/src/scss/elements/_base.scss from overriding Decanter styles #}
+          <li><a class="hb-global-footer__link" href="https://www.stanford.edu">Stanford Home</a></li>
+          <li><a class="hb-global-footer__link" href="https://visit.stanford.edu/plan/">Maps &amp; Directions</a></li>
+          <li><a class="hb-global-footer__link" href="https://www.stanford.edu/search/">Search Stanford</a></li>
+          <li><a class="hb-global-footer__link" href="https://emergency.stanford.edu">Emergency Info</a></li>
+        </ul>
+        <ul class="su-global-footer__menu su-global-footer__menu--policy">
+          <li><a class="hb-global-footer__link" href="https://www.stanford.edu/site/terms/"
+                 title="Terms of use for sites">Terms of Use</a></li>
+          <li><a class="hb-global-footer__link" href="https://www.stanford.edu/site/privacy/"
+                 title="Privacy and cookie policy">Privacy</a></li>
+          <li><a class="hb-global-footer__link" href="https://uit.stanford.edu/security/copyright-infringement"
+                 title="Report alleged copyright infringement">Copyright</a></li>
+          <li><a class="hb-global-footer__link" href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4"
+                 title="Ownership and use of Stanford trademarks and images">Trademarks</a></li>
+          <li><a class="hb-global-footer__link" href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/"
+                 title="Non-discrimination policy">Non-Discrimination</a></li>
+          <li><a class="hb-global-footer__link" href="https://www.stanford.edu/site/accessibility"
+                 title="Report web accessibility issues">Accessibility</a></li>
+        </ul>
+      </nav>
+      <div class="su-global-footer__copyright">
+        <span>&copy; Stanford University.</span>
+        <span>&nbsp; Stanford, California 94305.</span>
+      </div>
+    </div>
+  </div>
+</footer> <!-- su-global-footer end -->

--- a/docroot/themes/humsci/humsci_basic/templates/components/logo.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/logo.html.twig
@@ -1,0 +1,19 @@
+{#
+  /**
+  * @file
+  * Logo Component
+  *
+  * The Stanford wordmark logo rendered with the custom Stanford ligature font as defined at https://decanter.stanford.edu/component/identity-logo/
+  * This component was modeled after the logo in the Stanford Basic theme at https://github.com/SU-SWS/stanford_basic/blob/8.x-4.x/dist/templates/decanter/components/logo/logo.twig
+  *
+  * Available variables:
+  * - attributes: For additional HTML attributes not already provided.
+  * - modifier_class: Additional CSS classes to change look and behaviour.
+  * - href: The URL that the logo links to.
+  * - logo_text: The text for the ligature logo - either Stanford<br>University or Stanford.
+  */
+#}
+
+<a {{ attributes }} class="su-logo {{ modifier_class }}" href="{{ href|default('https://www.stanford.edu') }}">
+  {{ logo_text|default('Stanford<br>University')|raw }}
+</a>

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -80,6 +80,5 @@
       document.write("<script async src='http://{{ browser_sync.host }}:{{ browser_sync.port }}/browser-sync/browser-sync-client.js'><\/script>".replace("HOST", location.hostname));
       </script>
     {% endif %}
-    {#}{ pattern("globalfooter") }#}
   </body>
 </html>

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -30,3 +30,5 @@
     {{ page.footer }}
   </div>
 {% endif %}
+
+{% include humsci_basic ~ '/themes/humsci/humsci_basic/templates/components/global-footer.html.twig' with { modifier_class : global_footer_variant_classname } %}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -25,10 +25,12 @@
   {{ page.content }}
 </div>
 
+{# Local Footer #}
 {% if page.footer %}
   <div id="footer">
     {{ page.footer }}
   </div>
 {% endif %}
 
+{# Global Footer #}
 {% include humsci_basic ~ '/themes/humsci/humsci_basic/templates/components/global-footer.html.twig' with { modifier_class : global_footer_variant_classname } %}

--- a/docroot/themes/humsci/humsci_basic/theme-settings.php
+++ b/docroot/themes/humsci/humsci_basic/theme-settings.php
@@ -121,4 +121,21 @@ function humsci_basic_form_system_theme_settings_alter(array &$form, FormStateIn
     '#description' => t("Last line full width option."),
   ];
 
+  // Global Footer
+  $form['options_settings']['humsci_basic_global_footer'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Global Footer Settings'),
+  ];
+
+  $form['options_settings']['humsci_basic_global_footer']['global_footer_variant'] = [
+    '#type' => 'select',
+    '#title' => t('Global Footer Variant'),
+    '#options' => [
+      'default' => '- Default -',
+      'bright' => t('Bright'),
+      'dark' => t('Dark')
+    ],
+    '#default_value' => theme_get_setting('global_footer_variant'),
+  ];
+
 }


### PR DESCRIPTION
#  [STN-69](https://sparkbox.atlassian.net/browse/STN-69) READY FOR REVIEW

## Summary
Create global footer using [Decanter](https://decanter.stanford.edu/component/identity-global-footer/) styles and twig templates and following Stanford's [identity guidelines](https://identity.stanford.edu/web-mobile.html#build-something-new).

## Need Review By (Date)
2/14/2020

## Urgency
Medium

## Steps to Test
1. Go to http://swshumsci.suhumsci.loc
2. Verify the global footer displays the `default` style as shown in Decanter
3. To change the switch to another global footer display variant, in the Drupal admin panel go to Appearance > Settings
4. Select the `HumSci Colorful` tab
5. Under `Theme Specific Settings` find `Global Footer Settings`. In the `Global Footer Variant` dropdown menu select `Dark`. Click `Save configuration`. Go back to the site and confirm the global footer displays the `dark` style variant as shown in Decanter. Repeat the process to test the `Bright` variant.
6. Verify the global footer meets the following acceptance criteria:
    - [x] Ensure that a person using the Colorful theme will see the global footer across the bottom of the page
    - [x] Ensure that a person using the Colorful theme will have a theme setting for switching between each of the global footer display variations found in the latest Decanter.
    - [x] Features have been implemented such that they are inherited by the other sub-themes (traditional and airy).

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
