### PR TITLE
fix(STN-200): add contextual link hack

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -111,7 +111,6 @@
   'elements/base',
   'elements/forms',
   'elements/tables',
-  'elements/wysiwyg-text-area', // WYSIWYG editor
 
   // =====================================================================
   // 5. Objects
@@ -148,4 +147,6 @@
   //    Utilities and helper classes with ability to override anything
   //    which goes before in the triangle, eg. hide helper class
   'utilities/fonts',
-  'utilities/font-awesome';
+  'utilities/font-awesome',
+  'utilities/wysiwyg-text-area', // WYSIWYG editor
+  'utilities/admin.contextual-links';

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.contextual-links.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.contextual-links.scss
@@ -1,0 +1,15 @@
+// Overlapping contextual links are difficult.
+// Different links show at the top for different users.
+// Space them all out so we can see them all.
+// Taken from suhumsci theme here: https://github.com/SU-HSDO/suhumsci/blob/develop/docroot/themes/humsci/su_humsci_theme/scss/components/atoms/_contextual_links.scss
+
+$sel: '';
+@for $i from 0 through 4 {
+  $sel: if($i == 0, '.contextual-region.paragraph', selector-nest($sel, '.contextual-region')) !global;
+
+  #{$sel} {
+    .contextual {
+      right: 32px * $i;
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -1,4 +1,4 @@
-// WYSIWYG text area component
+// WYSIWYG text area styles
 .field-hs-text-area {
   margin: 0 hb-calculate-rems(48px);
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
[Jira Card](https://sparkbox.atlassian.net/browse/STN-200)

Adds hack so that contextual links don't overlap.

## Steps to Test
1. Look at a page with paragraph types on it
2. Check that the contextual links don't overlap.
3. Make sure `npm run test` passes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
