### PR TITLE
STN-172: Local Footer

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -22,6 +22,10 @@
   'decanter/core/src/scss/elements/image',
   'decanter/core/src/scss/elements/embed',
 
+  // Grid
+  // Pulls in the flexbox based grid system
+  'decanter/core/src/scss/decanter-grid',
+
   // Components
   // Below here are Decanter specific components we probably want the styles for:
   'decanter/core/src/scss/components/brand-bar',
@@ -136,9 +140,11 @@
   'components/brandbar',
   'components/global-footer',
   'components/site-search',
+  'components/local-footer',
 
   // =====================================================================
   // 8. Utilities
   //    Utilities and helper classes with ability to override anything
   //    which goes before in the triangle, eg. hide helper class
-  'utilities/fonts';
+  'utilities/fonts',
+  'utilities/font-awesome';

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
@@ -1,4 +1,5 @@
-.button {
+.button,
+a.button {
   @include button-style;
 
   // This is our only option for targeting the exposed filters reset button

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -1,0 +1,64 @@
+.hb-local-footer {
+  font-size: hb-calculate-rems(16px);
+  padding: hb-calculate-rems(48px) 0;
+  border-top: 1px solid $su-color-driftwood;
+
+  .menu {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .menu-item {
+    margin-bottom: hb-calculate-rems(14px);
+  }
+
+  .block__title,
+  .hb-secondary-nav__heading {
+    font-size: hb-calculate-rems(14px);
+    font-weight: hb-theme-font-weight(bold);
+    margin: 0 0 hb-calculate-rems(20px);
+    text-transform: uppercase;
+  }
+
+  @include hb-colorful {
+    a:not([class]) {
+      &:hover,
+      &:focus {
+        box-shadow: none;
+        color: hb-colorful-variation(primary);
+      }
+    }
+
+    &--dark {
+      $hb-lighten-color--primary: lighten(hb-colorful-variation(primary), 30%);
+      $hb-lighten-color-hover--primary: lighten(hb-colorful-variation(primary), 70%);
+      background-color: darken(hb-colorful-variation(primary), 10%);
+      color: $hb-color--white;
+      border-top: 0;
+
+      a:not([class]) {
+        color: $hb-lighten-color--primary;
+
+        &:hover,
+        &:focus {
+          color: $hb-lighten-color-hover--primary;
+        }
+      }
+
+      .fa-ext {
+        &::before {
+          background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{$hb-lighten-color--primary}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
+        }
+      }
+
+      a.fab {
+        color: lighten(hb-colorful-variation(secondary), 10%);
+
+        &:hover {
+          color: hb-colorful-variation(secondary);
+        }
+      }
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
@@ -1,3 +1,3 @@
-.hb-masthead {
-  @include hb-page-width;
+.su-masthead .su-lockup {
+  z-index: $hb-z-index-lockup;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -4,7 +4,7 @@ html {
 }
 
 body {
-  font-size: hb-calculate-rems(16px);
+  @include hb-body--small;
 
   @include hb-colorful {
     font-family: $hb-colorful-font--sans;
@@ -65,7 +65,6 @@ h6:not([class]) {
 }
 
 p:not([class]) {
-  @include hb-body--small;
   margin-top: 0;
 
   &:last-of-type {

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
@@ -17,3 +17,4 @@ $hb-z-index-12: 1200;
 // For example:
 // $hb-z-index-modal: $hb-z-index-1;
 $hb-z-index-main-menu: $hb-z-index-1;
+$hb-z-index-lockup: $hb-z-index-5; // keeps the lockup from laying on top of the admin menu

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
@@ -1,5 +1,6 @@
 @mixin button-style {
   @include unbuttonize;
+  display: inline-block;
   padding: 0 hb-calculate-rems(20px);
   border-radius: hb-calculate-rems(30px);
   font-family: $hb-colorful-font--sans;
@@ -40,4 +41,5 @@
   font: inherit;
   border-radius: 0;
   appearance: none; // Just in case we missed anything.
+  text-decoration: none;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_font-awesome.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_font-awesome.scss
@@ -1,0 +1,18 @@
+// Font Awesome Icons
+.fab,
+a.fab {
+  font-size: hb-calculate-rems(34px);
+  text-decoration: none;
+  display: inline-block;
+  margin-right: hb-calculate-rems(14px);
+  margin-bottom: hb-calculate-rems(14px);
+  transition: 125ms color ease-out;
+
+  @include hb-colorful {
+    color: hb-colorful-variation(secondary);
+
+    &:hover {
+      color: darken(hb-colorful-variation(secondary), 10%);
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -32,8 +32,10 @@
 
 {# Local Footer #}
 {% if page.footer %}
-  <div id="footer">
-    {{ page.footer }}
+  <div class="hb-local-footer {{ local_footer_variant_classname }}">
+    <div class="hb-page-width flex-container flex-container--row-gap">
+      {{ page.footer }}
+    </div>
   </div>
 {% endif %}
 

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
@@ -2,5 +2,18 @@
 
 /**
  * @file
- * Functions to support theming in the HumSci Colorful theme.
+ * Functions to support theming in the HumSci Basic theme.
  */
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function humsci_colorful_preprocess_page(&$vars) {
+  // Variant setting for the local footer.
+  $lfv = theme_get_setting('local_footer_variant_classname');
+  if ($lfv !== "none") {
+    $vars['local_footer_variant_classname'] = 'hb-local-footer--' . $lfv;
+  }
+}

--- a/docroot/themes/humsci/humsci_colorful/theme-settings.php
+++ b/docroot/themes/humsci/humsci_colorful/theme-settings.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Provides an additional config form for theme settings.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+use Drupal\Core\Render\Markup;
+
+// Set theme name to use in the key values.
+$theme_name = \Drupal::theme()->getActiveTheme()->getName();
+
+/**
+ * Implements hook_form_system_theme_settings_alter().
+ *
+ * Form override for theme settings.
+ */
+function humsci_colorful_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  // Local Footer
+  $form['options_settings']['humsci_basic_local_footer'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Local Footer Settings'),
+  ];
+
+  $form['options_settings']['humsci_basic_local_footer']['local_footer_variant_classname'] = [
+    '#type' => 'select',
+    '#title' => t('Local Footer Variant'),
+    '#options' => [
+      'default' => '- Default -',
+      'dark' => t('Dark'),
+    ],
+    '#default_value' => theme_get_setting('local_footer_variant_classname'),
+  ];
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request adds the local footer component with a default light variant as well as a theme option for a dark variant. Footer blocks use the Decanter flexbox grid system for layout. This grid system includes responsive classes and are added when configuring blocks.

- This PR also includes a z-index fix where the lockup was overlaying the admin bar at small-medium screen sizes.

**Tested in the following browsers:**
- Safari
- Chrome, Windows & Mac
- Firefox, Windows & Mac
- Edge
- IE 11

**Default:**
<img width="1444" alt="Faculty___Economics" src="https://user-images.githubusercontent.com/2486846/75068792-e245d180-54bd-11ea-8567-23032262022c.png">

**Dark Variant:**
<img width="1317" alt="Faculty___Economics" src="https://user-images.githubusercontent.com/2486846/75068846-fe497300-54bd-11ea-8967-2eac94777466.png">

In order to ensure that blocks are styled correctly the following items have been refactored:
- Move font styles from paragraph tag into the body element.
- Refactor button class to work with anchor tags.
- Style Font Awesome elements.

✅ Design reviewed and approved by @meranicosme 

## Need Review By (Date)
02/24

## Urgency
medium

## Steps to Test
1. Run `npm run build:sass` to compile assets
1. Run `npm test` to confirm there are no errors
1. Styles should match the [design mockups](https://www.figma.com/file/toNZnFLadtpNpG5dPzNGWz/%E2%9A%99%EF%B8%8F-Colorful-Theme---Working?node-id=3324%3A2505) for both light and dark variants.
1. Configure blocks to use [Flexbox Grid Classes](https://decanter.stanford.edu/page/layouts-grid-system/) for layout styles.
1. Confirm that the following block types match the screenshots above:
    - Menu block
    - Custom block with text
    - Custom block with image
    - Custom block with buttons
    - Custom block with Font Awesome icons.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
