### PR TITLE
feat(STN-239): adds grid system for up to 12 cols and a mixin

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
@@ -9,26 +9,14 @@
     margin-bottom: hb-calculate-rems(24px);
     width: 100%;
 
-    @include grid-media-min('sm') {
-      width: calc(50% - (#{hb-calculate-rems($hb-gutter-width)} / 2)); // for two elements, there is 1 gutter-width between
-      margin-right: hb-calculate-rems(48px);
-    }
-
-    &:nth-child(2n) {
-      margin-right: 0;
-    }
-
-    .hb-grid--cols-3 & {
-      @include grid-media-min('md') {
-        width: calc(33.33% - (2 * (#{hb-calculate-rems($hb-gutter-width)}) / 3)); // for 3 elements, 2 have gutter-width
-
-        &:nth-child(2n) {
-          margin-right: hb-calculate-rems(48px);
-        }
-
-        &:nth-child(3n) {
-          margin-right: 0;
-        }
+    // This is our grid maker, it defines classes for each breakdown
+    // of the grid and gives human readable versions when it can.
+    // 1-2 cols exist starting at the "sm" breakpoint
+    // 3-4 cols start at the "md" breakpoint
+    // all others start at "lg"
+    @for $i from 1 through $hb-grid-count {
+      .hb-grid--cols-#{$i} & {
+        @include hb-column($i);
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
@@ -1,6 +1,8 @@
 $hb-global-theme-list: ('airy', 'colorful', 'traditional');
 $hb-colorful-theme-variation-list: ('colorful-teal', 'colorful-mint');
 
+$hb-grid-count: 12;
+
 // We can use Decanter's breakpoints, but we don't need their largest one so we'll omit it from our map below.
 // See: https://github.com/SU-SWS/decanter/blob/master/core/src/scss/utilities/variables/core/_breakpoints.scss
 $hb-grid-media: (

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
@@ -5,3 +5,70 @@
   width: calc(100% - (2 * #{hb-calculate-rems($hb-gutter-width)})) !important;
   // scss-lint:enable ImportantRule
 }
+
+@mixin hb-column-width($percentage, $margin, $cols) {
+  width: calc(#{$percentage} - (#{$margin} / #{$cols})); // for 3 elements, 2 have gutter-width
+}
+
+// For this mixin:
+//
+// @param(integer) $col-number
+// For grids with 2 cols, it will remain 2 cols after sm.
+// For grids with 3 or 4 cols, it will become 3 or 4 cols at md and remain.
+// All grids above 4 cols will have:
+// 1 col at mobile,
+// 2 cols at sm,
+// 3 cols at md,
+// and then the requested number at lg.
+// Cols over 12 are not supported.
+@mixin hb-column($col-number: 2) {
+  $percentage-width: 100% / $col-number;
+  $one-less-col: $col-number - 1;
+  $total-margin: calc(#{$one-less-col} * #{hb-calculate-rems($hb-gutter-width)});
+
+  @if ($col-number > 1) {
+    // 2 cols
+    @include grid-media-min('sm') {
+      @include hb-column-width(50%, calc(1 * #{hb-calculate-rems($hb-gutter-width)}), 2); // for two elements, there is 1 gutter-width between
+      margin-right: hb-calculate-rems(48px);
+
+      &:nth-child(2n) {
+        margin-right: 0;
+      }
+    }
+
+    @if ($col-number > 2) {
+      @if ($col-number != 4) {
+        // 3 cols
+        @include grid-media-min('md') {
+          @include hb-column-width(33.33%, calc(2 * #{hb-calculate-rems($hb-gutter-width)}), 3); // for 3 elements, 2 have gutter-width
+
+          &:nth-child(2n) {
+            margin-right: hb-calculate-rems(48px);
+          }
+
+          &:nth-child(3n) {
+            margin-right: 0;
+          }
+        }
+      }
+
+      // above 3 cols
+      @include grid-media("lg") {
+        @include hb-column-width($percentage-width, $total-margin, $col-number);
+
+        &:nth-child(2n) {
+          margin-right: hb-calculate-rems(48px);
+        }
+
+        &:nth-child(3n) {
+          margin-right: hb-calculate-rems(48px);
+        }
+
+        &:nth-child(#{$col-number}n) {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Creates a grid layout for larger 4-12 col grids.

## Steps to Test
1. In a view for horizontal, vertical, or date stacked card, add a Grid pattern to that view with 4 cols in the input. (See screenshots below).
2. On that basic page, make sure 4 cols looks good, and then use the inspector to change the `.hb-grid--cols-4` class to different numbers and make sure the behavior and responsiveness looks good!
2. Make sure `npm run test` passes.

<img width="516" alt="Screen Shot 2020-03-12 at 2 06 22 PM" src="https://user-images.githubusercontent.com/12848168/76553674-d91ba500-646a-11ea-9de4-9c0407910829.png">
<img width="549" alt="Screen Shot 2020-03-12 at 2 06 32 PM" src="https://user-images.githubusercontent.com/12848168/76553676-d91ba500-646a-11ea-98e1-ad145edccfd4.png">


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
