### PR TITLE
feat(STN-170): adds Colorful pairing theme setting to humsci_colorful

### DIFF
--- a/docroot/themes/humsci/humsci_airy/config/install/humsci_airy.settings.yml
+++ b/docroot/themes/humsci/humsci_airy/config/install/humsci_airy.settings.yml
@@ -1,0 +1,4 @@
+brand_bar_variant_classname: default
+lockup:
+  option: default
+global_footer_variant_classname: default

--- a/docroot/themes/humsci/humsci_basic/config/install/humsci_basic.settings.yml
+++ b/docroot/themes/humsci/humsci_basic/config/install/humsci_basic.settings.yml
@@ -1,0 +1,4 @@
+brand_bar_variant_classname: default
+lockup:
+  option: default
+global_footer_variant_classname: default

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -44,15 +44,18 @@ function humsci_basic_preprocess_field(&$variables, $hook) {
 function humsci_basic_preprocess_page(&$vars) {
   // Variant setting for the brand bar.
   $bbv = theme_get_setting('brand_bar_variant_classname');
-  if ($bbv !== "none") {
+  if ($bbv) {
     $vars['brand_bar_variant_classname'] = 'su-brand-bar--' . $bbv;
   }
 
   // Variant setting for the global footer.
   $gfv = theme_get_setting('global_footer_variant_classname');
-  if ($gfv !== "none") {
+  if ($gfv) {
     $vars['global_footer_variant_classname'] = 'su-global-footer--' . $gfv;
   }
+
+  // Variant setting for the local footer to be used in children themes
+  $vars['local_footer_variant_classname'] = '';
 }
 
 /**

--- a/docroot/themes/humsci/humsci_colorful/config/install/humsci_colorful.settings.yml
+++ b/docroot/themes/humsci/humsci_colorful/config/install/humsci_colorful.settings.yml
@@ -1,0 +1,6 @@
+brand_bar_variant_classname: default
+lockup:
+  option: default
+global_footer_variant_classname: default
+local_footer_variant_classname: default
+theme_color_pairing: ocean

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.theme
@@ -2,10 +2,23 @@
 
 /**
  * @file
- * Functions to support theming in the HumSci Basic theme.
+ * Functions to support theming in the HumSci Colorful theme.
  */
 
 use Drupal\Component\Utility\Html;
+
+/**
+ * Prepares variables for the html.html.twig template.
+ */
+function humsci_colorful_preprocess_html(&$vars) {
+
+  // Theme color pairing setting to set the way the Colorful theme will appear.
+  $color_pairing = theme_get_setting('theme_color_pairing');
+  if ($color_pairing) {
+    // Set html_attributes for html DOM element
+    $vars['html_attributes']->addClass('hc-pairing-' . $color_pairing);
+  }
+}
 
 /**
  * Implements hook_preprocess_page().
@@ -13,7 +26,7 @@ use Drupal\Component\Utility\Html;
 function humsci_colorful_preprocess_page(&$vars) {
   // Variant setting for the local footer.
   $lfv = theme_get_setting('local_footer_variant_classname');
-  if ($lfv !== "none") {
+  if ($lfv) {
     $vars['local_footer_variant_classname'] = 'hb-local-footer--' . $lfv;
   }
 }

--- a/docroot/themes/humsci/humsci_colorful/theme-settings.php
+++ b/docroot/themes/humsci/humsci_colorful/theme-settings.php
@@ -16,13 +16,31 @@ $theme_name = \Drupal::theme()->getActiveTheme()->getName();
  * Form override for theme settings.
  */
 function humsci_colorful_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  // Colorful theme color pairing setting
+  // theme_color_pairing
+  $form['options_settings']['humsci_colorful_color_pairing'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Color Pairing'),
+  ];
+
+  $form['options_settings']['humsci_colorful_color_pairing']['theme_color_pairing'] = [
+    '#type' => 'select',
+    '#title' => t('Color Pairing'),
+    '#options' => [
+      'ocean' => t('Ocean'),
+      'mountain' => t('Mountain'),
+      'sand' => t('Sand'),
+    ],
+    '#default_value' => theme_get_setting('theme_color_pairing'),
+  ];
+
   // Local Footer
-  $form['options_settings']['humsci_basic_local_footer'] = [
+  $form['options_settings']['humsci_colorful_local_footer'] = [
     '#type' => 'fieldset',
     '#title' => t('Local Footer Settings'),
   ];
 
-  $form['options_settings']['humsci_basic_local_footer']['local_footer_variant_classname'] = [
+  $form['options_settings']['humsci_colorful_local_footer']['local_footer_variant_classname'] = [
     '#type' => 'select',
     '#title' => t('Local Footer Variant'),
     '#options' => [

--- a/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
+++ b/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
@@ -1,0 +1,4 @@
+brand_bar_variant_classname: default
+lockup:
+  option: default
+global_footer_variant_classname: default


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- adds Colorful pairing theme setting to humsci_colorful
- adds hard coded default configs to each theme for global theme
  settings

## Steps to Test
1. Ensure tests pass `npm run test`.
2. On a site such as the default site, uninstall the Humsci Colorful and Humsci Basic themes. Install Stanford Humsci Theme. Switch back and install the Humsci Basic theme (basically you need to do a fresh install). 
3. Go to your home page and check the classes that are being applied to the brandbar, lockup, and global footer. Ensure. a `--default` class is being applied to all. For the  local footer, ensure that no default class is applied.
4. Install the Humsci Colorful theme now.
5. Go to your home page and check the classes that are being applied to the brandbar, lockup, local footer, and global footer. Ensure. a `--default` class is being applied to all. 
6. Check that the class on the `html` element is `hc-pairing-ocean`.
6. Go into the theme settings for Humsci Colorful, and change the selected option for the color pairing for this theme. Check the classes on the `html` element again and make sure it switched.
7. Go into the theme settings for Humsci Basic and ensure that the color pairing setting does not exist there.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
