### PR TITLE
fix(STN-273): calc bug with IE11

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.layout.scss
@@ -23,13 +23,14 @@
 // Cols over 12 are not supported.
 @mixin hb-column($col-number: 2) {
   $percentage-width: 100% / $col-number;
-  $one-less-col: $col-number - 1;
-  $total-margin: calc(#{$one-less-col} * #{hb-calculate-rems($hb-gutter-width)});
 
   @if ($col-number > 1) {
+    $one-less-col: $col-number - 1;
+    $total-margin: $one-less-col * $hb-gutter-width;
+
     // 2 cols
     @include grid-media-min('sm') {
-      @include hb-column-width(50%, calc(1 * #{hb-calculate-rems($hb-gutter-width)}), 2); // for two elements, there is 1 gutter-width between
+      @include hb-column-width(50%, (hb-calculate-rems($hb-gutter-width)), 2); // for two elements, there is 1 gutter-width between
       margin-right: hb-calculate-rems(48px);
 
       &:nth-child(2n) {
@@ -41,7 +42,7 @@
       @if ($col-number != 4) {
         // 3 cols
         @include grid-media-min('md') {
-          @include hb-column-width(33.33%, calc(2 * #{hb-calculate-rems($hb-gutter-width)}), 3); // for 3 elements, 2 have gutter-width
+          @include hb-column-width(33.33%, #{hb-calculate-rems(2 * $hb-gutter-width)}, 3); // for 3 elements, 2 have gutter-width
 
           &:nth-child(2n) {
             margin-right: hb-calculate-rems(48px);
@@ -55,7 +56,7 @@
 
       // above 3 cols
       @include grid-media('lg') {
-        @include hb-column-width($percentage-width, $total-margin, $col-number);
+        @include hb-column-width($percentage-width, hb-calculate-rems($total-margin), $col-number);
 
         &:nth-child(2n) {
           margin-right: hb-calculate-rems(48px);


### PR DESCRIPTION
# READY FOR REVIEW

## Summary

Fixes an IE11 bug but also a more general issue with my use of `calc` on the grid.  You cannot mix certain operations in css with different units and you must be very careful about order of operations


## Steps to Test
1. See that the bug described here (using a view within a grid for 3-12 columns) no longer exists in ie11: https://sparkbox.atlassian.net/browse/STN-273
2. ensure that `npm run test` passes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
