### PR TITLE
STN-68: Brand Bar

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -37,3 +37,14 @@ function humsci_basic_preprocess_field(&$variables, $hook) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function humsci_basic_preprocess_page(&$vars) {
+  // Variant setting for the brand bar.
+  $bbv = theme_get_setting('brand_bar_variant_classname');
+  if ($bbv !== "none") {
+    $vars['brand_bar_variant_classname'] = 'su-brand-bar--' . $bbv;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -128,6 +128,7 @@
   'components/secondary-nav',
   'components/views-field-field-hs-person',
   'components/structured-card',
+  'components/brandbar',
 
   // =====================================================================
   // 8. Utilities

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_brandbar.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_brandbar.scss
@@ -1,0 +1,5 @@
+.su-brand-bar {
+  .fa-ext {
+    display: none;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
@@ -1,3 +1,7 @@
+.hb-page-width {
+  @include hb-page-width;
+}
+
 // If a component needs *any* additional styles, move the rule into /src/scss/components.
 .layout-builder__message {
   @include hb-page-width;

--- a/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
@@ -1,0 +1,5 @@
+<section class="su-brand-bar {{ modifier_class }}">
+  <div class="su-brand-bar__container hb-page-width">
+    <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
+  </div>
+</section>

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -68,10 +68,9 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
-      <a href="#main-content" class="visually-hidden focusable su-skipnav">
-        {{ 'Skip to main content'|t }}
-      </a>
-    {#}{ pattern("brandbar", {}, brand_bar_variant) }#}
+    <a href="#main-content" class="visually-hidden focusable su-skipnav">
+      {{ 'Skip to main content'|t }}
+    </a>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -1,3 +1,5 @@
+{% include humsci_basic ~ '/themes/humsci/humsci_basic/templates/components/brandbar.html.twig' with { modifier_class : brand_bar_variant_classname } %}
+
 <header class="hb-masthead">
   <section>
   {% if page.header %}

--- a/docroot/themes/humsci/humsci_basic/theme-settings.php
+++ b/docroot/themes/humsci/humsci_basic/theme-settings.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Provides an additional config form for theme settings.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
+
+
+// Set theme name to use in the key values.
+$theme_name = \Drupal::theme()->getActiveTheme()->getName();
+
+/**
+ * Implements hook_form_system_theme_settings_alter().
+ *
+ * Form override for theme settings.
+ */
+function humsci_basic_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  $form['options_settings'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Theme Specific Settings'),
+  ];
+
+  // Brandbar
+  $form['options_settings']['humsci_basic_brand_bar'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Brand Bar Settings'),
+  ];
+
+  $form['options_settings']['humsci_basic_brand_bar']['brand_bar_variant_classname'] = [
+    '#type' => 'select',
+    '#title' => t('Brand Bar Variant'),
+    '#options' => [
+      'default' => '- Default -',
+      'bright' => t('Bright'),
+      'dark' => t('Dark'),
+      'white' => t('White'),
+    ],
+    '#default_value' => theme_get_setting('brand_bar_variant_classname'),
+  ];
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request adds the brand bar as a template component. The brandbar has 4 different color theme options that can be adjusted in the Colorful theme settings.

_Note: I am adding a class to the brand bar container element to ensure that logo always aligns with the page content. I could not find anything in the documentation that says we cannot do that and after checking a variety of existing sites the brand bar logo always lines up with the rest of the content on the page so this felt like the right thing to do. Documentation can be found [here](https://decanter.stanford.edu/component/identity-brand-bar/) and [here](https://elegant-poitras-87214a.netlify.com/page/brand-design-elements-brand/)._

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Run `npm run build:sass` to build style assets
1. Run `npm test` to confirm there are no errors
1. Confirm that there is a brand bar at the top of each page that links back to stanford.edu
1. Test that the brand bar theme can be updated in the [Colorful theme settings](http://swshumsci.suhumsci.loc/admin/appearance/settings/humsci_colorful). There should be options for: default, bright, dark, and white.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
