### PR TITLE
feat(STN-195): hero integration

### DIFF
--- a/docroot/modules/humsci/hs_layouts/src/Plugin/Layout/HumsciLayout.php
+++ b/docroot/modules/humsci/hs_layouts/src/Plugin/Layout/HumsciLayout.php
@@ -33,9 +33,9 @@ class HumsciLayout extends LayoutDefault implements PluginFormInterface {
       '#type' => 'select',
       '#title' => $this->t('Section Width'),
       '#description' => $this->t('Choose if the sections should be full width or limited.'),
-      '#empty_option' => $this->t('Full Width'),
-      '#default_value' => $this->configuration['section_width'] ?: NULL,
+      '#default_value' => $this->configuration['section_width'] ?: 'hs-full-width',
       '#options' => [
+        'hs-full-width' => $this->t('Full Width'),
         'decanter-grid' => $this->t('Limited Width'),
       ],
     ];

--- a/docroot/themes/humsci/humsci_basic/package.json
+++ b/docroot/themes/humsci/humsci_basic/package.json
@@ -5,11 +5,12 @@
   "main": "Gruntfile.js",
   "scripts": {
     "start": "npm run build:sass && npm run watch",
-    "watch:sass": "grunt watch",
     "build:sass": "grunt compile",
+    "build:js": "webpack",
+    "build": "npm run build:sass & npm run build:js",
     "lint:sass": "stylelint 'src/scss/**/*.scss' --config .stylelintrc",
     "test:sass": "mocha 'tests/true-sass-spec.js'",
-    "build:js": "webpack",
+    "watch:sass": "grunt watch",
     "watch:js": "webpack --watch",
     "watch": "npm run watch:sass & npm run watch:js",
     "test": "npm run lint:sass && npm run test:sass"

--- a/docroot/themes/humsci/humsci_basic/package.json
+++ b/docroot/themes/humsci/humsci_basic/package.json
@@ -7,7 +7,7 @@
     "start": "npm run build:sass && npm run watch",
     "build:sass": "grunt compile",
     "build:js": "webpack",
-    "build": "npm run build:sass & npm run build:js",
+    "build": "npm run build:sass && npm run build:js",
     "lint:sass": "stylelint 'src/scss/**/*.scss' --config .stylelintrc",
     "test:sass": "mocha 'tests/true-sass-spec.js'",
     "watch:sass": "grunt watch",

--- a/docroot/themes/humsci/humsci_basic/patterns/hero-text-overlay/hero-text-overlay.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/hero-text-overlay/hero-text-overlay.ui_patterns.yml
@@ -19,7 +19,7 @@ hero_text_overlay:
       description: Brown Gradient
   fields:
     image:
-      label: "Left"
+      label: "Image"
       preview:
         theme: image
         uri: "http://placecorgi.com/2000/800"

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
@@ -1,5 +1,7 @@
 // scss-lint:disable ImportantRule
 .su-masthead {
+  z-index: $hb-z-index-masthead;
+
   .su-lockup {
     z-index: $hb-z-index-lockup;
   }
@@ -15,7 +17,6 @@
   .su-main-nav {
     margin: 0 !important;
     width: 100% !important;
-    z-index: $hb-z-index-main-menu;
 
     @include grid-media-min('sm') {
       flex: unset;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -11,7 +11,7 @@
     }
   }
 }
-  
+
 .hb-hero-overlay {
   &--1 {
     display: grid;
@@ -167,7 +167,7 @@
       li {
         &::before {
           @include hb-colorful {
-            background-color: lighten(hb-colorful-variation(secondary), 20%);
+            background-color: lighten(hb-colorful-variation(secondary), 10%);
           }
         }
       }
@@ -177,7 +177,7 @@
       li {
         &::before {
           @include hb-colorful {
-            color: lighten(hb-colorful-variation(secondary), 20%);
+            color: lighten(hb-colorful-variation(secondary), 10%);
           }
         }
       }
@@ -195,7 +195,7 @@
     a {
       @include hb-colorful {
         color: lighten(hb-colorful-variation(primary), 30%);
-    
+
         &:hover,
         &:focus {
           box-shadow: none;
@@ -208,6 +208,12 @@
       a,
       button {
         @include hb-border-button;
+        @include hb-colorful {
+          @include hb-border-button(
+            lighten(hb-colorful-variation(primary), 30%),
+            lighten(hb-colorful-variation(primary), 70%)
+          );
+        }
 
         .fa-ext {
           display: none;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -1,3 +1,17 @@
+// If only the image is present (no overlay text) or hero wrapper,
+// make sure vertical margin is present
+.field-hs-hero-image {
+  .hs-full-width & {
+    // Special negative margin for the hero
+    // to get rid of the vertical padding on all basic pages
+    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+
+    @include grid-media-min('md') {
+      margin: calc(-2 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+    }
+  }
+}
+  
 .hb-hero-overlay {
   &--1 {
     display: grid;
@@ -68,6 +82,14 @@
   }
 
   &__image-wrapper {
+    // If inside an img wrapper,
+    // no margin should be added
+    .field-hs-hero-image {
+      .hs-full-width & {
+        margin: 0;
+      }
+    }
+
     .hb-hero-overlay--1 & {
       grid-column-start: 2;
       grid-column-end: 3;
@@ -141,12 +163,44 @@
       }
     }
 
+    ul {
+      li {
+        &::before {
+          @include hb-colorful {
+            background-color: lighten(hb-colorful-variation(secondary), 20%);
+          }
+        }
+      }
+    }
+
+    ol {
+      li {
+        &::before {
+          @include hb-colorful {
+            color: lighten(hb-colorful-variation(secondary), 20%);
+          }
+        }
+      }
+    }
+
     .text-long,
     a {
       font-size: hb-calculate-rems(16px);
 
       @include grid-media-min('md') {
         font-size: hb-calculate-rems(18px);
+      }
+    }
+
+    a {
+      @include hb-colorful {
+        color: lighten(hb-colorful-variation(primary), 30%);
+    
+        &:hover,
+        &:focus {
+          box-shadow: none;
+          color: lighten(hb-colorful-variation(primary), 70%);
+        }
       }
     }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -150,12 +150,14 @@
       }
     }
 
-    a,
-    button {
-      @include hb-border-button;
+    .field-hs-hero-link {
+      a,
+      button {
+        @include hb-border-button;
 
-      .fa-ext {
-        display: none;
+        .fa-ext {
+          display: none;
+        }
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -4,9 +4,10 @@
     @include clearfix;
     grid-template-columns: 2% 5% 93%; // 3 cols, position 1-4
     grid-template-rows: $hb-gutter-width 1fr 1fr auto auto $hb-gutter-width; // 6 rows, position 1-7
-    margin: 0 0 $hb-gutter-width;
+    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
 
     @include grid-media-min('md') {
+      margin-top: calc(-2 * #{hb-calculate-rems($hb-gutter-width)});
       grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
       grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -2,7 +2,7 @@
   &--1 {
     display: grid;
     @include clearfix;
-    grid-template-columns: 2% 5% 93%; // 3 cols, position 1-4
+    grid-template-columns: 7% 93%; // 2 cols, position 1-2
     grid-template-rows: $hb-gutter-width 1fr 1fr auto auto $hb-gutter-width; // 6 rows, position 1-7
     margin: 0 0 $hb-gutter-width;
 
@@ -34,8 +34,8 @@
     // Offset background color psuedo element
     &::before {
       background-color: lighten($su-color-driftwood, 25%);
-      grid-column-start: 2;
-      grid-column-end: 4;
+      grid-column-start: 1;
+      grid-column-end: 3;
       grid-row-start: 1;
       grid-row-end: 7;
 
@@ -52,7 +52,7 @@
       &::after {
         background-color: hb-colorful-variation(secondary);
         grid-column-start: 1;
-        grid-column-end: 3;
+        grid-column-end: 2;
         grid-row-start: 3;
         grid-row-end: 4;
         z-index: $hb-z-index-block-background;
@@ -70,7 +70,7 @@
   &__image-wrapper {
     .hb-hero-overlay--1 & {
       grid-column-start: 2;
-      grid-column-end: 4;
+      grid-column-end: 3;
       grid-row-start: 2;
       grid-row-end: 5;
 
@@ -103,11 +103,11 @@
     }
 
     .hb-hero-overlay--1 & {
-      grid-column-start: 3;
-      grid-column-end: 4;
+      grid-column-start: 2;
+      grid-column-end: 3;
       grid-row-start: 4;
       grid-row-end: 6;
-      padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
+      padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
       position: relative;
 
       @include grid-media-min('md') {
@@ -115,6 +115,7 @@
         grid-column-end: 4;
         grid-row-start: 4;
         grid-row-end: 7;
+        padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
       }
 
       h2 {
@@ -125,13 +126,17 @@
         // Line decoration pseudo element
         &::after {
           display: block;
-          top: hb-calculate-rems(56px);
+          top: hb-calculate-rems(32px);
 
           @include psuedo-background-box(
             lighten(hb-colorful-variation(primary), 30%),
             hb-calculate-rems(4px),
             hb-calculate-rems(65px)
           );
+
+          @include grid-media-min('md') {
+            top: hb-calculate-rems(56px);
+          }
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -4,16 +4,25 @@
     @include clearfix;
     grid-template-columns: 2% 5% 93%; // 3 cols, position 1-4
     grid-template-rows: $hb-gutter-width 1fr 1fr auto auto $hb-gutter-width; // 6 rows, position 1-7
-    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+    margin: 0 0 $hb-gutter-width;
 
     @include grid-media-min('md') {
-      margin-top: calc(-2 * #{hb-calculate-rems($hb-gutter-width)});
       grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
       grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
     }
 
     @include grid-media-min('xl') {
       grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
+    }
+
+    .hs-full-width & {
+      // Special negative margin for the hero
+      // to get rid of the vertical padding on all basic pages
+      margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+
+      @include grid-media-min('md') {
+        margin: calc(-2 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+      }
     }
 
     &::before,

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
@@ -2,6 +2,16 @@
   @include hb-page-width;
 }
 
+.hb-vertical-page-padding {
+  // scss-lint:disable ImportantRule
+  margin: hb-calculate-rems($hb-gutter-width) auto !important;
+
+  @include grid-media('md') {
+    margin: calc(2 * #{hb-calculate-rems($hb-gutter-width)}) auto !important;
+  }
+  // scss-lint:enable ImportantRule
+}
+
 // If a component needs *any* additional styles, move the rule into /src/scss/components.
 .layout-builder__message {
   @include hb-page-width;

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
@@ -6,7 +6,11 @@
     flex-wrap: nowrap;
   }
 
-  &.decanter-grid {
+  // If this uses the "limited width" section width
+  // option in layout builder, then apply our
+  // hb-page-width mixin. Otherwise, the section will
+  // go full width.
+  &:not(.hs-full-width) {
     @include hb-page-width;
   }
 
@@ -22,7 +26,7 @@
   &__main {
     width: 100%;
 
-    .hb-three-column--no-sidebar.decanter-grid & {
+    .hb-three-column--no-sidebar:not(.hs-full-width) & {
       max-width: hb-calculate-rems($hb-three-column-main-width);
     }
 
@@ -47,7 +51,7 @@
       }
     }
 
-    .hb-three-column--one-sidebar.decanter-grid & {
+    .hb-three-column--one-sidebar:not(.hs-full-width) & {
       @include grid-media-min('2xl') {
         max-width: hb-calculate-rems($hb-three-column-one-sidebar-width);
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column.scss
@@ -6,7 +6,7 @@
     flex-wrap: nowrap;
   }
 
-  &.hb-page-width {
+  &.decanter-grid {
     @include hb-page-width;
   }
 
@@ -22,7 +22,7 @@
   &__main {
     width: 100%;
 
-    .hb-three-column--no-sidebar & {
+    .hb-three-column--no-sidebar.decanter-grid & {
       max-width: hb-calculate-rems($hb-three-column-main-width);
     }
 
@@ -47,7 +47,7 @@
       }
     }
 
-    .hb-three-column--one-sidebar & {
+    .hb-three-column--one-sidebar.decanter-grid & {
       @include grid-media-min('2xl') {
         max-width: hb-calculate-rems($hb-three-column-one-sidebar-width);
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
@@ -6,7 +6,11 @@
     flex-wrap: nowrap;
   }
 
-  &.decanter-grid {
+  // If this uses the "limited width" section width
+  // option in layout builder, then apply our
+  // hb-page-width mixin. Otherwise, the section will
+  // go full width.
+  &:not(.hs-full-width) {
     @include hb-page-width;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
@@ -6,7 +6,7 @@
     flex-wrap: nowrap;
   }
 
-  &.hb-page-width {
+  &.decanter-grid {
     @include hb-page-width;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.three_column_w_image.scss
@@ -14,7 +14,7 @@
     @include hb-page-width;
   }
 
-  &--no-sidebar {
+  &--no-sidebar:not(.hs-full-width) {
     max-width: hb-calculate-rems($hb-three-column-w-image-main-width);
     margin: auto;
   }
@@ -125,7 +125,9 @@
   }
 
   &__main-body {
-    max-width: hb-calculate-rems($hb-three-column-w-image-main-body-width);
+    .hb-three-column-w-image--no-sidebar:not(.hs-full-width) & {
+      max-width: hb-calculate-rems($hb-three-column-w-image-main-body-width);
+    }
   }
 
   &__sidebar-2 {

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
@@ -17,7 +17,7 @@ $hb-z-index-12: 1200;
 // All z-index values used in partials should be mapped to a variable in this file.
 // For example:
 // $hb-z-index-modal: $hb-z-index-1;
-$hb-z-index-main-menu: $hb-z-index-1;
+$hb-z-index-masthead: $hb-z-index-1;
 $hb-z-index-lockup: $hb-z-index-5; // keeps the lockup from laying on top of the admin menu
 $hb-z-index-search: $hb-z-index-5; // keeps the search input from being hidden by the navigation
 $hb-z-index-block-background: $hb-z-index-small;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
@@ -49,7 +49,10 @@
   text-decoration: none;
 }
 
-@mixin hb-border-button {
+@mixin hb-border-button(
+  $button-color: $su-color-cardinal-red,
+  $button-color-hover: darken($su-color-cardinal-red, 10%)
+) {
   display: block;
   background-color: transparent;
   border-radius: hb-calculate-rems(42px);
@@ -62,14 +65,14 @@
   transition: all 200ms ease-in-out;
 
   @include hb-colorful {
-    border: 3px solid lighten(hb-colorful-variation(primary), 30%);
-    color: lighten(hb-colorful-variation(primary), 30%);
+    border: 3px solid $button-color;
+    color: $button-color;
 
     &:hover,
     &:focus {
       box-shadow: none;
-      border: 3px solid lighten(hb-colorful-variation(primary), 70%);
-      color: lighten(hb-colorful-variation(primary), 70%);
+      border: 3px solid $button-color-hover;
+      color: $button-color-hover;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
@@ -3,13 +3,5 @@
   max-width: hb-calculate-rems($hb-layout-max-width) !important;
   margin: 0 auto !important;
   width: calc(100% - (2 * #{hb-calculate-rems($hb-gutter-width)})) !important;
-
-  &--padded {
-    margin: hb-calculate-rems($hb-gutter-width) auto !important;
-
-    @include grid-media('md') {
-      margin: calc(2 * #{hb-calculate-rems($hb-gutter-width)}) auto !important;
-    }
-  }
   // scss-lint:enable ImportantRule
 }

--- a/docroot/themes/humsci/humsci_basic/templates/node.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/node.html.twig
@@ -73,7 +73,7 @@
   node.type ? node.type.entity.label|clean_class,
   view_mode ? 'node-layout-' ~ view_mode|clean_class,
   node.type and view_mode ? 'node-' ~ node.type.entity.label|clean_class ~ '-' ~ view_mode|clean_class,
-  "hb-page-width", "hb-page-width--padded"
+  "hb-vertical-page-padding"
 ]) %}
 {% set title_classes = [ node.bundle|clean_class ~ '__title'] %}
 {% set attributes = attributes.addClass(node_classes) %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Hero integration to allow it to be full-width on a basic page. The vertical margin of the full width hero at the top of the page will be different than a hero inserted with other components.

I also added a build task and refactored how hb-full-width works.

I tested and checked that default image styles (which is a responsive media field using hero image styles) are working as expected.

J and I paired on the mobile design, hero with no image, and hero with no overlay. Screenshots below:

#### No overlay
<img width="1440" alt="hero with no overla" src="https://user-images.githubusercontent.com/12848168/76031507-d3234280-5f05-11ea-92cc-3cf2a8a7f0fb.png">

#### No image
<img width="1440" alt="hero without image" src="https://user-images.githubusercontent.com/12848168/76031536-dc141400-5f05-11ea-835f-1490947252ec.png">
<img width="361" alt="Screen Shot 2020-03-05 at 5 16 48 PM" src="https://user-images.githubusercontent.com/12848168/76031546-dfa79b00-5f05-11ea-8140-6f63e2f037e0.png">


## Steps to Test
1. Add a hero to the home page using the hero image option. (See screenshot below). As for the display, go to Manage Display, and ensure that it's using the three column grid and the "Full width" section width option.
2. Do some browser testing and verify it looks good.
3. Go to another basic page, and add a hero to the page as the first thing using the paragraph type. Check out manage display for that page, and toggle back and forth between using the three column grid and the "Full width" section width option and the "limited width" option.
2. Do some browser testing and verify it looks good.

<img width="618" alt="Screen Shot 2020-03-05 at 12 56 49 PM" src="https://user-images.githubusercontent.com/12848168/76010619-2f27a000-5ee1-11ea-9feb-ebabc740b4b0.png">


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
