### PR TITLE
STN-142 : Style Drupal Admin Links

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -111,6 +111,8 @@
   'elements/base',
   'elements/forms',
   'elements/tables',
+  'elements/wysiwyg-text-area', // WYSIWYG editor
+  'elements/local-tasks', // Drupal admin task list
 
   // =====================================================================
   // 5. Objects

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -111,8 +111,6 @@
   'elements/base',
   'elements/forms',
   'elements/tables',
-  'elements/wysiwyg-text-area', // WYSIWYG editor
-  'elements/local-tasks', // Drupal admin task list
 
   // =====================================================================
   // 5. Objects
@@ -151,4 +149,5 @@
   'utilities/fonts',
   'utilities/font-awesome',
   'utilities/wysiwyg-text-area', // WYSIWYG editor
-  'utilities/admin.contextual-links';
+  'utilities/admin.contextual-links',
+  'utilities/local-tasks'; // Drupal admin task list

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_local-tasks.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_local-tasks.scss
@@ -4,7 +4,11 @@ $hb-color--drupal-light: #53B0EB;
 $hb-color--drupal-dark: #0678BE;
 
 .block--local-tasks {
-  border-bottom: 1px solid $hb-color--drupal-light;
+  @include hb-page-width;
+  // scss-lint:disable ImportantRule
+  margin-bottom: hb-calculate-rems(40px) !important; // override margin-bottom set in hb-page-width
+  // scss-lint:enable ImportantRule
+  border-bottom: 2px solid $hb-color--drupal-dark;
 
   .tabs {
     margin: hb-calculate-rems(40px) 0 0 0;
@@ -12,7 +16,7 @@ $hb-color--drupal-dark: #0678BE;
 
     &__tab {
       display: inline-block;
-      background-color: tint($hb-color--drupal-light, 93%);
+      background-color: tint($hb-color--drupal-light, 88%);
       list-style-type: none;
       padding: hb-calculate-rems(8px) hb-calculate-rems(12px);
       margin-top: hb-calculate-rems(4px);
@@ -38,7 +42,7 @@ $hb-color--drupal-dark: #0678BE;
       }
 
       &:hover:not(.tabs__tab--active) {
-        background-color: tint($hb-color--drupal-light, 83%);
+        background-color: tint($hb-color--drupal-light, 73%);
 
         a {
           box-shadow: none;

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_local-tasks.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_local-tasks.scss
@@ -1,0 +1,49 @@
+// Drupal brand colors
+// https://www.drupal.org/drupalorg/style-guide/colors
+$hb-color--drupal-light: #53B0EB;
+$hb-color--drupal-dark: #0678BE;
+
+.block--local-tasks {
+  border-bottom: 1px solid $hb-color--drupal-light;
+
+  .tabs {
+    margin: hb-calculate-rems(40px) 0 0 0;
+    padding: 0;
+
+    &__tab {
+      display: inline-block;
+      background-color: tint($hb-color--drupal-light, 93%);
+      list-style-type: none;
+      padding: hb-calculate-rems(8px) hb-calculate-rems(12px);
+      margin-top: hb-calculate-rems(4px);
+      font-size: hb-calculate-rems(15px);
+      transition: background-color 250ms ease-in-out;
+
+      a {
+        color: $hb-color--black;
+        text-decoration: none;
+
+        &:focus {
+          box-shadow: none;
+        }
+      }
+
+      &--active {
+        background-color: $hb-color--drupal-dark;
+
+        a {
+          color: $hb-color--white;
+          box-shadow: none;
+        }
+      }
+
+      &:hover:not(.tabs__tab--active) {
+        background-color: tint($hb-color--drupal-light, 83%);
+
+        a {
+          box-shadow: none;
+        }
+      }
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
@@ -27,3 +27,8 @@ $hb-colorful--variations: (
     tertiary: darken($su-color-sky, 30%)
   )
 );
+
+// Drupal brand colors
+// https://www.drupal.org/drupalorg/style-guide/colors
+$hb-color--drupal-light: #53B0EB;
+$hb-color--drupal-dark: #0678BE;

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_local-tasks.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_local-tasks.scss
@@ -1,7 +1,6 @@
-// Drupal brand colors
-// https://www.drupal.org/drupalorg/style-guide/colors
-$hb-color--drupal-light: #53B0EB;
-$hb-color--drupal-dark: #0678BE;
+// Style the inline Drupal admin local tasks
+// View / Edit / Publish / Manage Display / Layout / Revisions / Devel
+// located within page content
 
 .block--local-tasks {
   @include hb-page-width;
@@ -26,10 +25,7 @@ $hb-color--drupal-dark: #0678BE;
       a {
         color: $hb-color--black;
         text-decoration: none;
-
-        &:focus {
-          box-shadow: none;
-        }
+        box-shadow: none;
       }
 
       &--active {
@@ -37,16 +33,11 @@ $hb-color--drupal-dark: #0678BE;
 
         a {
           color: $hb-color--white;
-          box-shadow: none;
         }
       }
 
       &:hover:not(.tabs__tab--active) {
         background-color: tint($hb-color--drupal-light, 73%);
-
-        a {
-          box-shadow: none;
-        }
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/templates/block/block--local-tasks-block.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/block/block--local-tasks-block.html.twig
@@ -1,5 +1,5 @@
 {% extends "@block/block.html.twig" %}
-{% set attributes = attributes.addClass('block--local-tasks hb-page-width') %}
+{% set attributes = attributes.addClass('block--local-tasks') %}
 {#
 /**
  * @file


### PR DESCRIPTION
# [JIRA STN-142](https://sparkbox.atlassian.net/browse/STN-142) READY FOR REVIEW

## Summary
Style Drupal admin links.

Design reviewed and approved by Merani ✅

## Need Review By (Date)
3/2/2020

## Urgency
low

## Steps to Test
1. In the CLI run `npm run test` and verify our tests still pass.
2. Go to http://economics.suhumsci.loc and review the Drupal admin links located below the masthead. There are no designs for this. Reference the first comment in [JIRA STN-142](https://sparkbox.atlassian.net/browse/STN-142) for a screenshot with the request to implement something similar.
3. Go to http://economics.suhumsci.loc/node/1/layout and confirm the admin bar looks good there as well.

<img width="1039" alt="drupal admin" src="https://user-images.githubusercontent.com/12678977/75462742-b52c6f80-5952-11ea-8727-5ae2ce35394f.png">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
