### PR TITLE
STN-181: Vertical Link Card

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_postcard.token.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_postcard.token.yml
@@ -86,13 +86,13 @@ content:
     label: hidden
     settings:
       trim_length: 80
-      url_only: false
+      url_only: true
       url_plain: false
       rel: '0'
       target: '0'
     third_party_settings:
       field_formatter_class:
-        class: decanter-button
+        class: ''
     type: link
     region: button
   field_hs_postcard_title:

--- a/docroot/themes/humsci/humsci_basic/patterns/vertical-link-card/vertical-link-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/vertical-link-card/vertical-link-card.html.twig
@@ -1,28 +1,27 @@
-{% set attributes = attributes.addClass('vertical-link-card') %}
+{% set attributes = attributes.addClass('hb-vertical-linked-card') %}
+{%- set has_image = image|render|striptags('<drupal-render-placeholder><img>')|trim -%}
+{%- set has_description = description|render|striptags('<drupal-render-placeholder><img>')|trim -%}
 
 <div{{ attributes }}>
-  {% if button %}
-    <a href="{{ button|render|striptags|trim }}" title="{{ title|render|striptags|trim }}">
+  {% if has_image %}
+    <div class="hb-vertical-linked-card__img">
+      {{ image }}
+    </div>
   {% endif %}
 
-    {% if image %}
-      <div class="vertical-link-card__img">
-        {{ image }}
-      </div>
-    {% endif %}
+  {% if title %}
+    <h2 class="hb-vertical-linked-card__title">
+      {{ title|render|striptags|trim|raw }}
+    </h2>
+  {% endif %}
 
-    <div class="vertical-link-card__content-container">
-      {% if title %}
-        <h2 class="vertical-link-card__title">{{ title|render|striptags|trim|raw }}</h2>
-      {% endif %}
-      {% if description %}
-        <div class="vertical-link-card__description">
-          {{ description }}
-        </div>
-      {% endif %}
+  {% if has_description %}
+    <div class="hb-vertical-linked-card__description">
+      {{ description }}
     </div>
+  {% endif %}
 
   {% if button %}
-    </a>
+    <a href="{{ button|render|striptags|trim }}" aria-label="{{ title|render|striptags|trim }}" class="hb-vertical-linked-card__link"></a>
   {% endif %}
 </div>

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -89,6 +89,7 @@
   'tools/functions.fonts',
   'tools/functions.general',
   'tools/functions.svg',
+  'tools/functions.animation',
   'tools/mixins.general',
   'tools/mixins.themes',
   'tools/mixins.text',
@@ -145,6 +146,7 @@
   'components/pattern.hero',
   'components/postcard',
   'components/more-link',
