### PR TITLE
STN-293 : Color Pairing Architecture

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -72,6 +72,7 @@
   //    to write comments describing the colors and font stacks as a guide.
   //    If using features such as custom properties, those that are global
   //    custom properties should be described in this section.
+  'settings/variables.color-pairings',
   'settings/variables.theme.colors',
   'settings/variables.general',
   'settings/variables.fonts',
@@ -102,6 +103,7 @@
   'tools/mixins.icons',
   'tools/mixins.lists',
   'tools/mixins.tables',
+  'tools/mixins.color-pairings',
 
   // =====================================================================
   // 3. Generic

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -73,7 +73,7 @@
   //    If using features such as custom properties, those that are global
   //    custom properties should be described in this section.
   'settings/variables.theme.colors',
-  'settings/variables.color-pairings',
+  'settings/variables.colorful-pairings',
   'settings/variables.general',
   'settings/variables.fonts',
   'settings/variables.zindex',

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -72,8 +72,8 @@
   //    to write comments describing the colors and font stacks as a guide.
   //    If using features such as custom properties, those that are global
   //    custom properties should be described in this section.
-  'settings/variables.color-pairings',
   'settings/variables.theme.colors',
+  'settings/variables.color-pairings',
   'settings/variables.general',
   'settings/variables.fonts',
   'settings/variables.zindex',
@@ -92,6 +92,7 @@
   'tools/functions.general',
   'tools/functions.svg',
   'tools/functions.animation',
+  'tools/functions.color-pairings',
   'tools/mixins.general',
   'tools/mixins.themes',
   'tools/mixins.text',
@@ -168,4 +169,5 @@
   'utilities/admin.contextual-links',
   'utilities/local-tasks', // Drupal admin task list
   'utilities/general',
