### PR TITLE
STN-111: Node Detail Page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
     "drupal/environment_indicator": "^3.3",
     "drupal/extlink": "^1.0",
     "drupal/fast_404": "^1.0@alpha",
-    "drupal/field_formatter_class": "dev-1.x#9080241b6aa20de49bd3027627f8d67579343dd0",
+    "drupal/field_formatter_class": "dev-1.x#e7b3c4a959f63d7a9efc74f2d3a67de306b8ddb4",
     "drupal/field_group": "^3.0",
     "drupal/field_permissions": "^1.0@beta",
     "drupal/focal_point": "^1.0@beta",
@@ -335,7 +335,7 @@
         "https://www.drupal.org/project/domain_301_redirect/issues/3010370": "https://www.drupal.org/files/issues/2019-09-24/domain_301_redirect-roles-3010370-3.patch"
       },
       "drupal/field_formatter_class": {
-        "https://www.drupal.org/project/field_formatter_class/issues/3017781": "https://www.drupal.org/files/issues/2018-12-03/field_formatter_class-clear_token-3017781.patch"
+        "https://www.drupal.org/project/field_formatter_class/issues/3046372": "https://www.drupal.org/files/issues/2020-02-03/field_formatter_class-3046372-10.patch"
       },
       "drupal/audio_embed_field": {
         "https://www.drupal.org/project/audio_embed_field/issues/3022148": "https://www.drupal.org/files/issues/2018-12-21/audio_embed_field-method-compatable-3022148.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac20a6aa0034e8d57204da34a12c4a6e",
+    "content-hash": "54272466ad0682e591ada9a392f090d0",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4580,7 +4580,7 @@
                     "https://www.drupal.org/project/drupal/issues/2999491": "https://www.drupal.org/files/issues/2019-04-13/reusable-inline-blocks-2999491-9.patch",
                     "https://www.drupal.org/project/drupal/issues/3045171": "https://www.drupal.org/files/issues/2019-11-15/drupal-layout_builder_unable_to_save-3045171-103.patch",
                     "https://www.drupal.org/project/drupal/issues/2981837": "https://www.drupal.org/files/issues/2019-05-22/findMigrationDependencies-null-process-value-2981837-5.patch",
-                    "": "https://www.drupal.org/files/issues/2020-03-17/3118087-67.8_8_x.patch"
+                    "https://www.drupal.org/project/drupal/issues/3118087": "https://www.drupal.org/files/issues/2020-03-17/3118087-67.8_8_x.patch"
                 }
             },
             "autoload": {
@@ -12766,6 +12766,20 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "funding": [
+                {
+                    "url": "https://marcus.bointon.com/donations/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/marcusbointon",
+                    "type": "patreon"
+                }
+            ],
             "time": "2020-03-14T14:23:48+00:00"
         },
         {
@@ -18492,6 +18506,16 @@
                 "autoload",
                 "dependency",
                 "package"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-03-13T19:34:27+00:00"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -6119,7 +6119,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/field_formatter_class.git",
-                "reference": "9080241b6aa20de49bd3027627f8d67579343dd0"
+                "reference": "e7b3c4a959f63d7a9efc74f2d3a67de306b8ddb4"
             },
             "require": {
                 "drupal/core": "*"
@@ -6130,15 +6130,15 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0+5-dev",
-                    "datestamp": "1543857780",
+                    "version": "8.x-1.0+6-dev",
+                    "datestamp": "1544386681",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
                 },
                 "patches_applied": {
-                    "https://www.drupal.org/project/field_formatter_class/issues/3017781": "https://www.drupal.org/files/issues/2018-12-03/field_formatter_class-clear_token-3017781.patch"
+                    "https://www.drupal.org/project/field_formatter_class/issues/3046372": "https://www.drupal.org/files/issues/2020-02-03/field_formatter_class-3046372-10.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6166,9 +6166,9 @@
             "description": "Provides custom HTML class settings for field formatters.",
             "homepage": "https://www.drupal.org/project/field_formatter_class",
             "support": {
-                "source": "http://cgit.drupalcode.org/field_formatter_class"
+                "source": "https://git.drupalcode.org/project/field_formatter_class"
             },
-            "time": "2018-12-03T17:18:01+00:00"
+            "time": "2019-12-23T23:52:13+00:00"
         },
         {
             "name": "drupal/field_group",
@@ -22525,5 +22525,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/docroot/modules/humsci/hs_blocks/hs_blocks.module
+++ b/docroot/modules/humsci/hs_blocks/hs_blocks.module
@@ -5,8 +5,9 @@
  * Contains hs_blocks.module.
  */
 
-use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_help().
@@ -54,11 +55,23 @@ function hs_blocks_preprocess_block__block_content(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function hs_blocks_preprocess_block__group_block(&$variables) {
+  if (!empty($variables['elements']['#configuration']['class'])) {
+    $classes = explode(' ', $variables['elements']['#configuration']['class']);
+    foreach ($classes as $class) {
+      $variables['attributes']['class'][] = Html::cleanCssIdentifier($class);
+    }
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function hs_blocks_form_layout_builder_update_block_alter(&$form, FormStateInterface $form_state) {
   /** @var \Drupal\layout_builder\SectionStorageInterface $section_storage */
-  list($section_storage, $delta, , $uuid) = $form_state->getBuildInfo()['args'];
+  [$section_storage, $delta, , $uuid] = $form_state->getBuildInfo()['args'];
   $section = $section_storage->getSection($delta);
   $component = $section->getComponent($uuid);
   $component_id = $component->get('configuration')['id'];
@@ -77,7 +90,7 @@ function hs_blocks_form_layout_builder_update_block_alter(&$form, FormStateInter
  * Implements hook_form_FORM_ID_alter().
  */
 function hs_blocks_form_layout_builder_add_block_alter(&$form, FormStateInterface $form_state) {
-  list(, , , $field_id) = $form_state->getBuildInfo()['args'];
+  [, , , $field_id] = $form_state->getBuildInfo()['args'];
 
   // We only want to hide the label display checkbox for fields, not regular
   // blocks.

--- a/docroot/modules/humsci/hs_blocks/src/Plugin/Block/GroupBlock.php
+++ b/docroot/modules/humsci/hs_blocks/src/Plugin/Block/GroupBlock.php
@@ -111,7 +111,7 @@ class GroupBlock extends BlockBase implements ContainerFactoryPluginInterface, R
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return ['machine_name' => NULL, 'children' => []];
+    return ['machine_name' => NULL, 'children' => [], 'class' => NULL];
   }
 
   /**
@@ -277,12 +277,27 @@ class GroupBlock extends BlockBase implements ContainerFactoryPluginInterface, R
   /**
    * {@inheritdoc}
    */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['class'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Class'),
+      '#description' => $this->t('Add a class to the group'),
+      '#default_value' => $this->configuration['class'] ?? '',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
     // Set the machine name to a uuid value only if its a new block.
     if (!$form_state->getErrors() && empty($this->configuration['machine_name'])) {
       $this->setUniqueUuid();
     }
+    $this->configuration['class'] = $form_state->getValue('class');
   }
 
   /**

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -147,6 +147,7 @@
   'components/postcard',
   'components/more-link',
   'components/vertical-linked-card',
+  'components/block-layout',
 
   // =====================================================================
   // 8. Utilities
@@ -158,4 +159,5 @@
   'utilities/wysiwyg-editor',
   'utilities/admin.contextual-links',
   'utilities/local-tasks', // Drupal admin task list
-  'utilities/general';
+  'utilities/general',
+  'utilities/block-layout';

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -99,6 +99,7 @@
   'tools/mixins.buttons',
   'tools/mixins.menu-icons',
   'tools/mixins.icons',
+  'tools/mixins.lists',
 
   // =====================================================================
   // 3. Generic
@@ -160,4 +161,4 @@
   'utilities/admin.contextual-links',
   'utilities/local-tasks', // Drupal admin task list
   'utilities/general',
-  'utilities/block-layout';
+  'utilities/lists';

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -12,6 +12,10 @@
   }
 }
 
+.block__title {
+  
+}
+
 .field-label,
 .views-label {
   @include hb-field-label;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -1,0 +1,80 @@
+.block-layout-builder:not(:last-child) {
+  margin-bottom: hb-calculate-rems(20px);
+}
+
+.block-hs-blocks {
+  padding: hb-calculate-rems(20px) hb-calculate-rems(16px);
+  border-top: $hb-menu-light-border;
+  border-bottom: $hb-menu-light-border;
+
+  &:not(:last-child) {
+    margin-bottom: hb-calculate-rems(18px);
+  }
+}
+
+.field-label,
+.views-label {
+  @include hb-field-label;
+}
+
+.label-inline {
+  display: flex;
+
+  .field-label {
+    margin-right: hb-calculate-rems(6px);
+  }
+}
+
+.email {
+  [class^="fa-"] {
+    display: none;
+  }
+}
+
+.datetime {
+  color: darken($su-color-driftwood, 45%);
+}
+
+.address {
+  margin: 0;
+  font-style: italic;
+  color: darken($su-color-driftwood, 45%);
+}
+
+.given-name,
+.family-name {
+  font-weight: hb-theme-font-weight(semibold);
+  font-style: normal;
+}
+
+.string {
+  // Adds spacing between lines of text
+  div div {
+    margin-bottom: hb-calculate-rems(6px);
+  }
+}
+
+// Improve readability of the Drupal admin interface
+.layout-builder-form,
+.ui-dialog-off-canvas,
+.block-categories,
+.layout-builder-discard-changes {
+  font-size: hb-calculate-rems(16px);
+}
+
+// Hide the FontAwesome icon that is configured by default in
+// config/default/extlink.settings.yml
+// and replace with different icon
+.fa-ext {
+  // scss-lint:disable ImportantRule
+  margin-right: 0 !important; // removes link underline from icon
+  // scss-lint:enable ImportantRule
+
+  @include hb-colorful {
+    @include hb-external-link-icon;
+
+    .fa-arrow-right {
+      display: none;
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -3,9 +3,8 @@
 }
 
 .block-hs-blocks {
-  padding: hb-calculate-rems(20px) hb-calculate-rems(16px);
-  border-top: $hb-menu-light-border;
-  border-bottom: $hb-menu-light-border;
+  padding: hb-calculate-rems(20px) hb-calculate-rems(18px);
+  border: $hb-menu-light-border;
 
   &:not(:last-child) {
     margin-bottom: hb-calculate-rems(18px);
@@ -13,7 +12,10 @@
 }
 
 .block__title {
-  
+  @include hb-block-heading;
+  margin-top: 0;
+  margin-bottom: hb-calculate-rems(20px);
+  width: 100%;
 }
 
 .field-label,

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -11,55 +11,19 @@
   }
 
   &__category {
-    @include hb-subheading;
-    text-transform: uppercase;
-    margin: 0;
-
     ol,
     ul {
+      list-style-type: none;
       padding: 0;
       margin: 0;
     }
 
     li:not([class]) { // increase specificity so that these styles override the base list styles
-      color: $hb-color--black;
-      display: inline-block;
-      list-style: none;
-      margin-right: hb-calculate-rems(12px);
-      margin-bottom: hb-calculate-rems(3px);
-      padding-bottom: 0;
-      line-height: 133%;
-
-      @include hb-colorful {
-        &::before {
-          content: '';
-          display: inline-block;
-          height: hb-calculate-rems(12px);
-          width: hb-calculate-rems(3px);
-          margin-right: hb-calculate-rems(6px);
-          background-color: hb-colorful-variation(secondary);
-          border-radius: 0;
-          position: relative;
-          left: 0;
-          top: 0;
-        }
-      }
-
-      &:last-of-type {
-        margin-right: 0;
-      }
+      @include hb-category-item;
     }
 
     a {
-      color: $hb-color--black;
-      text-decoration: none;
-
-      &:hover,
-      &:focus {
-        color: $hb-color--black;
-        border-bottom: 1px solid $hb-color--black;
-        box-shadow: none;
-      }
+      @include hb-category-link;
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -122,13 +122,11 @@
     &:not(:last-child) {
       margin-bottom: hb-calculate-rems(20px);
     }
-  }
 
-  .views-label {
-    font-weight: hb-theme-font-weight(bold);
-
-    @include hb-colorful {
-      color: hb-colorful-variation(secondary);
+    .views-label {
+      @include hb-field-label--featured;
+      display: inline-block;
+      margin-right: hb-calculate-rems(6px);
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_structured-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_structured-card.scss
@@ -18,16 +18,6 @@
     }
   }
 
-  .hb-card__description {
-    .views-label {
-      display: inline-block;
-      font-size: hb-calculate-rems(15px);
-      color: $hb-color--black;
-      text-transform: uppercase;
-      margin-bottom: hb-calculate-rems(2px);
-    }
-  }
-
   .hb-card__category,
   .hb-card__columns {
     .views-field {
@@ -47,9 +37,7 @@
     }
 
     .views-label {
-      display: inline-block;
       margin-bottom: hb-calculate-rems(14px);
-      color: $hb-color--black;
     }
   }
 
@@ -58,19 +46,12 @@
     flex-wrap: wrap;
 
     .views-field {
+      margin-bottom: hb-calculate-rems(28px);
       padding-right: hb-calculate-rems(11px);
       width: 100%;
 
       @include grid-media-min('sm') {
         width: 50%;
-      }
-
-      .views-label {
-        display: inline-block;
-        font-size: hb-calculate-rems(15px);
-        color: $hb-color--black;
-        text-transform: uppercase;
-        margin-bottom: hb-calculate-rems(2px);
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_structured-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_structured-card.scss
@@ -8,14 +8,8 @@
   }
 
   .hb-card__subtitle {
-    font-weight: hb-theme-font-weight(semibold);
-    line-height: 122%;
+    @include hb-subtitle;
     margin-bottom: hb-calculate-rems(13px);
-    font-size: hb-calculate-rems(16px);
-
-    @include grid-media-min('lg') {
-      font-size: hb-calculate-rems(18px);
-    }
   }
 
   .hb-card__category,

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -9,6 +9,10 @@ body {
   @include hb-colorful {
     font-family: $hb-colorful-font--sans;
   }
+
+  @include grid-media-min('lg') {
+    @include hb-body--medium;
+  }
 }
 
 a:not([class]) {
@@ -84,10 +88,6 @@ p:not([class]) {
   &:last-of-type {
     margin-bottom: 0;
   }
-
-  @include grid-media-min('lg') {
-    @include hb-body--medium;
-  }
 }
 
 strong:not([class]) {
@@ -122,35 +122,4 @@ button:not([class]) {
   &:hover {
     cursor: pointer;
   }
-}
-
-// Hide the FontAwesome icon that is configured by default in
-// config/default/extlink.settings.yml
-// and replace with different icon
-.fa-ext {
-  // scss-lint:disable ImportantRule
-  margin-right: 0 !important; // removes link underline from icon
-  // scss-lint:enable ImportantRule
-
-  @include hb-colorful {
-    @include hb-external-link-icon;
-
-    .fa-arrow-right {
-      display: none;
-    }
-  }
-}
-
-// Update the base of all regions to use 1.6 rems.
-// This is necessary so that items which were inheriting a font-size of 1rem render at 16px and not 10px.
-.contextual-region {
-  font-size: hb-calculate-rems(16px);
-}
-
-// Improve readability of the Drupal admin interface
-.layout-builder-form,
-.ui-dialog-off-canvas,
-.block-categories,
-.layout-builder-discard-changes {
-  font-size: hb-calculate-rems(16px);
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -1,0 +1,38 @@
+@mixin hb-category-item {
+  @include hb-subheading;
+  text-transform: uppercase;
+
+  position: relative;
+  display: inline-block;
+  margin: 0 hb-calculate-rems(12px) hb-calculate-rems(3px);
+  padding: 0;
+
+  @include hb-colorful {
+    &::before {
+      content: '';
+      display: inline-block;
+      height: hb-calculate-rems(12px);
+      width: hb-calculate-rems(3px);
+      margin-right: hb-calculate-rems(6px);
+      background-color: hb-colorful-variation(secondary);
+      border-radius: 0;
+
+      position: absolute;
+      left: hb-calculate-rems(-12px);
+      top: hb-calculate-rems(4px);
+    }
+  }
+}
+
+@mixin hb-category-link {
+  color: $hb-color--black;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+
+  &:hover,
+  &:focus {
+    color: $hb-color--black;
+    border-color: $hb-color--black;
+    box-shadow: none;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -1,3 +1,11 @@
+@mixin hb-block-heading {
+  @include hb-colorful {
+    font-weight: hb-theme-font-weight(semibold);
+    font-size: hb-calculate-rems(27px);
+    line-height: 109%;
+  }
+}
+
 @mixin hb-heading-1 {
   @include hb-colorful {
     font-weight: hb-theme-font-weight(semibold);
@@ -26,9 +34,7 @@
 
 @mixin hb-heading-3 {
   @include hb-colorful {
-    font-weight: hb-theme-font-weight(semibold);
-    font-size: hb-calculate-rems(27px);
-    line-height: 109%;
+    @include hb-block-heading;
 
     @include grid-media-min('lg') {
       font-size: hb-calculate-rems(38px);
@@ -62,6 +68,17 @@
     font-weight: hb-theme-font-weight(semibold);
     font-size: hb-calculate-rems(16px);
     line-height: 117%;
+  }
+}
+
+@mixin hb-subtitle {
+  font-weight: hb-theme-font-weight(semibold);
+  line-height: 122%;
+
+  font-size: hb-calculate-rems(16px);
+
+  @include grid-media-min('lg') {
+    font-size: hb-calculate-rems(18px);
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -167,3 +167,23 @@
     margin-right: 10px;
   }
 }
+
+@mixin hb-field-label {
+  display: block;
+  font-weight: hb-theme-font-weight(bold);
+  font-size: hb-calculate-rems(15px);
+  font-style: normal;
+  color: $hb-color--black;
+  text-transform: uppercase;
+  margin-bottom: hb-calculate-rems(4px);
+}
+
+@mixin hb-field-label--featured {
+  font-size: hb-calculate-rems(16px);
+  font-style: normal;
+  text-transform: inherit;
+
+  @include hb-colorful {
+    color: hb-colorful-variation(secondary);
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_block-layout.scss
@@ -1,0 +1,4 @@
+.hb-highlighted-label,
+.hb-highlighted-label .field-label {
+  @include hb-field-label--featured;
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_block-layout.scss
@@ -1,4 +1,0 @@
-.hb-highlighted-label,
-.hb-highlighted-label .field-label {
-  @include hb-field-label--featured;
-}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
@@ -42,7 +42,10 @@
   @include hb-link--inline;
 }
 
-.hb-highlighted-label,
 .hb-highlighted-label .field-label {
   @include hb-field-label--featured;
+}
+
+.hb-subtitle {
+  @include hb-subtitle;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
@@ -42,3 +42,7 @@
   @include hb-link--inline;
 }
 
+.hb-highlighted-label,
+.hb-highlighted-label .field-label {
+  @include hb-field-label--featured;
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
@@ -1,3 +1,18 @@
 .hb-position-relative {
   position: relative;
 }
+
+.hb-columns {
+  display: flex;
+  flex-wrap: wrap;
+
+  > div {
+    width: 50%;
+    padding-right: hb-calculate-rems(11px);
+  }
+}
+
+.hb-well {
+  background-color: lighten($su-color-driftwood, 27%);
+  border: none;
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
@@ -1,0 +1,17 @@
+.hb-categories {
+  &.entity-reference {
+    div:not([class]) {
+      @include hb-category-item;
+    }
+  }
+
+  &.string {
+    div div {
+      @include hb-category-item;
+    }
+  }
+
+  a {
+    @include hb-category-link;
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds default styles for node detail pages as well as a handful of utility classes.

**Browser Tested in:**
- Chrome (Windows & Mac)
- Firefox (Windows & Mac)
- Safari
- Edge
- IE 11

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. We'll have to pair to apply a git patch with the config for a custom content type and custom field types. Otherwise you'll have to make it all from scratch.
2. Run `lando composer install` to install layout builder patch
3. Run `npm start` to build CSS
4. Run `npm test` to make sure we didn't break anything
5. Build a custom detail page using _all_ of the fields

We should have default styles for the following:
- [ ] Label above content
- [ ] Label inline with content
- [ ] Hidden Label
- [ ] Content groups (should be wrapped in a border)
- [ ] Proper spacing between all blocks
- [ ] Proper spacing between all content groups
- [ ] Can have content groups stacked with proper spacing
- [ ] Content group titles are styled

Test the following utility classes:
**Classes for Content Groups**
- [ ] `.hb-well` (adds a background color)
- [ ] `.hb-columns` (two column layout for fields)

**Classes for Blocks**
- [ ] `.hb-highlighted-label` (green lower case label text)
- [ ] `.hb-categories` (category styles for list elements and taxonomy)
- [ ] `.hb-subtitle` (bold subtitle text)

_Note: Utility classes will be documented in the H&S Pattern Documentation Doc._

![swshumsci suhumsci loc_collaborationfeatures_custom-content-detail-page](https://user-images.githubusercontent.com/2486846/77364760-4e209180-6d2b-11ea-9368-326f72485857.png)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
