### PR TITLE
refactor:  media queries

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -48,7 +48,7 @@
   .field-hs-news-categories {
     margin: 0 0 hb-calculate-rems(20px);
 
-    @include grid-media('sm') {
+    @include grid-media-min('sm') {
       margin-bottom: hb-calculate-rems(26px);
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node.scss
@@ -5,7 +5,7 @@
     line-height: 109%;
     margin: 0 0 hb-calculate-rems(20px);
 
-    @include grid-media('sm') {
+    @include grid-media-min('sm') {
       font-size: hb-calculate-rems(38px);
       margin: 0 0 hb-calculate-rems(28px);
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_tables.scss
@@ -22,7 +22,7 @@ table {
   font-size: hb-calculate-rems(13px);
   text-align: left;
 
-  @include grid-media('sm') {
+  @include grid-media-min('sm') {
     font-size: hb-calculate-rems(16px);
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  @include grid-media('lg') {
+  @include grid-media-min('lg') {
     flex-wrap: nowrap;
   }
 
@@ -14,7 +14,7 @@
     width: 100%;
     margin: 0 0 hb-calculate-rems($hb-gutter-width);
 
-    @include grid-media('md') {
+    @include grid-media-min('md') {
       width: $hb-sidebar-width;
       margin: 0 hb-calculate-rems($hb-gutter-width) 0 0;
     }
@@ -28,7 +28,7 @@
       max-width: hb-calculate-rems($hb-three-column-main-width);
     }
 
-    @include grid-media('md') {
+    @include grid-media-min('md') {
       .hb-three-column--one-sidebar &,
       .hb-three-column--two-sidebar & {
         width: calc(100% - #{$hb-sidebar-width} - #{hb-calculate-rems($hb-gutter-width)});
@@ -40,7 +40,7 @@
       }
     }
 
-    @include grid-media('lg') {
+    @include grid-media-min('lg') {
       width: 100%;
       margin-bottom: 0;
 
@@ -50,7 +50,7 @@
     }
 
     .hb-three-column--one-sidebar & {
-      @include grid-media('2xl') {
+      @include grid-media-min('2xl') {
         max-width: hb-calculate-rems($hb-three-column-one-sidebar-width);
       }
     }
@@ -61,13 +61,13 @@
     margin: 0;
 
     .hb-three-column--one-sidebar & {
-      @include grid-media('md') {
+      @include grid-media-min('md') {
         width: $hb-sidebar-width;
         margin: 0 0 0 hb-calculate-rems($hb-gutter-width);
       }
     }
 
-    @include grid-media('lg') {
+    @include grid-media-min('lg') {
       width: $hb-sidebar-width;
       margin: 0 0 0 hb-calculate-rems($hb-gutter-width);
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  @include grid-media('lg') {
+  @include grid-media-min('lg') {
     flex-wrap: nowrap;
   }
 
@@ -19,16 +19,16 @@
     width: 100%;
     margin: 0 0 hb-calculate-rems($hb-gutter-width);
 
-    @include grid-media('md') {
+    @include grid-media-min('md') {
       width: $hb-sidebar-width;
       margin-right: hb-calculate-rems(map-get($hb-screen-margins, 'md'));
     }
 
-    @include grid-media('lg') {
+    @include grid-media-min('lg') {
       margin-right: hb-calculate-rems(map-get($hb-screen-margins, 'lg'));
     }
 
-    @include grid-media('xl') {
+    @include grid-media-min('xl') {
       margin-right: hb-calculate-rems(map-get($hb-screen-margins, 'xl'));
     }
   }
@@ -37,7 +37,7 @@
     width: 100%;
     margin-bottom: hb-calculate-rems($hb-gutter-width);
 
-    @include grid-media('md') {
+    @include grid-media-min('md') {
       .hb-three-column-w-image--one-sidebar &,
       .hb-three-column-w-image--two-sidebar & {
         width: calc(100% - #{$hb-sidebar-width} - #{hb-calculate-rems(map-get($hb-screen-margins, 'md'))});
@@ -49,7 +49,7 @@
       }
     }
 
-    @include grid-media('lg') {
+    @include grid-media-min('lg') {
       .hb-three-column-w-image--one-sidebar &,
       .hb-three-column-w-image--two-sidebar & {
         width: 100%;
@@ -67,13 +67,13 @@
     flex-wrap: wrap;
 
     .hb-three-column-w-image--one-sidebar & {
-      @include grid-media('lg') {
+      @include grid-media-min('lg') {
         flex-wrap: nowrap;
       }
     }
 
     .hb-three-column-w-image--no-sidebar & {
-      @include grid-media('md') {
+      @include grid-media-min('md') {
         flex-wrap: nowrap;
       }
     }
@@ -84,7 +84,7 @@
     margin-bottom: hb-calculate-rems(16px);
 
     .hb-three-column-w-image--one-sidebar & {
-      @include grid-media('lg') {
+      @include grid-media-min('lg') {
         width: 60%;
         display: flex;
         flex-direction: column;
@@ -92,7 +92,7 @@
     }
 
     .hb-three-column-w-image--no-sidebar & {
-      @include grid-media('md') {
+      @include grid-media-min('md') {
         width: 60%;
         display: flex;
         flex-direction: column;
@@ -104,19 +104,19 @@
     width: 100%;
     margin-bottom: hb-calcualte-rems(16px);
 
-    @include grid-media('md') {
+    @include grid-media-min('md') {
       margin-bottom: hb-calculate-rems($hb-gutter-width);
     }
 
     .hb-three-column-w-image--one-sidebar & {
-      @include grid-media('lg') {
+      @include grid-media-min('lg') {
         width: 40%;
         margin-left: hb-calculate-rems(20px);
       }
     }
 
     .hb-three-column-w-image--no-sidebar & {
-      @include grid-media('md') {
+      @include grid-media-min('md') {
         width: 40%;
         margin-left: hb-calculate-rems(20px);
       }
@@ -130,7 +130,7 @@
         width: 100%;
         max-height: hb-calculate-rems(375px);
 
-        @include grid-media('md') {
+        @include grid-media-min('md') {
           max-height: hb-calculate-rems(250px);
         }
       }
@@ -146,18 +146,18 @@
     margin-left: 0;
 
     .hb-three-column-w-image--one-sidebar & {
-      @include grid-media('md') {
+      @include grid-media-min('md') {
         width: $hb-sidebar-width;
         margin-left: hb-calcualte-rems(map-get($hb-screen-margins, 'md'));
       }
     }
 
-    @include grid-media('lg') {
+    @include grid-media-min('lg') {
       width: $hb-sidebar-width;
       margin-left: hb-calculate-rems(map-get($hb-screen-margins, 'lg'));
     }
 
-    @include grid-media('xl') {
+    @include grid-media-min('xl') {
       margin-left: hb-calculate-rems(map-get($hb-screen-margins, 'xl'));
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Refactors all media queries to use `grid-media-min` instead of `grid-media`

## Steps to Test
1. Make sure the styles on the site still look good/resizes correctly
2. run `npm run test` and make sure the tests pass.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
