### PR TITLE
feat: adds js and css watch task

### DIFF
--- a/docroot/themes/humsci/humsci_basic/package.json
+++ b/docroot/themes/humsci/humsci_basic/package.json
@@ -5,11 +5,13 @@
   "main": "Gruntfile.js",
   "scripts": {
     "start": "npm run build:sass && npm run watch",
-    "watch": "grunt watch",
+    "watch:sass": "grunt watch",
     "build:sass": "grunt compile",
     "lint:sass": "stylelint 'src/scss/**/*.scss' --config .stylelintrc",
     "test:sass": "mocha 'tests/true-sass-spec.js'",
     "build:js": "webpack",
+    "watch:js": "webpack --watch",
+    "watch": "npm run watch:sass & npm run watch:js",
     "test": "npm run lint:sass && npm run test:sass"
   },
   "license": "MIT",

--- a/docroot/themes/humsci/humsci_basic/webpack.config.js
+++ b/docroot/themes/humsci/humsci_basic/webpack.config.js
@@ -5,6 +5,7 @@
 const srcDir = path.resolve( __dirname, 'src/' );
  
  module.exports = {
+  mode: 'production',
   entry: srcDir + "/js/index.js",
   output: {
     path: srcDir + "/js/build/",


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds a watch task for both js and scss builds. (`npm run watch`)

## Steps to Test
1. run `npm run watch`
2. see that both processes start
3. comment out something in the scss and see that the watch task captures that
4. comment out something in index.js and see that the watch task captures that

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
