### PR TITLE
STN-276: Basic Page Layout

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -56,6 +56,18 @@ function humsci_basic_preprocess_page(&$vars) {
 
   // Variant setting for the local footer to be used in children themes
   $vars['local_footer_variant_classname'] = '';
+
+  // Node pages are configured with layout builder so we dont need to set this
+  // class.
+  $route = \Drupal::routeMatch()->getRouteName();
+  $layout_routes = [
+    'layout_builder.overrides.node.view',
+    'layout_builder.defaults.node.view',
+  ];
+
+  if (!isset($vars['node']) && !in_array($route, $layout_routes)) {
+    $vars['main_class'] = 'hb-page-width';
+  }
 }
 
 /**

--- a/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/objects/_layouts.general.scss
@@ -15,4 +15,13 @@
 
 .layout-builder-form .form-actions {
   @include hb-page-width;
+
+  .button {
+    width: auto;
+  }
+}
+
+.block-help {
+  @include hb-page-width;
+  padding-top: hb-calculate-rems(40px);
 }

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -26,7 +26,7 @@
   </div>
 {% endif %}
 
-<div id="main-content">
+<div id="main-content" class="{{ main_class }}">
   {{ page.content }}
 </div>
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request adds the `hb-page-width` class to pages that do not use the layout builder.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Confirm that existing pages are not broken: home, 3 column layout, 3 column w/ image
2. Search for `courses` and confirm that the search results page aligns with the header and footer content.
3. View a taxonomy page and confirm that the page aligns with the header and footer content.
4. Open the layout builder for any page and confirm that the form controls at the top of the page align with the header content.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
