### PR TITLE
feat(STN-194 ): hero pattern 2

### DIFF
--- a/docroot/themes/humsci/humsci_basic/patterns/hero-text-overlay/hero-text-overlay.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/hero-text-overlay/hero-text-overlay.html.twig
@@ -1,11 +1,4 @@
-{%
-  set classes = [
-    'hb-hero-overlay',
-    'hb-hero-overlay--1'
-  ]
- %}
-
-{%- set attributes = attributes.addClass(classes) -%}
+{%- set attributes = attributes.addClass('hb-hero-overlay') -%}
 
 {% if variant %}
   {% set variant_class = "hb-hero-overlay--color-#{variant}" %}

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -148,6 +148,7 @@
   'components/site-search',
   'components/local-footer',
   'components/pattern.hero',
+  'components/pattern.carousel',
   'components/postcard',
   'components/more-link',
   'components/vertical-linked-card',

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
@@ -1,5 +1,16 @@
-.hb-hero-overlay {
+.field-hs-hero-image {
+  // For the humsci_colorful theme carousel with just an image, get rid of colorful overlay
   .paragraph--type--hs-carousel & {
+    @include hb-colorful {
+      &::before {
+        display: none;
+      }
+    }
+  }
+}
+
+  .paragraph--type--hs-carousel {
+  .hb-hero-overlay {
     @include hb-colorful {
       @include clearfix;
       padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 8%;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
@@ -1,15 +1,9 @@
-.field-hs-hero-image {
-  // For the humsci_colorful theme carousel with just an image, get rid of colorful overlay
-  .paragraph--type--hs-carousel & {
-    @include hb-colorful {
-      &::before {
-        display: none;
-      }
-    }
-  }
-}
-
 .paragraph--type--hs-carousel {
+  // Get rid of the colorful overlay on carousels (for both image-only and text-content ones)
+  .field-hs-hero-image::before {
+    display: none;
+  }
+
   .hb-hero-overlay {
     @include hb-colorful {
       @include clearfix;
@@ -83,13 +77,6 @@
           opacity: 1;
 
           @include grid-media-min('md') {
-            display: none;
-          }
-        }
-
-        .field-hs-hero-image {
-          // Override for default hero styles
-          &::before {
             display: none;
           }
         }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
@@ -9,7 +9,7 @@
   }
 }
 
-  .paragraph--type--hs-carousel {
+.paragraph--type--hs-carousel {
   .hb-hero-overlay {
     @include hb-colorful {
       @include clearfix;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
@@ -45,11 +45,8 @@
         }
       }
     }
-  }
 
-  &__image-wrapper {
-    .paragraph--type--hs-carousel & {
-
+    &__image-wrapper {
       @include hb-colorful {
         position: relative;
 
@@ -101,10 +98,8 @@
         }
       }
     }
-  }
 
-  &__text {
-    .paragraph--type--hs-carousel & {
+    &__text {
       @include hb-colorful {
         // scss-lint:disable ImportantRule
         @include hb-pairing-color('background-color', 'primary-hero-overlay');

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.carousel.scss
@@ -1,0 +1,178 @@
+.hb-hero-overlay {
+  .paragraph--type--hs-carousel & {
+    @include hb-colorful {
+      @include clearfix;
+      padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 8%;
+
+      @include grid-media-min('md') {
+        padding: 0;
+        display: grid;
+        grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
+        grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
+      }
+
+      @include grid-media-min('xl') {
+        grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
+      }
+
+      // Offset background color psuedo element
+      &::before {
+        @include hb-global-color('background-color', 'gray-light');
+        z-index: $hb-z-index-hero1-background;
+
+        @include grid-media-min('md') {
+          position: unset;
+          padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 10%;
+          grid-column-start: 1;
+          grid-column-end: 5;
+          grid-row-start: 1;
+          grid-row-end: 6;
+        }
+      }
+
+      // Secondary color block psuedo element that shows up in the grid
+      &::after {
+        content: '';
+        display: block;
+        z-index: $hb-z-index-hero1-overlay;
+        @include hb-pairing-color('background-color', 'secondary');
+
+        @include grid-media-min('md') {
+          grid-column-start: 1;
+          grid-column-end: 2;
+          grid-row-start: 3;
+          grid-row-end: 4;
+        }
+      }
+    }
+  }
+
+  &__image-wrapper {
+    .paragraph--type--hs-carousel & {
+
+      @include hb-colorful {
+        position: relative;
+
+        @include grid-media-min('md') {
+          // This will make sure that the image fills the entire area
+          display: flex;
+          margin-top: 0;
+          grid-column-start: 3;
+          grid-column-end: 6;
+          grid-row-start: 2;
+          grid-row-end: 5;
+          padding-top: 0;
+        }
+
+        // On mobile, make the secondary color box out of psuedo element,
+        // then on 'md' breakpoint, it becomes part of the grid
+        &::before {
+          display: block;
+          bottom: 0;
+          left: -8.75%;
+          top: initial;
+          @include psuedo-background-box('secondary', 50%, 8.75%);
+          opacity: 1;
+
+          @include grid-media-min('md') {
+            display: none;
+          }
+        }
+
+        .field-hs-hero-image {
+          // Override for default hero styles
+          &::before {
+            display: none;
+          }
+        }
+
+        img {
+          object-fit: initial;
+          min-height: auto;
+
+          @include grid-media-min('sm') {
+            min-height: auto;
+          }
+
+          @include grid-media-min('md') {
+            min-height: 55vh;
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
+
+  &__text {
+    .paragraph--type--hs-carousel & {
+      @include hb-colorful {
+        // scss-lint:disable ImportantRule
+        @include hb-pairing-color('background-color', 'primary-hero-overlay');
+        padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
+        position: relative;
+        width: auto !important;
+        margin: 0 0 !important;
+        transform: none;
+        top: 0;
+        left: 0;
+
+        @include grid-media-min('md') {
+          grid-column-start: 2;
+          grid-column-end: 4;
+          grid-row-start: 4;
+          grid-row-end: 7;
+          padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
+          width: auto !important;
+        }
+
+        @include grid-media-min('lg') {
+          width: auto !important;
+        }
+        // scss-lint:enable ImportantRule
+
+        // Line decoration pseudo element
+        &::after {
+          display: block;
+          top: hb-calculate-rems(32px);
+          @include psuedo-background-box('tertiary-reversed', hb-calculate-rems(4px), hb-calculate-rems(65px));
+
+          @include grid-media-min('md') {
+            top: hb-calculate-rems(56px);
+          }
+        }
+
+        h2 {
+          @include hb-heading-4;
+          margin: hb-calculate-rems(24px) 0;
+
+          @include grid-media-min('md') {
+            @include hb-heading-4;
+            margin: hb-calculate-rems(24px) 0;
+          }
+
+          @include grid-media-min('lg') {
+            @include hb-heading-3;
+            margin: hb-calculate-rems(28px) 0;
+          }
+        }
+
+        h2,
+        .field-hs-hero-body {
+          width: auto;
+
+          @include grid-media-min('sm') {
+            width: auto;
+          }
+
+          @include grid-media-min('md') {
+            width: auto;
+          }
+
+          @include grid-media-min('lg') {
+            width: auto;
+          }
+        }
+      }
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -1,7 +1,7 @@
 // Note: this scss is the base of the hero, AND the carousel patterns
 // If you change something here, you will likely need to change it and override it in the carousel.scss
 .field-hs-hero-image {
-  // For the humsci_colorful theme, ensure there is a background color added to the image alone
+  // For the humsci_colorful theme hero, ensure there is a background color added to the image alone
   @include hb-colorful {
     position: relative;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -1,4 +1,4 @@
-// If only the image is present (no overlay text) or hero wrapper,
+// For all themes, if only the hero image is present (no overlay text) or hero wrapper,
 // make sure vertical margin is present
 .field-hs-hero-image {
   .hs-full-width & {
@@ -13,57 +13,60 @@
 }
 
 .hb-hero-overlay {
-  &--1 {
-    @include clearfix;
-    margin: 0 0 $hb-gutter-width;
-    padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 8%;
+  .hs-full-width & {
+    // Special negative margin for the hero
+    // to get rid of the vertical padding on all basic pages
+    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+  }
+
+  @include hb-colorful {
     position: relative;
+    margin: 0 0 $hb-gutter-width;
+  }
 
-    @include grid-media-min('md') {
-      padding: 0;
-      display: grid;
-      grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
-      grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
-    }
-
-    @include grid-media-min('xl') {
-      grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
-    }
-
-    .hs-full-width & {
-      // Special negative margin for the hero
-      // to get rid of the vertical padding on all basic pages
-      margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
-    }
-
-    &::before,
-    &::after {
-      content: '';
-      display: block;
-    }
-
-    // Offset background color psuedo element
-    &::before {
-      @include hb-global-color('background-color', 'gray-light');
-      position: absolute;
-      height: 100%;
-      width: 100%;
-      top: 0;
-      left: 0;
-      z-index: $hb-z-index-hero1-background;
+  .paragraph--type--hs-carousel & {
+    @include hb-colorful {
+      @include clearfix;
+      padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 8%;
 
       @include grid-media-min('md') {
-        position: unset;
-        padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 10%;
-        grid-column-start: 1;
-        grid-column-end: 5;
-        grid-row-start: 1;
-        grid-row-end: 6;
+        padding: 0;
+        display: grid;
+        grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
+        grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
       }
-    }
 
-    // Secondary color block psuedo element that shows up in the grid
-    @include hb-colorful {
+      @include grid-media-min('xl') {
+        grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
+      }
+
+      &::before,
+      &::after {
+        content: '';
+        display: block;
+      }
+
+      // Offset background color psuedo element
+      &::before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        @include hb-global-color('background-color', 'gray-light');
+        z-index: $hb-z-index-hero1-background;
+
+        @include grid-media-min('md') {
+          position: unset;
+          padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 10%;
+          grid-column-start: 1;
+          grid-column-end: 5;
+          grid-row-start: 1;
+          grid-row-end: 6;
+        }
+      }
+
+      // Secondary color block psuedo element that shows up in the grid
       &::after {
         z-index: $hb-z-index-hero1-overlay;
         @include hb-pairing-color('background-color', 'secondary');
@@ -78,13 +81,15 @@
     }
   }
 
-  &__image-wrapper,
-  &__text {
-    z-index: $hb-z-index-hero1-overlay;
+  @include hb-colorful {
+    &__image-wrapper,
+    &__text {
+      z-index: $hb-z-index-hero1-overlay;
+    }
   }
 
   &__image-wrapper {
-    // If inside an img wrapper,
+    // For all themes, if inside an img wrapper,
     // no margin should be added
     .field-hs-hero-image {
       .hs-full-width & {
@@ -92,80 +97,211 @@
       }
     }
 
-    .hb-hero-overlay--1 & {
+    @include hb-colorful {
       position: relative;
 
-      @include hb-colorful {
+      &::before {
+        @include hb-pairing-color('background-color', 'primary-hero-overlay');
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0.9;
+        z-index: $hb-z-index-hero1-overlay;
+      }
+
+      img {
+        height: 100%;
+        width: 100%;
+        min-height: 60vh;
+        object-fit: cover;
+
+        @include grid-media-min('sm') {
+          min-height: 55vh;
+        }
+      }
+
+      .paragraph--type--hs-carousel & {
         // On mobile, make the secondary color box out of psuedo element,
         // then on 'md' breakpoint, it becomes part of the grid
         &::before {
           display: block;
           bottom: 0;
           left: -8.75%;
-          z-index: $hb-z-index-hero1-overlay;
+          top: initial;
           @include psuedo-background-box('secondary', 50%, 8.75%);
+          opacity: 1;
 
           @include grid-media-min('md') {
             display: none;
           }
         }
-      }
-
-      @include grid-media-min('md') {
-        // This will make sure that the image fills the entire area
-        display: flex;
-        margin-top: 0;
-        grid-column-start: 3;
-        grid-column-end: 6;
-        grid-row-start: 2;
-        grid-row-end: 5;
-        padding-top: 0;
-      }
-
-      img {
-        height: 100%;
-        width: 100%;
 
         @include grid-media-min('md') {
-          min-height: 55vh;
-          object-fit: cover;
+          // This will make sure that the image fills the entire area
+          display: flex;
+          margin-top: 0;
+          grid-column-start: 3;
+          grid-column-end: 6;
+          grid-row-start: 2;
+          grid-row-end: 5;
+          padding-top: 0;
+        }
+
+        img {
+          object-fit: initial;
+          min-height: auto;
+
+          @include grid-media-min('sm') {
+            min-height: auto;
+          }
+
+          @include grid-media-min('md') {
+            min-height: 55vh;
+            object-fit: cover;
+          }
         }
       }
     }
   }
 
   &__text {
-    display: block;
-
     @include hb-colorful {
+      display: block;
       @include hb-global-color('color', 'white');
-      @include hb-pairing-color('background-color', 'primary-hero-overlay');
-    }
-
-    .hb-hero-overlay--1 & {
-      padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
-      position: relative;
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      left: 50%;
+      width: 90%;
 
       @include grid-media-min('md') {
-        transform: none;
-        grid-column-start: 2;
-        grid-column-end: 4;
-        grid-row-start: 4;
-        grid-row-end: 7;
-        padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
+        transform: translate(0%, -50%);
+        width: 80%;
+        left: 8%;
+      }
+
+      @include grid-media-min('lg') {
+        width: 60%;
+        left: 12%;
       }
 
       h2 {
-        @include hb-heading-4;
-        margin-top: hb-calculate-rems(24px);
+        font-weight: hb-theme-font-weight(semibold);
+        font-size: hb-calculate-rems(27px);
+        line-height: 117%;
+        margin: 0 0 hb-calculate-rems($hb-gutter-width--small);
+
+        @include grid-media-min('md') {
+          @include hb-heading-2;
+          margin: 0 0 hb-calculate-rems($hb-gutter-width);
+        }
 
         @include grid-media-min('lg') {
-          @include hb-heading-3;
-          margin-top: hb-calculate-rems(28px);
+          @include hb-heading-1;
         }
       }
 
+      ul {
+        li {
+          &::before {
+            @include hb-pairing-color('background-color', 'secondary');
+          }
+        }
+      }
+
+      ol {
+        li {
+          &::before {
+            @include hb-pairing-color('color', 'secondary-active');
+          }
+        }
+      }
+
+      .field-hs-hero-body {
+        width: 90%;
+
+        @include grid-media-min('sm') {
+          width: 70%;
+        }
+
+        @include grid-media-min('xl') {
+          width: 60%;
+        }
+      }
+
+      .field-hs-hero-body,
+      a {
+        font-size: hb-calculate-rems(16px);
+
+        @include grid-media-min('lg') {
+          font-size: hb-calculate-rems(18px);
+        }
+      }
+
+      a {
+        @include hb-pairing-color('color', 'tertiary-reversed');
+
+        &:hover,
+        &:focus {
+          box-shadow: none;
+          @include hb-pairing-color('color', 'tertiary-highlight');
+        }
+      }
+
+      .field-hs-hero-link {
+        a,
+        button {
+          max-width: 80%;
+          margin-top: hb-calculate-rems($hb-gutter-width--small);
+          @include hb-border-button('tertiary-reversed', 'secondary-highlight');
+
+          @include grid-media-min('md') {
+            margin-top: hb-calculate-rems($hb-gutter-width);
+          }
+
+          @include grid-media-min('lg') {
+            max-width: 75%;
+          }
+
+          .fa-ext {
+            display: none;
+          }
+        }
+      }
+    }
+
+    .paragraph--type--hs-carousel & {
       @include hb-colorful {
+        @include hb-pairing-color('background-color', 'primary-hero-overlay');
+        padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
+        position: relative;
+        width: auto;
+        transform: none;
+        top: initial;
+        left: initial;
+
+        @include grid-media-min('md') {
+          top: initial;
+          left: initial;
+          transform: none;
+          grid-column-start: 2;
+          grid-column-end: 4;
+          grid-row-start: 4;
+          grid-row-end: 7;
+          padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
+          width: auto;
+        }
+
+        @include grid-media-min('lg') {
+          top: initial;
+          left: initial;
+          transform: none;
+          width: auto;
+        }
+
         // Line decoration pseudo element
         &::after {
           display: block;
@@ -176,65 +312,32 @@
             top: hb-calculate-rems(56px);
           }
         }
-      }
-    }
 
-    ul {
-      li {
-        &::before {
-          @include hb-colorful {
-            @include hb-pairing-color('background-color', 'secondary');
+        h2 {
+          @include hb-heading-4;
+          margin: hb-calculate-rems(24px) 0;
+
+          @include grid-media-min('md') {
+            @include hb-heading-4;
+            margin: hb-calculate-rems(24px) 0;
+          }
+
+          @include grid-media-min('lg') {
+            @include hb-heading-3;
+            margin: hb-calculate-rems(28px) 0;
           }
         }
-      }
-    }
 
-    ol {
-      li {
-        &::before {
-          @include hb-colorful {
-            @include hb-pairing-color('color', 'secondary-active');
+        .field-hs-hero-body {
+          width: auto;
+
+          @include grid-media-min('sm') {
+            width: auto;
           }
-        }
-      }
-    }
 
-    .text-long,
-    a {
-      font-size: hb-calculate-rems(16px);
-
-      @include grid-media-min('lg') {
-        font-size: hb-calculate-rems(18px);
-      }
-    }
-
-    a {
-      @include hb-colorful {
-        @include hb-pairing-color('color', 'tertiary-reversed');
-
-        &:hover,
-        &:focus {
-          box-shadow: none;
-          @include hb-pairing-color('color', 'tertiary-highlight');
-        }
-      }
-    }
-
-    .field-hs-hero-link {
-      a,
-      button {
-        max-width: 80%;
-
-        @include hb-colorful {
-          @include hb-border-button('tertiary-reversed', 'secondary-highlight');
-        }
-
-        @include grid-media-min('lg') {
-          max-width: 75%;
-        }
-
-        .fa-ext {
-          display: none;
+          @include grid-media-min('xl') {
+            width: auto;
+          }
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -22,6 +22,23 @@
   @include hb-colorful {
     position: relative;
     margin: 0 0 $hb-gutter-width;
+
+    min-height: 60vh;
+
+    @include grid-media-min('sm') {
+      min-height: 55vh;
+    }
+
+    &::before {
+      @include hb-pairing-color('background-color', 'primary-hero-overlay');
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: $hb-z-index-hero1-overlay;
+    }
   }
 
   .paragraph--type--hs-carousel & {
@@ -40,19 +57,8 @@
         grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
       }
 
-      &::before,
-      &::after {
-        content: '';
-        display: block;
-      }
-
       // Offset background color psuedo element
       &::before {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
         @include hb-global-color('background-color', 'gray-light');
         z-index: $hb-z-index-hero1-background;
 
@@ -68,6 +74,8 @@
 
       // Secondary color block psuedo element that shows up in the grid
       &::after {
+        content: '';
+        display: block;
         z-index: $hb-z-index-hero1-overlay;
         @include hb-pairing-color('background-color', 'secondary');
 
@@ -175,18 +183,7 @@
       top: 50%;
       transform: translate(-50%, -50%);
       left: 50%;
-      width: 90%;
-
-      @include grid-media-min('md') {
-        transform: translate(0%, -50%);
-        width: 80%;
-        left: 8%;
-      }
-
-      @include grid-media-min('lg') {
-        width: 60%;
-        left: 12%;
-      }
+      @include hb-page-width;
 
       h2 {
         font-weight: hb-theme-font-weight(semibold);
@@ -220,15 +217,20 @@
         }
       }
 
+      h2,
       .field-hs-hero-body {
         width: 90%;
 
         @include grid-media-min('sm') {
+          width: 80%;
+        }
+
+        @include grid-media-min('md') {
           width: 70%;
         }
 
-        @include grid-media-min('xl') {
-          width: 60%;
+        @include grid-media-min('lg') {
+          width: 50%;
         }
       }
 
@@ -278,28 +280,22 @@
         @include hb-pairing-color('background-color', 'primary-hero-overlay');
         padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
         position: relative;
-        width: auto;
+        width: auto !important;
         transform: none;
         top: initial;
         left: initial;
 
         @include grid-media-min('md') {
-          top: initial;
-          left: initial;
-          transform: none;
           grid-column-start: 2;
           grid-column-end: 4;
           grid-row-start: 4;
           grid-row-end: 7;
           padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
-          width: auto;
+          width: auto !important;
         }
 
         @include grid-media-min('lg') {
-          top: initial;
-          left: initial;
-          transform: none;
-          width: auto;
+          width: auto !important;
         }
 
         // Line decoration pseudo element
@@ -328,6 +324,7 @@
           }
         }
 
+        h2,
         .field-hs-hero-body {
           width: auto;
 
@@ -335,7 +332,11 @@
             width: auto;
           }
 
-          @include grid-media-min('xl') {
+          @include grid-media-min('md') {
+            width: auto;
+          }
+
+          @include grid-media-min('lg') {
             width: auto;
           }
         }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -1,10 +1,29 @@
-// For all themes, if only the hero image is present (no overlay text) or hero wrapper,
-// make sure vertical margin is present
+// Note: this scss is the base of the hero, AND the carousel patterns
+// If you change something here, you will likely need to change it and override it in the carousel.scss
 .field-hs-hero-image {
+  // For the humsci_colorful theme, ensure there is a background color added to the image alone
+  @include hb-colorful {
+    position: relative;
+
+    &::before {
+      @include hb-pairing-color('background-color', 'primary-hero-overlay');
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0.9;
+      z-index: $hb-z-index-hero1-overlay;
+    }
+  }
+
+  // For all themes, if only the hero image is present (no overlay text) or hero wrapper,
+  // make sure vertical margin is present on full width layout
   .hs-full-width & {
     // Special negative margin for the hero
     // to get rid of the vertical padding on all basic pages
-    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 hb-calculate-rems($hb-gutter-width);
 
     img {
       width: 100%;
@@ -13,16 +32,16 @@
 }
 
 .hb-hero-overlay {
+  margin: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width);
+
   .hs-full-width & {
     // Special negative margin for the hero
     // to get rid of the vertical padding on all basic pages
-    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 $hb-gutter-width;
+    margin: calc(-1 * #{hb-calculate-rems($hb-gutter-width)}) 0 hb-calculate-rems($hb-gutter-width);
   }
 
   @include hb-colorful {
     position: relative;
-    margin: 0 0 $hb-gutter-width;
-
     min-height: 60vh;
 
     @include grid-media-min('sm') {
@@ -37,55 +56,7 @@
       left: 0;
       width: 100%;
       height: 100%;
-      z-index: $hb-z-index-hero1-overlay;
-    }
-  }
-
-  .paragraph--type--hs-carousel & {
-    @include hb-colorful {
-      @include clearfix;
-      padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 8%;
-
-      @include grid-media-min('md') {
-        padding: 0;
-        display: grid;
-        grid-template-columns: 8% 7% 45% 20% 20%; // 5 cols, position 1-6
-        grid-template-rows: 60px 1fr 1fr auto auto 60px; // 6 rows, position 1-7
-      }
-
-      @include grid-media-min('xl') {
-        grid-template-columns: 8% 7% 35% 30% 20%; // 5 cols, position 1-6
-      }
-
-      // Offset background color psuedo element
-      &::before {
-        @include hb-global-color('background-color', 'gray-light');
-        z-index: $hb-z-index-hero1-background;
-
-        @include grid-media-min('md') {
-          position: unset;
-          padding: hb-calculate-rems($hb-gutter-width) 0 hb-calculate-rems($hb-gutter-width) 10%;
-          grid-column-start: 1;
-          grid-column-end: 5;
-          grid-row-start: 1;
-          grid-row-end: 6;
-        }
-      }
-
-      // Secondary color block psuedo element that shows up in the grid
-      &::after {
-        content: '';
-        display: block;
-        z-index: $hb-z-index-hero1-overlay;
-        @include hb-pairing-color('background-color', 'secondary');
-
-        @include grid-media-min('md') {
-          grid-column-start: 1;
-          grid-column-end: 2;
-          grid-row-start: 3;
-          grid-row-end: 4;
-        }
-      }
+      z-index: $hb-z-index-hero-fallback;
     }
   }
 
@@ -106,20 +77,6 @@
     }
 
     @include hb-colorful {
-      position: relative;
-
-      &::before {
-        @include hb-pairing-color('background-color', 'primary-hero-overlay');
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        opacity: 0.9;
-        z-index: $hb-z-index-hero1-overlay;
-      }
-
       img {
         height: 100%;
         width: 100%;
@@ -128,48 +85,6 @@
 
         @include grid-media-min('sm') {
           min-height: 55vh;
-        }
-      }
-
-      .paragraph--type--hs-carousel & {
-        // On mobile, make the secondary color box out of psuedo element,
-        // then on 'md' breakpoint, it becomes part of the grid
-        &::before {
-          display: block;
-          bottom: 0;
-          left: -8.75%;
-          top: initial;
-          @include psuedo-background-box('secondary', 50%, 8.75%);
-          opacity: 1;
-
-          @include grid-media-min('md') {
-            display: none;
-          }
-        }
-
-        @include grid-media-min('md') {
-          // This will make sure that the image fills the entire area
-          display: flex;
-          margin-top: 0;
-          grid-column-start: 3;
-          grid-column-end: 6;
-          grid-row-start: 2;
-          grid-row-end: 5;
-          padding-top: 0;
-        }
-
-        img {
-          object-fit: initial;
-          min-height: auto;
-
-          @include grid-media-min('sm') {
-            min-height: auto;
-          }
-
-          @include grid-media-min('md') {
-            min-height: 55vh;
-            object-fit: cover;
-          }
         }
       }
     }
@@ -270,74 +185,6 @@
 
           .fa-ext {
             display: none;
-          }
-        }
-      }
-    }
-
-    .paragraph--type--hs-carousel & {
-      @include hb-colorful {
-        @include hb-pairing-color('background-color', 'primary-hero-overlay');
-        padding: calc(#{hb-calculate-rems(64px)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2) calc(#{hb-calculate-rems($hb-gutter-width)} / 2);
-        position: relative;
-        width: auto !important;
-        transform: none;
-        top: initial;
-        left: initial;
-
-        @include grid-media-min('md') {
-          grid-column-start: 2;
-          grid-column-end: 4;
-          grid-row-start: 4;
-          grid-row-end: 7;
-          padding: hb-calculate-rems(64px) hb-calculate-rems($hb-gutter-width) hb-calculate-rems($hb-gutter-width);
-          width: auto !important;
-        }
-
-        @include grid-media-min('lg') {
-          width: auto !important;
-        }
-
-        // Line decoration pseudo element
-        &::after {
-          display: block;
-          top: hb-calculate-rems(32px);
-          @include psuedo-background-box('tertiary-reversed', hb-calculate-rems(4px), hb-calculate-rems(65px));
-
-          @include grid-media-min('md') {
-            top: hb-calculate-rems(56px);
-          }
-        }
-
-        h2 {
-          @include hb-heading-4;
-          margin: hb-calculate-rems(24px) 0;
-
-          @include grid-media-min('md') {
-            @include hb-heading-4;
-            margin: hb-calculate-rems(24px) 0;
-          }
-
-          @include grid-media-min('lg') {
-            @include hb-heading-3;
-            margin: hb-calculate-rems(28px) 0;
-          }
-        }
-
-        h2,
-        .field-hs-hero-body {
-          width: auto;
-
-          @include grid-media-min('sm') {
-            width: auto;
-          }
-
-          @include grid-media-min('md') {
-            width: auto;
-          }
-
-          @include grid-media-min('lg') {
-            width: auto;
           }
         }
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.zindex.scss
@@ -1,4 +1,5 @@
 $hb-index-negative: -1;
+$hb-z-index-zero: 0;
 $hb-z-index-small-1: 1;
 $hb-z-index-small-2: 2;
 $hb-z-index-small-3: 3;
@@ -24,6 +25,7 @@ $hb-z-index-12: 1200;
 $hb-z-index-masthead: $hb-z-index-1;
 $hb-z-index-lockup: $hb-z-index-5; // keeps the lockup from laying on top of the admin menu
 $hb-z-index-search: $hb-z-index-5; // keeps the search input from being hidden by the navigation
+$hb-z-index-hero-fallback: $hb-z-index-zero;
 $hb-z-index-hero1-background: $hb-z-index-small-1;
 $hb-z-index-hero1-overlay: $hb-z-index-small-2;
 $hb-z-index-decorative-link: $hb-z-index-1;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.buttons.scss
@@ -59,7 +59,6 @@
   background-color: transparent;
   border-radius: hb-calculate-rems(42px);
   font-weight: hb-theme-font-weight(semibold);
-  margin-top: hb-calculate-rems($hb-gutter-width);
   padding: hb-calculate-rems(12px);
   text-decoration: none;
   text-align: center;

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
@@ -31,7 +31,7 @@
           @include hb-global-color('color', 'gray-dark');
         }
         @include contains {
-          color: #413E39;
+          color: #413e39;
         }
       }
     }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- adds support and styles for hero option 2
- for hero 1, those styles are now scoped to the carousel paragraph pattern
- I also refactored the styles for the hero a bit, so almost all styles now sit under the `hb-colorful` theme declaration

Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] IE11 I am seeing issues, can someone else confirm?

TODO
- [x] rebase and change base branch
- check without an image but still text 👍 
- default image alone with background color  👍 
- try out focal point - I dont think this matters with our css 👍 (ask Bryan)
- pair with merani 👍 

## Steps to Test
1. Ensure that `npm test` passes in the Humsci Basic theme.
2. Create a basic page with a carousel
3. Create a basic page with a hero
4. Ensure that styles match the designs https://www.figma.com/file/toNZnFLadtpNpG5dPzNGWz/%E2%9A%99%EF%B8%8F-Colorful-Theme---Working?node-id=3446%3A2 and look good at different responsive sizes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
