### PR TITLE
Fix CodeClimate warnings for styles

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,6 +1,7 @@
 # Default application configuration that all configurations inherit from.
 
 scss_files: "**/*.scss"
+exclude: 'docroot/themes/humsci/humsci_basic/**'
 plugin_directories: ['.scss-linters']
 
 # List of gem names to load custom linters from (make sure they are already

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -37,3 +37,14 @@ function humsci_basic_preprocess_field(&$variables, $hook) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function humsci_basic_preprocess_page(&$vars) {
+  // Variant setting for the brand bar.
+  $bbv = theme_get_setting('brand_bar_variant_classname');
+  if ($bbv !== "none") {
+    $vars['brand_bar_variant_classname'] = 'su-brand-bar--' . $bbv;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -128,6 +128,7 @@
   'components/secondary-nav',
   'components/views-field-field-hs-person',
   'components/structured-card',
+  'components/brandbar',
 
   // =====================================================================
   // 8. Utilities

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_brandbar.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_brandbar.scss
@@ -1,0 +1,5 @@
+.su-brand-bar {
+  .fa-ext {
+    display: none;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
@@ -1,3 +1,7 @@
+.hb-page-width {
+  @include hb-page-width;
+}
+
 // If a component needs *any* additional styles, move the rule into /src/scss/components.
 .layout-builder__message {
   @include hb-page-width;

--- a/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
@@ -1,0 +1,5 @@
+<section class="su-brand-bar {{ modifier_class }}">
+  <div class="su-brand-bar__container hb-page-width">
+    <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
+  </div>
+</section>

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -68,10 +68,9 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
-      <a href="#main-content" class="visually-hidden focusable su-skipnav">
-        {{ 'Skip to main content'|t }}
-      </a>
-    {#}{ pattern("brandbar", {}, brand_bar_variant) }#}
+    <a href="#main-content" class="visually-hidden focusable su-skipnav">
+      {{ 'Skip to main content'|t }}
+    </a>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -1,3 +1,5 @@
+{% include humsci_basic ~ '/themes/humsci/humsci_basic/templates/components/brandbar.html.twig' with { modifier_class : brand_bar_variant_classname } %}
+
 <header class="hb-masthead">
   <section>
   {% if page.header %}

--- a/docroot/themes/humsci/humsci_basic/theme-settings.php
+++ b/docroot/themes/humsci/humsci_basic/theme-settings.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Provides an additional config form for theme settings.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
+
+
+// Set theme name to use in the key values.
+$theme_name = \Drupal::theme()->getActiveTheme()->getName();
+
+/**
+ * Implements hook_form_system_theme_settings_alter().
+ *
+ * Form override for theme settings.
+ */
+function humsci_basic_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  $form['options_settings'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Theme Specific Settings'),
+  ];
+
+  // Brandbar
+  $form['options_settings']['humsci_basic_brand_bar'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Brand Bar Settings'),
+  ];
+
+  $form['options_settings']['humsci_basic_brand_bar']['brand_bar_variant_classname'] = [
+    '#type' => 'select',
+    '#title' => t('Brand Bar Variant'),
+    '#options' => [
+      'default' => '- Default -',
+      'bright' => t('Bright'),
+      'dark' => t('Dark'),
+      'white' => t('White'),
+    ],
+    '#default_value' => theme_get_setting('brand_bar_variant_classname'),
+  ];
+}


### PR DESCRIPTION
## Summary
We've been having issues with CodeClimate giving us a bunch of warnings from the `scss-lint` linter which is setup for the old theming working. Our new themes are using Dart Sass and `scss-lint` does not support this latest version of Dart and doesn't intent to, since it is based on Ruby. The [scss-lint](https://github.com/sds/scss-lint) project recommended using a different linter like Stylelint, which is what we are using for new themes.

This being the case, this PR excludes the new Humsci Basic theme from the old `scss-lint` configuration, so CodeClimate will note generate warnings on new code for the old linter.

We may want to further configure CodeClimate or CircleCI to run our stylelint linter.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)