### PR TITLE
fix: global footer classes snafu

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/components/global-footer.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/global-footer.html.twig
@@ -15,8 +15,8 @@
   {%- set template_path_logo = "/themes/humsci/humsci_basic/templates/components/logo.html.twig" -%}
 {%- endif %}
 
-<footer class="hb-global-footer su-global-footer hb-page-width{{ modifier_class }}">
-  <div class="su-global-footer__container">
+<footer class="hb-global-footer su-global-footer {{ modifier_class }}">
+  <div class="su-global-footer__container hb-page-width">
     <div class="su-global-footer__brand">
       {%- include humsci_basic ~ template_path_logo -%}
     </div>


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
The global footer theme is not working due to a spacing / syntax error. Once the error was corrected I realized the `hb-page-width` class needed to be place don the container div, not the footer tag.

## Need Review By (Date)
2/17/2020

## Urgency
MEDIUM

## Steps to Test
1. Go to http://swshumsci.suhumsci.loc
2. Verify the global footer displays the `default` style as shown in Decanter
3. To change the switch to another global footer display variant, in the Drupal admin panel go to Appearance > Settings
4. Select the `HumSci Colorful` tab
5. Under `Theme Specific Settings` find `Global Footer Settings`. In the `Global Footer Variant` dropdown menu select `Dark`. Click `Save configuration`. Go back to the site and confirm the global footer displays the `dark` style variant as shown in Decanter. Repeat the process to test the `Bright` variant.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