+  'components/vertical-linked-card',
 
   // =====================================================================
   // 8. Utilities

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -150,7 +150,7 @@
         border-bottom: 0 none;
 
         img {
-          transform: scale(1.07);
+          transform: scale($hb-image-hover-scale);
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
@@ -1,0 +1,118 @@
+.hb-vertical-linked-card {
+  position: relative;
+  // The margin-top matches the margin-top on both the title and image to prevent
+  // overlap issues.
+  // The margin-left matches the negative margin-left on the title to prevent
+  // overlap issues.
+  margin: hb-calculate-rems(24px) 0 hb-calculate-rems($hb-gutter-width) hb-calculate-rems(31px);
+  padding-bottom: hb-calculate-rems(28px);
+
+  @include hb-colorful {
+    color: $hb-color--white;
+
+    // The gradient adds a 20px height white block at the top of the linked card
+    // so that the title looks like it has a negative margin on the top when
+    // there isn't an image.
+    background-image: linear-gradient(to bottom, $hb-color--white, $hb-color--white hb-calculate-rems(20px), darken(hb-colorful-variation(tertiary), 30%) hb-calculate-rems(20px));
+    // The gradient looks intimidating but it's only because of all the mixins
+    // we have to use. If we get rid of those it looks more like this:
+    // linear-gradient(to bottom, white, white 20px, colorful-color 20px);
+  }
+
+  &__img {
+    margin-top: hb-calculate-rems(-24px);
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      transition: hb-transition(transform);
+
+      .hb-vertical-linked-card:hover &,
+      .hb-vertical-linked-card:focus & {
+        transform: scale($hb-image-hover-scale);
+      }
+    }
+  }
+
+  &__title {
+    // Without this the negative margins on the title cause it to lay under the
+    // image. Adding position relative makes sure everything is layered correctly.
+    position: relative;
+    margin: hb-calculate-rems(-24px) hb-calculate-rems(20px) 0 hb-calculate-rems(-31px);
+    padding: hb-calculate-rems(20px) hb-calculate-rems(68px) hb-calculate-rems(20px) hb-calculate-rems(20px);
+
+    font-size: hb-calculate-rems(20px);
+    line-height: 118%;
+
+    @include grid-media-min('sm') {
+      font-size: hb-calculate-rems(24px);
+    }
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(27px);
+    }
+
+    &::after {
+      content: '';
+      display: block;
+      height: hb-calculate-rems(48px);
+      width: hb-calculate-rems(48px);
+      @include hb-icon-link-arrow($hb-color--white);
+
+      position: absolute;
+      right: 0;
+      bottom: hb-calculate-rems(10px);
+
+      transition: hb-transition(background-position);
+    }
+
+    .hb-vertical-linked-card:hover &::after,
+    .hb-vertical-linked-card:focus &::after {
+      background-position: 6px;
+    }
+
+    @include hb-colorful {
+      background-color: hb-colorful-variation(secondary);
+      transition: hb-transition(background-color);
+
+      .hb-vertical-linked-card:hover &,
+      .hb-vertical-linked-card:focus & {
+        background-color: darken(hb-colorful-variation(secondary), 15%);
+      }
+    }
+  }
+
+  &__link {
+    // We need the entire hb-vertical-linked-card to be a link but wrapping the entire
+    // element or wrapping individual elements in anchor tags is not very accessible.
+    // Instead we'll add a link at the bottom of the card (with an aria-label)
+    // and use the Pseudo Content Trick to make the entire card a link:
+    // https://inclusive-components.design/cards/#thepseudocontenttrick
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+    }
+
+    .fa-ext {
+      display: none;
+    }
+  }
+
+  &__description {
+    padding: hb-calculate-rems(20px) hb-calculate-rems(20px) 0;
+    font-size: hb-calculate-rems(16px);
+    line-height: 127%;
+
+    @include grid-media-min('sm') {
+      font-size: hb-calculate-rems(18px);
+    }
+
+    .field-hs-postcard-body {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
@@ -29,6 +29,11 @@ $hb-sidebar-width: 22.5%;
 
 $hb-border-radius: 4px;
 
+$hb-animation-duration: 150ms;
+$hb-animation-timing-function: ease-in-out;
+
+$hb-image-hover-scale: 1.07;
+
 // Menu Variables
 $hb-menu-light-border: 1px solid $su-color-driftwood;
 $hb-menu-link-background-hover: lighten($su-color-driftwood, 25%);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.animation.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.animation.scss
@@ -1,0 +1,3 @@
+@function hb-transition($property) {
+  @return $property $hb-animation-duration $hb-animation-timing-function;
+}

--- a/docroot/themes/humsci/su_humsci_theme/su_humsci_theme.theme
+++ b/docroot/themes/humsci/su_humsci_theme/su_humsci_theme.theme
@@ -235,27 +235,6 @@ function su_humsci_theme_preprocess_field(&$vars) {
 }
 
 /**
- * Implements hook_preprocess_HOOK().
- *
- * Alter the button on the vertical link card to provide only the url.
- */
-function su_humsci_theme_preprocess_pattern_vertical_link_card(&$vars) {
-  if (!isset($vars['button'])) {
-    return;
-  }
-
-  // Find the link in the button region and pull out the href so that we can
-  // wrap the entire contents of the pattern in a link.
-  $dom = new DOMDocument();
-  $dom->loadHTML(render($vars['button']));
-  if ($dom->getElementsByTagName('a')->length) {
-    $link = $dom->getElementsByTagName('a')->item(0)->getAttribute('href');
-    $vars['button'] = $link;
-    return;
-  }
-}
-
-/**
  * Implements hook_preprocess_menu().
  */
 function su_humsci_theme_preprocess_menu(&$vars) {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR adds the vertical link card and styles. The only required field in a vertical link card is the title so various combinations of title, image, and description test have been tested:

<img width="993" alt="Screen Shot 2020-03-13 at 5 11 56 PM" src="https://user-images.githubusercontent.com/2486846/76659862-e2317280-654d-11ea-9ec7-9c106bbfad1f.png">

Design: https://www.figma.com/file/toNZnFLadtpNpG5dPzNGWz/%E2%9A%99%EF%B8%8F-Colorful-Theme---Working?node-id=4321%3A146

Has been design reviewed by @meranicosme 

*Note: There are some responsive issues where things look extra squished at certain breakpoints. This is more of a grid problem and should be resolved in a design polish card*

_More Notes: We've made a config update at the platform level so that vertical linked cards will always return a url for the button variable. This update clashes with how the Stanford Humsci theme works and will cause vertical cards to break for older themes. To ensure that does not happen we have also removed the function in Stanford Humsci that was updating the button variable._

**Browser Tested In:**
- Chrome (Windows & Mac)
- Firefox (Windows & Mac)
- Safari
- Edge
- IE 11 (There is some breakage but it appears to be related to the grid, not the card)

## Need Review By (Date)
3/16

## Urgency
medium

## Steps to Test
1. Run `npm run build:sass` to build CSS assets
1. Run `npm test` to confirm there are no linting errors
1. Test using as a paragraph both in a row and outside of a row
1. Optionally this can be used as a view:
    - Duplicate the vertical card view
    - Set the Pattern to _Vertical Link Card_
    - Map the following fields:
        - Title -> Title
        - Image -> Image
        - Body -> Description
        - Link to Content -> Button
    - Edit the Title field to render in an `<h2>` 
    - Update the Link to Content field and check the `Output the URL as text` box
1. Test to make sure we are not breaking other themes:
    - Switch to the Stanford Humsci theme and ensure that vertical link cards do not break
    - Check that horizontal and vertical cards are unaffected by the change

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