-  'utilities/lists';
+  'utilities/lists',
+  'utilities/color-pairings';

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -66,7 +66,7 @@
     @include hb-colorful {
       &::after {
         z-index: $hb-z-index-hero1-overlay;
-        @include hb-add-palette("background-color", "secondary");
+        @include hb-pairing-color("background-color", "secondary");
 
         @include grid-media-min('md') {
           grid-column-start: 1;
@@ -103,6 +103,7 @@
           bottom: 0;
           left: -8.75%;
           z-index: $hb-z-index-hero1-overlay;
+          // TODO: rewrite psuedo-background-box mixin to work with the color-pairing mixins
           @include psuedo-background-box(
             hb-colorful-variation(secondary),
             50%,
@@ -139,12 +140,13 @@
   }
 
   &__text {
-    background-color: darken($su-color-driftwood, 10%);
-    color: $hb-color--white;
+    // background-color: darken($su-color-driftwood, 10%);
+    @include hb-global-color("background-color", "gray");
+    @include hb-global-color("color", "white");
     display: block;
 
     @include hb-colorful {
-      @include hb-add-palette("background-color", "primary-hero-overlay");
+      @include hb-pairing-color("background-color", "primary-hero-overlay");
     }
 
     .hb-hero-overlay--1 & {
@@ -192,7 +194,7 @@
       li {
         &::before {
           @include hb-colorful {
-            background-color: lighten(hb-colorful-variation(secondary), 10%);
+            @include hb-pairing-color("background-color", "secondary");
           }
         }
       }
@@ -202,7 +204,10 @@
       li {
         &::before {
           @include hb-colorful {
-            color: lighten(hb-colorful-variation(secondary), 10%);
+            color: hb-colorful-variation(secondary); // #148762
+            color: lighten(hb-colorful-variation(secondary), 10%);  // original setting
+            // @include hb-pairing-color("color", "secondary");
+            @include hb-pairing-color-lighten("color", "secondary", var(--color-pairing), 10); // testing
           }
         }
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -66,8 +66,7 @@
     @include hb-colorful {
       &::after {
         z-index: $hb-z-index-hero1-overlay;
-        background-color: hb-colorful-variation(secondary);
-        @include add-theme("background-color", "secondary"); // WIP color-pairing
+        @include add-palette("background-color", "secondary");
 
         @include grid-media-min('md') {
           grid-column-start: 1;
@@ -145,8 +144,8 @@
     display: block;
 
     @include hb-colorful {
-      background-color: adjust-color(hb-colorful-variation(primary), $lightness: -9%, $alpha: -0.05);
-      @include add-theme("background-color", "primary"); // WIP color-pairing // update with correct primary variable reference
+      // background-color: adjust-color(hb-colorful-variation(primary), $lightness: -9%, $alpha: -0.05);
+      @include add-palette("background-color", "primary"); // TODO: update with correct primary variable. See how the background-color on line 147 passed through adjust-color.
     }
 
     .hb-hero-overlay--1 & {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -44,7 +44,7 @@
 
     // Offset background color psuedo element
     &::before {
-      @include hb-global-color("background-color", "gray-light");
+      @include hb-global-color('background-color', 'gray-light');
       position: absolute;
       height: 100%;
       width: 100%;
@@ -66,7 +66,7 @@
     @include hb-colorful {
       &::after {
         z-index: $hb-z-index-hero1-overlay;
-        @include hb-pairing-color("background-color", "secondary");
+        @include hb-pairing-color('background-color', 'secondary');
 
         @include grid-media-min('md') {
           grid-column-start: 1;
@@ -103,7 +103,7 @@
           bottom: 0;
           left: -8.75%;
           z-index: $hb-z-index-hero1-overlay;
-          // TODO: rewrite psuedo-background-box mixin to work with the color-pairing mixins
+          // TODO: MIXIN TO BE UPDATED!!!!!!!
           @include psuedo-background-box(
             hb-colorful-variation(secondary),
             50%,
@@ -140,13 +140,11 @@
   }
 
   &__text {
-    // background-color: darken($su-color-driftwood, 10%);
-    @include hb-global-color("background-color", "gray");
-    @include hb-global-color("color", "white");
     display: block;
 
     @include hb-colorful {
-      @include hb-pairing-color("background-color", "primary-hero-overlay");
+      @include hb-global-color('color', 'white');
+      @include hb-pairing-color('background-color', 'primary-hero-overlay');
     }
 
     .hb-hero-overlay--1 & {
@@ -177,6 +175,7 @@
           display: block;
           top: hb-calculate-rems(32px);
 
+          // TODO: MIXIN TO BE UPDATED!!!!!!!
           @include psuedo-background-box(
             lighten(hb-colorful-variation(primary), 30%),
             hb-calculate-rems(4px),
@@ -194,7 +193,7 @@
       li {
         &::before {
           @include hb-colorful {
-            @include hb-pairing-color("background-color", "secondary");
+            @include hb-pairing-color('background-color', 'secondary');
           }
         }
       }
@@ -204,8 +203,7 @@
       li {
         &::before {
           @include hb-colorful {
-            color: lighten(hb-colorful-variation(secondary), 10%);  // original setting
-            @include hb-pairing-color("color", "secondary-active");
+            @include hb-pairing-color('color', 'secondary-active');
           }
         }
       }
@@ -222,12 +220,12 @@
 
     a {
       @include hb-colorful {
-        color: lighten(hb-colorful-variation(primary), 30%);
+        @include hb-pairing-color('color', 'tertiary-reversed');
 
         &:hover,
         &:focus {
           box-shadow: none;
-          color: lighten(hb-colorful-variation(primary), 70%);
+          @include hb-pairing-color('color', 'tertiary-highlight');
         }
       }
     }
@@ -238,6 +236,7 @@
         max-width: 80%;
         @include hb-border-button;
         @include hb-colorful {
+          // TODO: MIXIN TO BE UPDATED!!!!!!!
           @include hb-border-button(
             lighten(hb-colorful-variation(primary), 30%),
             lighten(hb-colorful-variation(primary), 70%)

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -67,6 +67,7 @@
       &::after {
         z-index: $hb-z-index-hero1-overlay;
         background-color: hb-colorful-variation(secondary);
+        @include add-theme("background-color", "secondary"); // WIP color-pairing
 
         @include grid-media-min('md') {
           grid-column-start: 1;
@@ -145,6 +146,7 @@
 
     @include hb-colorful {
       background-color: adjust-color(hb-colorful-variation(primary), $lightness: -9%, $alpha: -0.05);
+      @include add-theme("background-color", "primary"); // WIP color-pairing // update with correct primary variable reference
     }
 
     .hb-hero-overlay--1 & {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -194,7 +194,7 @@
       li {
         &::before {
           @include hb-colorful {
-            @include hb-pairing-color("background-color", "secondary-active");
+            @include hb-pairing-color("background-color", "secondary");
           }
         }
       }
@@ -204,6 +204,7 @@
       li {
         &::before {
           @include hb-colorful {
+            color: lighten(hb-colorful-variation(secondary), 10%);  // original setting
             @include hb-pairing-color("color", "secondary-active");
           }
         }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -194,7 +194,7 @@
       li {
         &::before {
           @include hb-colorful {
-            @include hb-pairing-color("background-color", "secondary");
+            @include hb-pairing-color("background-color", "secondary-active");
           }
         }
       }
@@ -204,10 +204,7 @@
       li {
         &::before {
           @include hb-colorful {
-            color: hb-colorful-variation(secondary); // #148762
-            color: lighten(hb-colorful-variation(secondary), 10%);  // original setting
-            // @include hb-pairing-color("color", "secondary");
-            @include hb-pairing-color-lighten("color", "secondary", var(--color-pairing), 10); // testing
+            @include hb-pairing-color("color", "secondary-active");
           }
         }
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -44,7 +44,7 @@
 
     // Offset background color psuedo element
     &::before {
-      background-color: lighten($su-color-driftwood, 25%);
+      @include hb-global-color("background-color", "gray-light");
       position: absolute;
       height: 100%;
       width: 100%;
@@ -66,7 +66,7 @@
     @include hb-colorful {
       &::after {
         z-index: $hb-z-index-hero1-overlay;
-        @include add-palette("background-color", "secondary");
+        @include hb-add-palette("background-color", "secondary");
 
         @include grid-media-min('md') {
           grid-column-start: 1;
@@ -144,7 +144,7 @@
     display: block;
 
     @include hb-colorful {
-      @include add-palette("background-color", "primary-hero-overlay");
+      @include hb-add-palette("background-color", "primary-hero-overlay");
     }
 
     .hb-hero-overlay--1 & {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -144,8 +144,7 @@
     display: block;
 
     @include hb-colorful {
-      // background-color: adjust-color(hb-colorful-variation(primary), $lightness: -9%, $alpha: -0.05);
-      @include add-palette("background-color", "primary"); // TODO: update with correct primary variable. See how the background-color on line 147 passed through adjust-color.
+      @include add-palette("background-color", "primary-hero-overlay");
     }
 
     .hb-hero-overlay--1 & {

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -1,3 +1,11 @@
+:root {
+  // These variables will be used to style color pairings.
+  // They will be updated depending on the parent color pairing.
+  // We have to set the variables here and give them default values.
+  --palette--primary: #{get-color("primary", $hb-colorful-default)};
+  --palette--secondary: #{get-color("secondary", $hb-colorful-default)};
+}
+
 html {
   // Use Decanter's root font size
   font-size: $hb-root-font-size;

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -2,13 +2,15 @@
   // These variables will be used to style color pairings.
   // They will be updated depending on the parent color pairing.
   // We have to set the variables here and give them default values.
-  --palette--primary: #{get-color("primary", $hb-colorful-default)};
-  --palette--secondary: #{get-color("secondary", $hb-colorful-default)};
-  --palette--tertiary: #{get-color("tertiary", $hb-colorful-default)};
-  --palette--primary-hero-overlay: #{get-color("primary-hero-overlay", $hb-colorful-default)};
-  --palette--secondary-active: #{get-color("secondary-active", $hb-colorful-default)};
-  --palette--secondary-highlight: #{get-color("secondary-highlight", $hb-colorful-default)};
-  --palette--tertiary-reversed: #{get-color("tertiary-reversed", $hb-colorful-default)};
+  @include hb-colorful {
+    --palette--primary: #{hb-get-pairing-color("primary", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--secondary: #{hb-get-pairing-color("secondary", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--tertiary: #{hb-get-pairing-color("tertiary", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--primary-hero-overlay: #{hb-get-pairing-color("primary-hero-overlay", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $hb-colorful-default, $hc-colorful-pairings)};
+  }
 }
 
 html {

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -10,6 +10,7 @@
     --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $hb-colorful-default, $hc-colorful-pairings)};
+    --color-pairing: #{$hb-colorful-default};
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -4,6 +4,11 @@
   // We have to set the variables here and give them default values.
   --palette--primary: #{get-color("primary", $hb-colorful-default)};
   --palette--secondary: #{get-color("secondary", $hb-colorful-default)};
+  --palette--tertiary: #{get-color("tertiary", $hb-colorful-default)};
+  --palette--primary-hero-overlay: #{get-color("primary-hero-overlay", $hb-colorful-default)};
+  --palette--secondary-active: #{get-color("secondary-active", $hb-colorful-default)};
+  --palette--secondary-highlight: #{get-color("secondary-highlight", $hb-colorful-default)};
+  --palette--tertiary-reversed: #{get-color("tertiary-reversed", $hb-colorful-default)};
 }
 
 html {

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -3,14 +3,22 @@
   // They will be updated depending on the parent color pairing.
   // We have to set the variables here and give them default values.
   @include hb-colorful {
+    // BASE
     --palette--primary: #{hb-get-pairing-color("primary", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--secondary: #{hb-get-pairing-color("secondary", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--tertiary: #{hb-get-pairing-color("tertiary", $hb-colorful-default, $hc-colorful-pairings)};
+    // HERO
     --palette--primary-hero-overlay: #{hb-get-pairing-color("primary-hero-overlay", $hb-colorful-default, $hc-colorful-pairings)};
+    // SECONDARY VARIANTS
     --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--secondary-darken-12: #{hb-get-pairing-color("secondary-darken-12", $hb-colorful-default, $hc-colorful-pairings)};
+    // TERTIARY VARIANTS
+    --palette--tertiary-highlight: #{hb-get-pairing-color("tertiary-highlight", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--tertiary-highlight-darken-10: #{hb-get-pairing-color("tertiary-highlight-darken-10", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $hb-colorful-default, $hc-colorful-pairings)};
-    --color-pairing: #{$hb-colorful-default};
+    --palette--tertiary-reversed-darken-10: #{hb-get-pairing-color("tertiary-reversed-darken-10", $hb-colorful-default, $hc-colorful-pairings)};
+    --palette--tertiary-darken-20: #{hb-get-pairing-color("tertiary-darken-20", $hb-colorful-default, $hc-colorful-pairings)};
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/humsci_colorful.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/humsci_colorful.scss
@@ -1,4 +1,4 @@
 $hb-current-theme: 'colorful';
-$hb-colorful-variation: 'colorful-teal';
+// $hb-colorful-variation: 'colorful-teal'; // WIP move to settings.color-pairings as the default and rename to $hb-colorful-default
 
 @import 'main';

--- a/docroot/themes/humsci/humsci_basic/src/scss/humsci_colorful.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/humsci_colorful.scss
@@ -1,4 +1,3 @@
 $hb-current-theme: 'colorful';
-// $hb-colorful-variation: 'colorful-teal'; // WIP move to settings.color-pairings as the default and rename to $hb-colorful-default
 
 @import 'main';

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
@@ -1,7 +1,25 @@
-$default-theme: "teal"; // move to settings.color-pairings
-$hb-colorful-default: "colorful-teal";
+// Set the default color pairing value
+// The default color pairing also serves as the fallback color
+// pairing for browsers that do not support CSS custom properties
+$hb-colorful-default: "ocean";
 $hb-colorful-variation: 'colorful-teal'; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
 
-// Colorful Ocean Theme (primary: teal, secondary: mint, tertiary: sky)
-// Colorful Mountain Theme (primary: purple, secondary: sky, tertiary: mint)
-// Colorful Stanford Theme (primary: cardinal, secondary: gold, tertiary: driftwood)
+// TODO: UPDATE COLOR VALUES!!!!!!!!!!!!!
+// Each color pairing has a palette of color swatches
+$color-pairings: (
+  "ocean": (
+    "primary": $su-color-teal,
+    "secondary": $hb-color--mint,
+    "tertiary": $su-color-sky
+  ),
+  "mountain": (
+    "primary": $hb-color--mint,
+    "secondary": $su-color-purple,
+    "tertiary": darken($su-color-sky, 30%)
+  ),
+  "stanford": (
+    "primary": red,
+    "secondary": orange,
+    "tertiary": magenta
+  )
+);

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
@@ -2,24 +2,40 @@
 // The default color pairing also serves as the fallback color
 // pairing for browsers that do not support CSS custom properties
 $hb-colorful-default: "ocean";
-$hb-colorful-variation: 'colorful-teal'; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
+$hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
 
-// TODO: UPDATE COLOR VALUES!!!!!!!!!!!!!
+// TODO: UPDATE hex codes with color variables
+// TODO: UPDATE variables.themes.colors with new color swatches
+// TODO: Add file for global variable sass map
+// TODO: Finish updating pattern.hero.scss colors and background-colors to use add-palette mixin
+
 // Each color pairing has a palette of color swatches
 $color-pairings: (
   "ocean": (
-    "primary": $su-color-teal,
-    "secondary": $hb-color--mint,
-    "tertiary": $su-color-sky
+    "primary": $su-color-teal, // #00050C
+    "secondary": $hb-color--mint, // #148762
+    "tertiary": #007C8F,
+    "primary-hero-overlay": rgba(0, 36, 41, 0.97),
+    "secondary-active": #00CE9D,
+    "secondary-highlight": #E4F4EE,
+    "tertiary-reversed": #00D5F5
   ),
   "mountain": (
-    "primary": $hb-color--mint,
-    "secondary": $su-color-purple,
-    "tertiary": darken($su-color-sky, 30%)
+    "primary": #64305F,
+    "secondary": #00405B,
+    "tertiary": #148762,
+    "primary-hero-overlay": rgba(100, 48, 95, 0.97),
+    "secondary-active": #0098DB,
+    "secondary-highlight": #D5EFFE,
+    "tertiary-reversed": #74FBC7
   ),
   "stanford": (
-    "primary": red,
-    "secondary": orange,
-    "tertiary": magenta
+    "primary": #600E0E,
+    "secondary": #85703E,
+    "tertiary": #413E39,
+    "primary-hero-overlay": rgba(96, 14, 14, 0.97),
+    "secondary-active": #B3995D,
+    "secondary-highlight": #F4ECD7,
+    "tertiary-reversed": #D9D7D2
   )
 );

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
@@ -1,0 +1,7 @@
+$default-theme: "teal"; // move to settings.color-pairings
+$hb-colorful-default: "colorful-teal";
+$hb-colorful-variation: 'colorful-teal'; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
+
+// Colorful Ocean Theme (primary: teal, secondary: mint, tertiary: sky)
+// Colorful Mountain Theme (primary: purple, secondary: sky, tertiary: mint)
+// Colorful Stanford Theme (primary: cardinal, secondary: gold, tertiary: driftwood)

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.color-pairings.scss
@@ -6,8 +6,9 @@ $hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $
 
 // TODO: UPDATE hex codes with color variables
 // TODO: UPDATE variables.themes.colors with new color swatches
-// TODO: Add file for global variable sass map
+// TODO: Check to see if any of the global grays much the hb-gray function output
 // TODO: Finish updating pattern.hero.scss colors and background-colors to use add-palette mixin
+// TODO: write tests for add-palette mixin
 
 // Each color pairing has a palette of color swatches
 $color-pairings: (

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -50,7 +50,7 @@ $hc-colorful-pairings: (
   )
 );
 
-// Specific shades of gray that compliment all color pairing palettes
+// Specific shades of gray that compliment colorful pairing palettes
 $hc-colorful-globals: (
   "gray": $su-color-driftwood,
   "gray-dark": #413E39,

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -4,9 +4,6 @@
 $hb-colorful-default: "ocean";
 $hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
 
-// TODO: Finish updating pattern.hero.scss colors and background-colors to use hb-pairing-color mixin
-// TODO: write tests for hb-pairing-color mixin
-
 // Each color pairing has a palette of color swatches
 $hc-colorful-pairings: (
   "ocean": (

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -4,15 +4,14 @@
 $hb-colorful-default: "ocean";
 $hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
 
-// TODO: UPDATE hex codes with color variables that currently exisit
-// TODO: Finish updating pattern.hero.scss colors and background-colors to use hb-add-palette mixin
-// TODO: write tests for hb-add-palette mixin
+// TODO: Finish updating pattern.hero.scss colors and background-colors to use hb-pairing-color mixin
+// TODO: write tests for hb-pairing-color mixin
 
 // Each color pairing has a palette of color swatches
 $hc-colorful-pairings: (
   "ocean": (
     "primary": $su-color-teal,
-    "secondary": $hb-color--mint,
+    "secondary": #148762, // $hb-color--mint
     "tertiary": #007C8F,
     "primary-hero-overlay": rgba(0, 36, 41, 0.97),
     "secondary-active": #00CE9D,
@@ -28,7 +27,7 @@ $hc-colorful-pairings: (
     "secondary-highlight": #D5EFFE,
     "tertiary-reversed": #74FBC7
   ),
-  "stanford": (
+  "sand": (
     "primary": #600E0E,
     "secondary": #85703E,
     "tertiary": #413E39,
@@ -41,7 +40,7 @@ $hc-colorful-pairings: (
 
 // Specific shades of gray that compliment all color pairing palettes
 $hc-colorful-globals: (
-  "gray": #B6B1A9,
+  "gray": $su-color-driftwood,
   "gray-dark": #413E39,
   "gray-medium": #D9D7D2,
   "gray-light": #F1F0EE,

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -11,12 +11,17 @@ $hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $
 $hc-colorful-pairings: (
   "ocean": (
     "primary": $su-color-teal,
-    "secondary": #148762, // $hb-color--mint
+    "secondary": #148762,
     "tertiary": #007C8F,
     "primary-hero-overlay": rgba(0, 36, 41, 0.97),
     "secondary-active": #00CE9D,
     "secondary-highlight": #E4F4EE,
-    "tertiary-reversed": #00D5F5
+    "secondary-darken-12": darken(#148762, 12%),
+    "tertiary-highlight": #C2F7FF,
+    "tertiary-highlight-darken-10": darken(#C2F7FF, 10%),
+    "tertiary-reversed": #00D5F5,
+    "tertiary-reversed-darken-10": darken(#00D5F5, 10%),
+    "tertiary-darken-20": darken(#007C8F, 20%)
   ),
   "mountain": (
     "primary": #64305F,
@@ -25,7 +30,12 @@ $hc-colorful-pairings: (
     "primary-hero-overlay": rgba(100, 48, 95, 0.97),
     "secondary-active": #0098DB,
     "secondary-highlight": #D5EFFE,
-    "tertiary-reversed": #74FBC7
+    "secondary-darken-12": darken(#00405B, 12%),
+    "tertiary-highlight": #BEFDE5,
+    "tertiary-highlight-darken-10": darken(#BEFDE5, 10%),
+    "tertiary-reversed": #74FBC7,
+    "tertiary-reversed-darken-10": darken(#74FBC7, 10%),
+    "tertiary-darken-20": darken(#148762, 20%)
   ),
   "sand": (
     "primary": #600E0E,
@@ -34,7 +44,12 @@ $hc-colorful-pairings: (
     "primary-hero-overlay": rgba(96, 14, 14, 0.97),
     "secondary-active": #B3995D,
     "secondary-highlight": #F4ECD7,
-    "tertiary-reversed": #D9D7D2
+    "secondary-darken-12": darken(#85703E, 12%),
+    "tertiary-highlight": #F1F0EE,
+    "tertiary-highlight-darken-10": darken(#F1F0EE, 10%),
+    "tertiary-reversed": #D9D7D2,
+    "tertiary-reversed-darken-10": darken(#D0D7D2, 10%),
+    "tertiary-darken-20": darken(#413E39, 20%)
   )
 );
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -4,17 +4,15 @@
 $hb-colorful-default: "ocean";
 $hb-colorful-variation: "colorful-teal"; // WIP!!! We may or may not need both $hb-colorful-default AND $hb-colorful-variation
 
-// TODO: UPDATE hex codes with color variables
-// TODO: UPDATE variables.themes.colors with new color swatches
-// TODO: Check to see if any of the global grays much the hb-gray function output
-// TODO: Finish updating pattern.hero.scss colors and background-colors to use add-palette mixin
-// TODO: write tests for add-palette mixin
+// TODO: UPDATE hex codes with color variables that currently exisit
+// TODO: Finish updating pattern.hero.scss colors and background-colors to use hb-add-palette mixin
+// TODO: write tests for hb-add-palette mixin
 
 // Each color pairing has a palette of color swatches
-$color-pairings: (
+$hc-colorful-pairings: (
   "ocean": (
-    "primary": $su-color-teal, // #00050C
-    "secondary": $hb-color--mint, // #148762
+    "primary": $su-color-teal,
+    "secondary": $hb-color--mint,
     "tertiary": #007C8F,
     "primary-hero-overlay": rgba(0, 36, 41, 0.97),
     "secondary-active": #00CE9D,
@@ -39,4 +37,14 @@ $color-pairings: (
     "secondary-highlight": #F4ECD7,
     "tertiary-reversed": #D9D7D2
   )
+);
+
+// Specific shades of gray that compliment all color pairing palettes
+$hc-colorful-globals: (
+  "gray": #B6B1A9,
+  "gray-dark": #413E39,
+  "gray-medium": #D9D7D2,
+  "gray-light": #F1F0EE,
+  "white": #FFFFFF,
+  "black": #000000
 );

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
@@ -32,7 +32,7 @@ $hb-theme--colors: (
     color-sun: $su-color-sun,
     color-poppy: $su-color-poppy,
     color-purple: $su-color-purple,
-    color-sky: $su-color-sky
+    color-sky: $su-color-sky // update to match color pairings chart
   ),
   traditional: ()
 );
@@ -41,10 +41,10 @@ $hb-colorful--variations: (
   colorful-teal: (
     primary: $su-color-teal,
     secondary: $hb-color--mint,
-    tertiary: $su-color-sky
+    tertiary: $su-color-sky // TODO: make this value match the color pairing comparison chart color
   ),
   colorful-mint: (
-    primary: $hb-color--mint,
+    primary: $hb-color--mint, // TODO: make these values match the color pairing comparison chart colors
     secondary: $su-color-purple,
     tertiary: darken($su-color-sky, 30%)
   )

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
@@ -1,4 +1,5 @@
 // Grayscale
+// TODO: clean up / delete grayscale hb-gray functions and variables below
 @function hb-gray($level) {
   @return lighten(#000, $level * 1%);
 }
@@ -21,15 +22,6 @@ $hb-gray--10: hb-gray(10);
 $hb-color--black: hb-gray(0);
 $hb-color--white: hb-gray(100);
 
-// Global Grays
-// Specific shades of gray that compliment all color pairing palettes
-$hb-global-gray: #B6B1A9;
-$hb-global-gray-dark: #413E39;
-$hb-global-gray-medium: #D9D7D2;
-$hb-global-gray-light: #F1F0EE;
-$hb-global-white: hb-gray(0);
-$hb-global-black: hb-gray(100);
-
 $hb-color--mint: #148762; // darken $su-color-mint to pass color contrast
 
 // We can see if this ends up being useful with future themes
@@ -41,21 +33,19 @@ $hb-theme--colors: (
     color-sun: $su-color-sun,
     color-poppy: $su-color-poppy,
     color-purple: $su-color-purple,
-    // update to match color pairings chart
     color-sky: $su-color-sky
   ),
   traditional: ()
 );
 
+// TODO: revisit for clean up
 $hb-colorful--variations: (
   colorful-teal: (
     primary: $su-color-teal,
     secondary: $hb-color--mint,
-    // TODO: make this value match the color pairing comparison chart color
     tertiary: $su-color-sky
   ),
   colorful-mint: (
-    // TODO: make these values match the color pairing comparison chart colors
     primary: $hb-color--mint,
     secondary: $su-color-purple,
     tertiary: darken($su-color-sky, 30%)

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.theme.colors.scss
@@ -21,6 +21,15 @@ $hb-gray--10: hb-gray(10);
 $hb-color--black: hb-gray(0);
 $hb-color--white: hb-gray(100);
 
+// Global Grays
+// Specific shades of gray that compliment all color pairing palettes
+$hb-global-gray: #B6B1A9;
+$hb-global-gray-dark: #413E39;
+$hb-global-gray-medium: #D9D7D2;
+$hb-global-gray-light: #F1F0EE;
+$hb-global-white: hb-gray(0);
+$hb-global-black: hb-gray(100);
+
 $hb-color--mint: #148762; // darken $su-color-mint to pass color contrast
 
 // We can see if this ends up being useful with future themes
@@ -32,7 +41,8 @@ $hb-theme--colors: (
     color-sun: $su-color-sun,
     color-poppy: $su-color-poppy,
     color-purple: $su-color-purple,
-    color-sky: $su-color-sky // update to match color pairings chart
+    // update to match color pairings chart
+    color-sky: $su-color-sky
   ),
   traditional: ()
 );
@@ -41,10 +51,12 @@ $hb-colorful--variations: (
   colorful-teal: (
     primary: $su-color-teal,
     secondary: $hb-color--mint,
-    tertiary: $su-color-sky // TODO: make this value match the color pairing comparison chart color
+    // TODO: make this value match the color pairing comparison chart color
+    tertiary: $su-color-sky
   ),
   colorful-mint: (
-    primary: $hb-color--mint, // TODO: make these values match the color pairing comparison chart colors
+    // TODO: make these values match the color pairing comparison chart colors
+    primary: $hb-color--mint,
     secondary: $su-color-purple,
     tertiary: darken($su-color-sky, 30%)
   )

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
@@ -4,11 +4,28 @@
   // Set color-map to get the palette for a specific color pairing
   $color-map: map-get($theme-map, $palette);
 
-  // Retun a single color from the mapped palette
-  @return map-get($color-map, $key);
+  // Assign a single color from the mapped palette
+  $result: map-get($color-map, $key);
+
+  @if ($result) {
+    // Return value if it exists
+    @return $result;
+  } @else {
+    // Error if value doesn't exist
+    @error 'Couldn\'t find a value for this key: #{$key}';
+  }
 }
 
-// Map through all global grays
+// Map through all global colors
 @function hb-get-global-color($key, $globals-map) {
-  @return map-get($globals-map, $key);
+
+  $result: map-get($globals-map, $key);
+
+  @if ($result) {
+    // Return value if it exists
+    @return $result;
+  } @else {
+    // Error if value doesn't exist
+    @error 'Couldn\'t find a value for this key: #{$key}';
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
@@ -1,9 +1,14 @@
-// Map through all color pairings to find and set color palette
-@function get-color($key, $palette) {
+// Map through all color pairings to find and set a color palette
+@function hb-get-pairing-color($key, $palette, $theme-map) {
 
   // Set color-map to get the palette for a specific color pairing
-  $color-map: map-get($color-pairings, $palette);
+  $color-map: map-get($theme-map, $palette);
 
   // Retun a single color from the mapped palette
   @return map-get($color-map, $key);
+}
+
+// Map through all global grays
+@function hb-get-global-color($key, $globals-map) {
+  @return map-get($globals-map, $key);
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
@@ -1,5 +1,5 @@
 // Map through all color pairings to find and set color palette
-@function get-color($key, $palette) { // move to functions.color-pairings
+@function get-color($key, $palette) {
 
   // Set color-map to get the palette for a specific color pairing
   $color-map: map-get($color-pairings, $palette);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.color-pairings.scss
@@ -1,0 +1,9 @@
+// Map through all color pairings to find and set color palette
+@function get-color($key, $palette) { // move to functions.color-pairings
+
+  // Set color-map to get the palette for a specific color pairing
+  $color-map: map-get($color-pairings, $palette);
+
+  // Retun a single color from the mapped palette
+  @return map-get($color-map, $key);
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -1,12 +1,20 @@
-// The add-palette() mixin is used in place of the css property that needs
+// The hb-add-palette() mixin is used in place of the css property that needs
 // to have a color pairing:
 // .example {
-//   @include add-palette('background-color', 'primary');
+//   @include hb-add-palette('background-color', 'primary');
 // }
-@mixin add-palette($property, $color-swatch) {
-  // Fallback for browsers that do not support CSS variables
-  #{$property}: get-color($color-swatch, $hb-colorful-default);
+@mixin hb-add-palette($property, $color-swatch) {
+  @include hb-colorful {
+    // Fallback for browsers that do not support CSS variables
+    #{$property}: hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings);
 
-  // All modern browsers that support CSS variables
-  #{$property}: var(--palette--#{$color-swatch});
+    // All modern browsers that support CSS variables
+    #{$property}: var(--palette--#{$color-swatch});
+  }
+}
+
+@mixin hb-global-color($property, $color-swatch) {
+  @include hb-colorful {
+    #{$property}: hb-get-global-color($color-swatch, $hc-colorful-globals);
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -13,29 +13,6 @@
   }
 }
 
-// TESTING!!!!!
-@mixin hb-pairing-color-lighten($property, $color-swatch, $color-pairing, $percentage) {
-  @include hb-colorful {
-
-    // Fallback for browsers that do not support CSS variables - works!
-    #{$property}: lighten(hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings), $percentage);
-
-    // All modern browsers that support CSS variables
-    // #{$property}: var(--palette--#{$color-swatch}); // adding the lighten Sass function will not work with CSS custom properties
-
-    $hb-colorful-default: "mountain"; // testing - I need this value.
-    $hb-colorful-default: $color-pairing;
-
-    @if $color-pairing == sand {
-      $hb-colorful-default: "sand";
-    }
-
-    // @warn $hb-colorful-default;
-
-    #{$property}: lighten(hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings), $percentage);
-  }
-}
-
 @mixin hb-global-color($property, $color-swatch) {
   @include hb-colorful {
     #{$property}: hb-get-global-color($color-swatch, $hc-colorful-globals);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -1,0 +1,59 @@
+// $default-theme: "teal"; // move to settings.color-pairings
+
+// Color Pairing Groups // move to settings.color-pairings --> wrap in colorful theme
+$color-groups: (
+  "teal": (
+    "primary": $su-color-teal,
+    "secondary": $hb-color--mint,
+    "tertiary": $su-color-sky
+  ),
+  "mint": (
+    "primary": $hb-color--mint,
+    "secondary": $su-color-purple,
+    "tertiary": darken($su-color-sky, 30%)
+  )
+);
+
+// Map through all color groups to find and set theme
+@function get-color($key, $theme) { // move to functions.color-pairings
+  // Set color-map to get the color pairings for a specific theme
+  $color-map: map-get($color-groups, $theme);
+
+  // Retun a single color from the mapped color pairing
+  @return map-get($color-map, $key);
+}
+
+// GENERATE DEFAULT THEME VARIABLES // move to elements.base
+// ------------------------
+:root {
+  // This variable will be used to style all themed patterns.
+  // This variable will be updated depending on the parent theme.
+  // We have to set the variable here and give it a default value.
+  --theme--primary: #{get-color("primary", $default-theme)};
+  --theme--secondary: #{get-color("secondary", $default-theme)};
+}
+
+// GENERATE THEME CLASSES // move to utilities.color-pairings
+// ----------------------
+@each $theme, $pairings in $color-groups {
+  // These are the classes that update the CSS --theme variable.
+  // They should be applied to the parent element.
+  .t-#{$theme} {
+    --theme--primary: #{get-color("primary", $theme)};
+    --theme--secondary: #{get-color("secondary", $theme)};
+  }
+}
+
+// GENERATE FALLBACK CLASSES // move to mixins.color-pairings
+// -------------------------
+// The add-theme() mixin is used in place of the css property that needs to be themed:
+// .example {
+//   @include add-theme('color');
+// }
+@mixin add-theme($property, $color) {
+  // Fallback for browsers that do not support CSS variables
+  #{$property}: get-color($color, $default-theme);
+
+  // All modern browsers that support CSS variables
+  #{$property}: var(--theme--#{$color});
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -1,15 +1,38 @@
-// The hb-add-palette() mixin is used in place of the css property that needs
+// The hb-pairing-color() mixin is used in place of the css property that needs
 // to have a color pairing:
 // .example {
-//   @include hb-add-palette('background-color', 'primary');
+//   @include hb-pairing-color('background-color', 'primary');
 // }
-@mixin hb-add-palette($property, $color-swatch) {
+@mixin hb-pairing-color($property, $color-swatch) {
   @include hb-colorful {
     // Fallback for browsers that do not support CSS variables
     #{$property}: hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings);
 
     // All modern browsers that support CSS variables
     #{$property}: var(--palette--#{$color-swatch});
+  }
+}
+
+// TESTING!!!!!
+@mixin hb-pairing-color-lighten($property, $color-swatch, $color-pairing, $percentage) {
+  @include hb-colorful {
+
+    // Fallback for browsers that do not support CSS variables - works!
+    #{$property}: lighten(hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings), $percentage);
+
+    // All modern browsers that support CSS variables
+    // #{$property}: var(--palette--#{$color-swatch}); // adding the lighten Sass function will not work with CSS custom properties
+
+    $hb-colorful-default: "mountain"; // testing - I need this value.
+    $hb-colorful-default: $color-pairing;
+
+    @if $color-pairing == sand {
+      $hb-colorful-default: "sand";
+    }
+
+    // @warn $hb-colorful-default;
+
+    #{$property}: lighten(hb-get-pairing-color($color-swatch, $hb-colorful-default, $hc-colorful-pairings), $percentage);
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -1,59 +1,12 @@
-// $default-theme: "teal"; // move to settings.color-pairings
-
-// Color Pairing Groups // move to settings.color-pairings --> wrap in colorful theme
-$color-groups: (
-  "teal": (
-    "primary": $su-color-teal,
-    "secondary": $hb-color--mint,
-    "tertiary": $su-color-sky
-  ),
-  "mint": (
-    "primary": $hb-color--mint,
-    "secondary": $su-color-purple,
-    "tertiary": darken($su-color-sky, 30%)
-  )
-);
-
-// Map through all color groups to find and set theme
-@function get-color($key, $theme) { // move to functions.color-pairings
-  // Set color-map to get the color pairings for a specific theme
-  $color-map: map-get($color-groups, $theme);
-
-  // Retun a single color from the mapped color pairing
-  @return map-get($color-map, $key);
-}
-
-// GENERATE DEFAULT THEME VARIABLES // move to elements.base
-// ------------------------
-:root {
-  // This variable will be used to style all themed patterns.
-  // This variable will be updated depending on the parent theme.
-  // We have to set the variable here and give it a default value.
-  --theme--primary: #{get-color("primary", $default-theme)};
-  --theme--secondary: #{get-color("secondary", $default-theme)};
-}
-
-// GENERATE THEME CLASSES // move to utilities.color-pairings
-// ----------------------
-@each $theme, $pairings in $color-groups {
-  // These are the classes that update the CSS --theme variable.
-  // They should be applied to the parent element.
-  .t-#{$theme} {
-    --theme--primary: #{get-color("primary", $theme)};
-    --theme--secondary: #{get-color("secondary", $theme)};
-  }
-}
-
-// GENERATE FALLBACK CLASSES // move to mixins.color-pairings
-// -------------------------
-// The add-theme() mixin is used in place of the css property that needs to be themed:
+// The add-palette() mixin is used in place of the css property that needs
+// to have a color pairing:
 // .example {
-//   @include add-theme('color');
+//   @include add-palette('background-color', 'primary');
 // }
-@mixin add-theme($property, $color) {
+@mixin add-palette($property, $color-swatch) {
   // Fallback for browsers that do not support CSS variables
-  #{$property}: get-color($color, $default-theme);
+  #{$property}: get-color($color-swatch, $hb-colorful-default);
 
   // All modern browsers that support CSS variables
-  #{$property}: var(--theme--#{$color});
+  #{$property}: var(--palette--#{$color-swatch});
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -4,13 +4,21 @@
   // They should be applied to the parent element.
   // Note: If a hc-pairing- class is not applied, hc-pairing-ocean will apply as the default / fallback color pairing.
   .hc-pairing-#{$palette} {
+    // BASE
     --palette--primary: #{hb-get-pairing-color("primary", $palette, $hc-colorful-pairings)};
     --palette--secondary: #{hb-get-pairing-color("secondary", $palette, $hc-colorful-pairings)};
     --palette--tertiary: #{hb-get-pairing-color("tertiary", $palette, $hc-colorful-pairings)};
+    // HERO
     --palette--primary-hero-overlay: #{hb-get-pairing-color("primary-hero-overlay", $palette, $hc-colorful-pairings)};
+    // SECONDARY VARIANTS
     --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $palette, $hc-colorful-pairings)};
     --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $palette, $hc-colorful-pairings)};
+    --palette--secondary-darken-12: #{hb-get-pairing-color("secondary-darken-12", $palette, $hc-colorful-pairings)};
+    // TERTIARY VARIANTS
+    --palette--tertiary-highlight: #{hb-get-pairing-color("tertiary-highlight", $palette, $hc-colorful-pairings)};
+    --palette--tertiary-highlight-darken-10: #{hb-get-pairing-color("tertiary-highlight-darken-10", $palette, $hc-colorful-pairings)};
     --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $palette, $hc-colorful-pairings)};
-    --color-pairing: #{$palette};
+    --palette--tertiary-reversed-darken-10: #{hb-get-pairing-color("tertiary-reversed-darken-10", $palette, $hc-colorful-pairings)};
+    --palette--tertiary-darken-20: #{hb-get-pairing-color("tertiary-darken-20", $palette, $hc-colorful-pairings)};
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -2,7 +2,8 @@
 @each $palette, $color-swatches in $color-pairings {
   // These are the classes that update the CSS --palette variable.
   // They should be applied to the parent element.
-  .hb-colorful-#{$palette} {
+  // Note: There is not a .hc-pairing base class as all of the values in each coloring pairing are unique.
+  .hc-pairing-#{$palette} {
     --palette--primary: #{get-color("primary", $palette)};
     --palette--secondary: #{get-color("secondary", $palette)};
     --palette--tertiary: #{get-color("tertiary", $palette)};

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -1,15 +1,15 @@
 // Generate Color Palette Classes
-@each $palette, $color-swatches in $color-pairings {
+@each $palette, $color-swatches in $hc-colorful-pairings {
   // These are the classes that update the CSS --palette variable.
   // They should be applied to the parent element.
-  // Note: There is not a .hc-pairing base class as all of the values in each coloring pairing are unique.
+  // Note: If a hc-pairing- class is not applied, hc-pairing-ocean will apply as the default / fallback color pairing.
   .hc-pairing-#{$palette} {
-    --palette--primary: #{get-color("primary", $palette)};
-    --palette--secondary: #{get-color("secondary", $palette)};
-    --palette--tertiary: #{get-color("tertiary", $palette)};
-    --palette--primary-hero-overlay: #{get-color("primary-hero-overlay", $palette)};
-    --palette--secondary-active: #{get-color("secondary-active", $palette)};
-    --palette--secondary-highlight: #{get-color("secondary-highlight", $palette)};
-    --palette--tertiary-reversed: #{get-color("tertiary-reversed", $palette)};
+    --palette--primary: #{hb-get-pairing-color("primary", $palette, $hc-colorful-pairings)};
+    --palette--secondary: #{hb-get-pairing-color("secondary", $palette, $hc-colorful-pairings)};
+    --palette--tertiary: #{hb-get-pairing-color("tertiary", $palette, $hc-colorful-pairings)};
+    --palette--primary-hero-overlay: #{hb-get-pairing-color("primary-hero-overlay", $palette, $hc-colorful-pairings)};
+    --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $palette, $hc-colorful-pairings)};
+    --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $palette, $hc-colorful-pairings)};
+    --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $palette, $hc-colorful-pairings)};
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -11,5 +11,6 @@
     --palette--secondary-active: #{hb-get-pairing-color("secondary-active", $palette, $hc-colorful-pairings)};
     --palette--secondary-highlight: #{hb-get-pairing-color("secondary-highlight", $palette, $hc-colorful-pairings)};
     --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $palette, $hc-colorful-pairings)};
+    --color-pairing: #{$palette};
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -1,0 +1,9 @@
+// Generate Color Palette Classes
+@each $palette, $color-swatches in $color-pairings {
+  // These are the classes that update the CSS --palette variable.
+  // They should be applied to the parent element.
+  .hb-colorful-#{$palette} {
+    --palette--primary: #{get-color("primary", $palette)};
+    --palette--secondary: #{get-color("secondary", $palette)};
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -5,5 +5,10 @@
   .hb-colorful-#{$palette} {
     --palette--primary: #{get-color("primary", $palette)};
     --palette--secondary: #{get-color("secondary", $palette)};
+    --palette--tertiary: #{get-color("tertiary", $palette)};
+    --palette--primary-hero-overlay: #{get-color("primary-hero-overlay", $palette)};
+    --palette--secondary-active: #{get-color("secondary-active", $palette)};
+    --palette--secondary-highlight: #{get-color("secondary-highlight", $palette)};
+    --palette--tertiary-reversed: #{get-color("tertiary-reversed", $palette)};
   }
 }

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/sass-tests.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/sass-tests.scss
@@ -9,6 +9,8 @@ $hb-colorful-variation: 'colorful-teal';
 // Import all test partials here
 @include describe('Sass Unit Tests') {
   @import 'tools/mixins.themes';
+  @import 'tools/mixins.color-pairings';
+  @import 'tools/functions.color-pairings';
   @import 'tools/functions.colors';
   @import 'tools/functions.fonts';
 }

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
@@ -1,0 +1,71 @@
+@include describe('HB Color Pairing Function') {
+
+  // OCEAN
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Colorful Ocean palette.') {
+        $test: hb-get-pairing-color('primary', 'ocean', $hc-colorful-pairings);
+        $expect: #00505c;
+
+        @include assert-equal($test, $expect, 'The Ocean color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
+
+  // MOUNTAIN
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Colorful Mountain palette.') {
+        $test: hb-get-pairing-color('primary', 'mountain', $hc-colorful-pairings);
+        $expect: #64305F;
+
+        @include assert-equal($test, $expect, 'The Mountain color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
+
+  // SAND
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Colorful Sand palette.') {
+        $test: hb-get-pairing-color('primary', 'sand', $hc-colorful-pairings);
+        $expect: #600E0E;
+
+        @include assert-equal($test, $expect, 'The Sand color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
+
+  // PENDING TEST FOR INVALID KEY
+  // https://www.educative.io/blog/sass-tutorial-unit-testing-with-sass-true
+  @include describe('When given a invalid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Colorful ocean palette.') {
+        //   $test: hb-get-pairing-color(quarternary, ocean, $hc-colorful-pairings);
+        //   $expect: 'Couldn\'t find a value for this key: quarternary';
+
+        //   @include assert-equal($test, $expect, 'The Ocean color pairing quarternary color value should not match or nor exist.');
+      }
+    }
+  }
+}
+
+@include describe('HB Global Color Function') {
+
+  // GRAY
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-global-color() function') {
+      @include it('returns the Colorful Global Gray.') {
+        $test: hb-get-global-color('gray', $hc-colorful-globals);
+        $expect: #b6b1a9;
+
+        @include assert-equal($test, $expect, 'The global color value gray either does not match or does not exist.');
+      }
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
@@ -1,0 +1,39 @@
+// Describe what you're testing
+@include describe('Color Pairing mixin') {
+
+  // Default Colorful
+  // Other color pairings cannot be tested as the CSS variables
+  // for other pairing are only set via a class applied to
+  // the HTML tag.
+  @include describe('hb-pairing-color() mixin') {
+
+    @include it('returns the property and value for a color pairing') {
+      @include assert {
+        @include output {
+          @include hb-pairing-color('color', 'primary');
+        }
+        @include contains {
+          color: #00505c;
+        }
+      }
+    }
+  }
+}
+
+@include describe('Global colors mixin') {
+
+  // Global colors
+  @include describe('hb-global-color() mixin') {
+
+    @include it('returns the property and value for a global color') {
+      @include assert {
+        @include output {
+          @include hb-global-color('color', 'gray-dark');
+        }
+        @include contains {
+          color: #413E39;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# [STN-293](https://sparkbox.atlassian.net/browse/STN-293) READY FOR REVIEW

## Summary
Define the color pairings architecture and create a sample implementation using `src/scss/components/_pattern.hero.scss` in the colorful theme.

_NOTE:_ Color styles for the hero button and accent bar above the heading will be addressed in [STN-202](https://sparkbox.atlassian.net/browse/STN-202)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. In the CLI, run `npm run test` to confirm all tests pass.
2. Go to http://economics.suhumsci.loc
3. To test the color pairing architecture sample implementation, you will need to find a page with the hero implemented. If you have pulled data from the dev site, you can find the hero on the QA page. http://economics.suhumsci.loc/qa/qa-page
4. The page should display the `ocean` color pairing by default.
5. Go to `Appearance` > `Settings` > `HumSci Colorful` and change the `Color Pairing` setting to ` Mountain`. View the page and confirm the color blocks in the hero have updated to the `Mountain` color pairing.
6. Update the color pairing setting to `Sand`. View the page and confirm the color blocks in the hero have updated to the `Sand` color pairing.

### Expected results
#### Ocean (default)
<img width="1039" alt="default" src="https://user-images.githubusercontent.com/12678977/77800359-ffd20200-704c-11ea-8f04-cfe9fd8fced5.png">

#### Mountain
<img width="1047" alt="mountain" src="https://user-images.githubusercontent.com/12678977/77800412-23954800-704d-11ea-8bcc-402f544f2059.png">

#### Sand
<img width="1025" alt="sand" src="https://user-images.githubusercontent.com/12678977/77800465-3c9df900-704d-11ea-87e1-6f3e05706cbd.png">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
