### PR TITLE
STN-216 : QA Feedback for Sprint 10

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -26,9 +26,9 @@
       display: inline-block;
       list-style: none;
       margin-right: hb-calculate-rems(12px);
-      margin-bottom: hb-calculate-rems(5px);
+      margin-bottom: hb-calculate-rems(3px);
       padding-bottom: 0;
-      line-height: 1;
+      line-height: 133%;
 
       @include hb-colorful {
         &::before {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -17,6 +17,21 @@
 
   .menu-item {
     margin-bottom: hb-calculate-rems(14px);
+
+    @include grid-media-min('lg') {
+      font-size: hb-calculate-rems(18px);
+    }
+
+    @include hb-colorful {
+      a {
+        &:hover,
+        &:focus {
+          .fa-ext::before {
+            background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{hb-colorful-variation(primary)}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
+          }
+        }
+      }
+    }
   }
 
   .block__title,
@@ -35,19 +50,34 @@
         color: hb-colorful-variation(primary);
       }
     }
+  }
+}
 
-    &--dark {
-      $hb-lighten-color--primary: lighten(hb-colorful-variation(primary), 30%);
-      $hb-lighten-color-hover--primary: lighten(hb-colorful-variation(primary), 70%);
-      background-color: darken(hb-colorful-variation(primary), 10%);
-      color: $hb-color--white;
-      border-top: 0;
+.hb-local-footer--dark {
+  @include hb-colorful {
+    $hb-lighten-color--primary: lighten(hb-colorful-variation(primary), 30%);
+    $hb-lighten-color-hover--primary: lighten(hb-colorful-variation(primary), 70%);
+    background-color: darken(hb-colorful-variation(primary), 10%);
+    color: $hb-color--white;
+    border-top: 0;
 
-      a.fab {
-        color: lighten(hb-colorful-variation(secondary), 10%);
+    a.fab {
+      color: lighten(hb-colorful-variation(secondary), 10%);
 
-        &:hover {
-          color: hb-colorful-variation(secondary);
+      &:hover {
+        color: hb-colorful-variation(secondary);
+      }
+    }
+
+    .menu-item {
+      margin-bottom: hb-calculate-rems(14px);
+
+      a {
+        &:hover,
+        &:focus {
+          .fa-ext::before {
+            background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{lighten(hb-colorful-variation(primary), 70%)}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
+          }
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -3,6 +3,12 @@
   padding: hb-calculate-rems(48px) 0;
   border-top: 1px solid $su-color-driftwood;
 
+  .hb-secondary-nav {
+    // overwrite default secondary nav styles for menu items
+    // in the local footer to display at all times
+    display: block;
+  }
+
   .menu {
     list-style-type: none;
     margin: 0;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -43,21 +43,6 @@
       color: $hb-color--white;
       border-top: 0;
 
-      a:not([class]) {
-        color: $hb-lighten-color--primary;
-
-        &:hover,
-        &:focus {
-          color: $hb-lighten-color-hover--primary;
-        }
-      }
-
-      .fa-ext {
-        &::before {
-          background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{$hb-lighten-color--primary}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
-        }
-      }
-
       a.fab {
         color: lighten(hb-colorful-variation(secondary), 10%);
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.icons.scss
@@ -14,3 +14,5 @@ $hb-icon-down-arrow: '<svg viewBox="0 0 10 7"><path d="M1 1L5.14815 5L9 1" fill=
 
 // to pass a different color into the link arrow icon, use the hb-icon-link-arrow mixin
 $hb-icon-link-arrow: '<svg viewBox="0 0 23 24"><path fill="#{$hb-color--black}" d="M11 23l-2-2 7-7H0v-3h16L9 3l2-2 10 10 1 1-11 11z"/></svg>';
+
+$hb-icon-external-link: '<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{$hb-color--black}" stroke-width="2" stroke-miterlimit="10"/></svg>';

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -1,3 +1,4 @@
+// Used with the decanter-external-link class to add an external link icon
 @mixin hb-external-link-icon {
   margin-right: hb-calculate-rems(20px);
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -22,6 +22,12 @@
     &:focus::before {
       background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{$hb-color--primary}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
     }
+
+    .hb-local-footer--dark & {
+      &::before {
+        background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{lighten(hb-colorful-variation(primary), 30%)}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
+      }
+    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -27,6 +27,11 @@
       &::before {
         background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{lighten(hb-colorful-variation(primary), 30%)}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
       }
+
+      &:hover::before,
+      &:focus::before {
+        background: svg('<svg viewBox="0 0 12 12"><path d="M11.273 5.818v5.455H.727V.727h5.091m1.455 0h4v4m0-4L6.182 5.818" fill="transparent" stroke="#{lighten(hb-colorful-variation(primary), 70%)}" stroke-width="2" stroke-miterlimit="10"/></svg>') center center no-repeat;
+      }
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -125,6 +125,26 @@
       box-shadow: inset 0 hb-calculate-rems(-9px) 0 lighten(hb-colorful-variation(primary), 70%);
     }
   }
+
+  .hb-local-footer & {
+    &:hover,
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  .hb-local-footer--dark & {
+    @include hb-colorful {
+      color: lighten(hb-colorful-variation(primary), 30%);
+
+      &:hover,
+      &:focus {
+        // scss-lint:disable ImportantRule
+        color: lighten(hb-colorful-variation(primary), 70%) !important; // override default element styles
+        // scss-lint:enable ImportantRule
+      }
+    }
+  }
 }
 
 @mixin hb-blockquote {

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.contextual-links.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.contextual-links.scss
@@ -19,4 +19,8 @@ $sel: '';
 .contextual-links a:hover,
 .contextual-links a:focus {
   box-shadow: initial;
+
+  .hb-local-footer--dark & {
+    color: $hb-color--black !important; // override dark variant link styles on hover
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -172,6 +172,10 @@ blockquote:nth-child(n) {
     content: '';
   }
 
+  .hb-local-footer & {
+    margin: 0 0 2rem 0; // adjust blockquote browser spacing defaults when placed in the local footer
+  }
+
   p {
     @include hb-blockquote;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -44,7 +44,7 @@
       color: $hb-color--white;
 
       @include hb-colorful {
-        color: lighten(hb-colorful-variation(secondary), 10%); // WIP
+        color: lighten(hb-colorful-variation(secondary), 10%);
       }
     }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -30,7 +30,7 @@
     font-style: italic;
 
     .hb-local-footer--dark & {
-      color: $hb-color--white; // WIP
+      color: $hb-color--white;
     }
   }
 
@@ -73,7 +73,7 @@
     font-size: hb-calculate-rems(14px);
 
     .hb-local-footer--dark & {
-      color: $hb-color--white; // WIP
+      color: $hb-color--white;
     }
   }
 
@@ -175,7 +175,7 @@ blockquote:nth-child(n) {
   p {
     @include hb-blockquote;
 
-    .hb-local-footer--dark & { // WIP
+    .hb-local-footer--dark & {
       color: $hb-color--white;
 
       @include hb-colorful {

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -28,6 +28,10 @@
     color: darken($su-color-driftwood, 45%);
     font-size: hb-calculate-rems(14px);
     font-style: italic;
+
+    .hb-local-footer--dark & {
+      color: $hb-color--white; // WIP
+    }
   }
 
   &-font-lead {
@@ -35,6 +39,14 @@
     font-size: hb-calculate-rems(18px);
     font-weight: hb-theme-font-weight(regular);
     line-height: 127%;
+
+    .hb-local-footer--dark & {
+      color: $hb-color--white;
+
+      @include hb-colorful {
+        color: lighten(hb-colorful-variation(secondary), 10%); // WIP
+      }
+    }
 
     @include grid-media-min('lg') {
       font-size: hb-calculate-rems(20px);
@@ -59,6 +71,10 @@
   &-caption {
     color: darken($su-color-driftwood, 45%);
     font-size: hb-calculate-rems(14px);
+
+    .hb-local-footer--dark & {
+      color: $hb-color--white; // WIP
+    }
   }
 
   &-short-line-length {
@@ -158,5 +174,13 @@ blockquote:nth-child(n) {
 
   p {
     @include hb-blockquote;
+
+    .hb-local-footer--dark & { // WIP
+      color: $hb-color--white;
+
+      @include hb-colorful {
+        color: lighten(hb-colorful-variation(secondary), 10%);
+      }
+    }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/templates/block/block--system-branding-block.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/block/block--system-branding-block.html.twig
@@ -66,8 +66,8 @@
 
 {# If ALL lines 1-5 are not set, allow default Slogan and Site Name to be used #}
 {% if lockup.line1 is empty and line2 is empty and lockup.line3 is empty and lockup.line4 is empty and line5 is empty %}
-  {% set line2 = content.site_slogan|render %}
-  {% set line5 = content.site_name|render %}
+  {% set line2 = content.site_name|render %}
+  {% set line5 = content.site_slogan|render %}
 {% endif %}
 
 {# In case we ever want to pipe this through to a decanter template: #}


### PR DESCRIPTION
# [STN-216](https://sparkbox.atlassian.net/browse/STN-216)
## READY FOR REVIEW

## Summary
Implement feedback from Sprint 10.
- [x] Remap default Site Name and Slogan. The Site Name is on line 2. The Slogan is on line 5.
- [x] On `News Item` and `People` category list items, prevent hover state overlapping on multiple lines.
- [x] Add support for local footer dark variant WYSIWYG styles
- [x] Make custom menus created within the local footer visible at all screen sizes.
- [x] Design bonus: Remove spacing around blockquote when it is located in the global footer.

🎨Design reviewed by Merani ✅

## Need Review By (Date)
3/17/2020

## Urgency
medium

## Steps to Test
1. In the CLI, run `npm run test` to verify all tests pass.
2. Go to http://economics.suhumsci.loc
3. Verify the Site Name and Slogan display correctly in the masthead.
4. Add a category with a long name for testing.
    * Go to Structure > Taxonomy
    * News Categories > List Terms
    * Add Term (something _really_ long, approx. 9 to 10 words)
    * Save
5. Go to a basic page with list of horizontal or vertical news items.
    * Edit one of the news items in the list to use the super long category
    * View the news list page and verify the hover state underline does not overlap onto the text.
6. Scroll down the page to view the local footer.
    * You will need to have the dark variant applied to the local footer to verify these changes.
    * Create or update a block or two within the global footer with the following WYSIWYG styles:
        * Blockquote
        * Bold
        * Italic
        * Caption
        * Credits
        * Lead font
    * Review and verify the WYSIWYG styles listed above are supported
    * DESIGN BONUS: The blockquote should not have horizontal spacing when it resides within the footer.
7. Create a custom menu block in the local footer. Verify it is visible at all screen sizes.
8. Let's make sure the local footer still looks great when set to use the default variant. Update the local footer to use the default variant. Confirm all content looks as expected.

### Screenshot of expected WYSIWYG results
![global_footer](https://user-images.githubusercontent.com/12678977/76566153-88b04180-6482-11ea-9d03-335d9b108716.png)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
