### PR TITLE
STN-294 : Refactor External Links

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -1,5 +1,17 @@
-.block-layout-builder:not(:last-child) {
-  margin-bottom: hb-calculate-rems(20px);
+.block-layout-builder {
+  &:not(:last-child) {
+    margin-bottom: hb-calculate-rems(20px);
+  }
+
+  // Trigger change in fa-ext icon color when hovering over it's associated link text.
+  .link a {
+    &:hover,
+    &:focus {
+      @include hb-colorful {
+        @include hb-ext-icon-color('primary');
+      }
+    }
+  }
 }
 
 .block-hs-blocks {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -8,7 +8,7 @@
     &:hover,
     &:focus {
       @include hb-colorful {
-        @include hb-ext-icon-color('primary');
+        @include hb-ext-icon-color('tertiary-darken-20');
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -82,11 +82,6 @@
         }
       }
 
-      // this is being added to fix a safari bug with our external links
-      .field-content {
-        display: flex;
-      }
-
       a {
         font-weight: hb-theme-font-weight(semibold);
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -128,10 +128,10 @@
     // override default link styles that might go here
     a {
       display: block;
+      background-image: none;
 
       &:focus,
       &:hover {
-        box-shadow: none;
         border-bottom: 0 none;
 
         img {
@@ -288,10 +288,10 @@
       margin-left: hb-calculate-rems(-44px);
       text-decoration: none;
       z-index: $hb-z-index-decorative-link; // align the link above the arrow icon to make it clickable on the vertical card
+      background-image: none;
 
       &:focus,
       &:hover {
-        box-shadow: none;
         color: transparent;
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -28,11 +28,7 @@
       a {
         &:hover,
         &:focus {
-          .fa-ext::after {
-            @include hb-icon-background('ext-link', 'primary');
-            background-repeat: no-repeat;
-            background-position: center;
-          }
+          @include hb-ext-icon-color('primary');
         }
       }
     }
@@ -69,11 +65,7 @@
       a {
         &:hover,
         &:focus {
-          .fa-ext::before {
-            @include hb-icon-background('ext-link', 'secondary-active');
-            background-repeat: no-repeat;
-            background-position: center;
-          }
+          @include hb-ext-icon-color('tertiary-highlight');
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -44,9 +44,11 @@
 
   @include hb-colorful {
     a:not([class]) {
+      // background-image: none;
+
       &:hover,
       &:focus {
-        box-shadow: none;
+        box-shadow: none; // TODO: remove?
         @include hb-pairing-color('color', 'tertiary-darken-20');
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -18,6 +18,7 @@
 
   .menu-item {
     margin-bottom: hb-calculate-rems(14px);
+    padding-right: hb-calculate-rems(18px);
 
     @include grid-media-min('lg') {
       font-size: hb-calculate-rems(18px);
@@ -27,7 +28,7 @@
       a {
         &:hover,
         &:focus {
-          .fa-ext::before {
+          .fa-ext::after {
             @include hb-icon-background('ext-link', 'primary');
             background-repeat: no-repeat;
             background-position: center;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -44,11 +44,10 @@
 
   @include hb-colorful {
     a:not([class]) {
-      // background-image: none;
+      background-image: none;
 
       &:hover,
       &:focus {
-        box-shadow: none; // TODO: remove?
         @include hb-pairing-color('color', 'tertiary-darken-20');
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -28,7 +28,7 @@
       a {
         &:hover,
         &:focus {
-          @include hb-ext-icon-color('primary');
+          @include hb-ext-icon-color('tertiary-darken-20');
         }
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -75,7 +75,7 @@
     &:hover,
     &:focus {
       @include hb-colorful {
-        @include hb-ext-icon-color('primary');
+        @include hb-ext-icon-color('tertiary-darken-20');
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -69,24 +69,9 @@
   }
 }
 
-.views-field-field-hs-news-link a, // horizontal view link to external article default class
+// external link in a news view list item
+.views-field-field-hs-news-link .field-content a, // this creates a duplicate icon
+// external link in a news node detail page
 .field-hs-news-link a {
-  background-color: cyan;
-  @include hb-colorful {
-    position: relative;
-    margin-right: hb-calculate-rems(24px);
-    display: inline;
-    border-bottom: $hb-thin-border;
-    @include hb-pairing-color('border-color', 'tertiary');
-    @include hb-link--hover-style('tertiary-highlight', 'primary');
-
-    &:hover,
-    &:focus {
-      .fa-ext::before { // TODO: update to use mixin?
-        @include hb-icon-background('ext-link', 'tertiary');
-        background-repeat: no-repeat;
-        background-position: center;
-      }
-    }
-  }
+  @include hb-external-link-icon;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -70,8 +70,13 @@
 }
 
 // external link in a news view list item
-.views-field-field-hs-news-link .field-content a, // this creates a duplicate icon
-// external link in a news node detail page
-.field-hs-news-link a {
-  @include hb-external-link-icon;
+.views-field-field-hs-news-link .field-content {
+  a {
+    &:hover,
+    &:focus {
+      @include hb-colorful {
+        @include hb-ext-icon-color('primary');
+      }
+    }
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -30,6 +30,7 @@
     }
 
     text-decoration: none;
+    background-image: none;
 
     &:hover,
     &:focus {
@@ -38,8 +39,6 @@
         border-bottom: $hb-thin-border;
         @include hb-global-color('border-color', 'black');
       }
-
-      box-shadow: none;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_node--news-item.scss
@@ -71,6 +71,7 @@
 
 .views-field-field-hs-news-link a, // horizontal view link to external article default class
 .field-hs-news-link a {
+  background-color: cyan;
   @include hb-colorful {
     position: relative;
     margin-right: hb-calculate-rems(24px);
@@ -81,7 +82,7 @@
 
     &:hover,
     &:focus {
-      .fa-ext::before {
+      .fa-ext::before { // TODO: update to use mixin?
         @include hb-icon-background('ext-link', 'tertiary');
         background-repeat: no-repeat;
         background-position: center;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
@@ -31,17 +31,12 @@
       text-align: center;
       text-decoration: none;
       transition: background-color $hb-animation-duration $hb-animation-timing-function;
+      background-image: none;
 
       &:hover {
         @include hb-colorful {
           @include hb-global-color('background-color', 'gray-medium');
         }
-
-        box-shadow: none;
-      }
-
-      &:focus {
-        box-shadow: none;
       }
     }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -160,10 +160,10 @@
 
       a {
         @include hb-pairing-color('color', 'tertiary-reversed');
+        background-image: none;
 
         &:hover,
         &:focus {
-          box-shadow: none;
           @include hb-pairing-color('color', 'tertiary-highlight');
         }
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_postcard.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_postcard.scss
@@ -56,10 +56,10 @@
       color: transparent; // `hide` the text but make sure screen readers can still read it
       height: hb-calculate-rems(44px);
       text-decoration: none;
+      background-image: none;
 
       &:hover,
       &:focus {
-        box-shadow: none;
         color: transparent;
         cursor: pointer;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -57,7 +57,7 @@ a:not([class]) {
   @include hb-link--inline;
 }
 
-a[href*="http"][data-extlink] { // all external links - Shouldn't they have icons? // TODO: need another opinion
+a[href*="http"][data-extlink] {
   @include hb-link--inline($icon: true);
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -57,7 +57,7 @@ a:not([class]) {
   @include hb-link--inline;
 }
 
-a[href*="http"][data-extlink] {
+a[href*="//"][data-extlink] {
   @include hb-link--inline($icon: true);
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -57,6 +57,9 @@ a:not([class]) {
   @include hb-link--inline;
 }
 
+// Target all external URLs
+// The use of `//` allows users to input a vareity of URLs
+// examples: `https://google.com` `http://google.com` and `//google.com`
 a[href*="//"][data-extlink] {
   @include hb-link--inline($icon: true);
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -57,6 +57,10 @@ a:not([class]) {
   @include hb-link--inline;
 }
 
+a[href*="http"][data-extlink] { // all external links - Shouldn't they have icons? // TODO: need another opinion
+  @include hb-link--inline($icon: true);
+}
+
 h1:not([class]) {
   @include hb-heading-1;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -53,7 +53,7 @@ body {
   }
 }
 
-a:not([class]) { // TODO: remove the not class to see what happens
+a:not([class]) {
   @include hb-link--inline;
 }
 
@@ -69,7 +69,7 @@ h2:not([class]) {
   @include hb-heading-2;
 
   a.is-active,
-  a:not([class]) {  // TODO: remove the not class to see what happens
+  a:not([class]) {
     @include hb-link;
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -55,7 +55,6 @@ body {
 
 a:not([class]) { // TODO: remove the not class to see what happens
   @include hb-link--inline;
-  // background-color: yellow;
 }
 
 h1:not([class]) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -53,8 +53,9 @@ body {
   }
 }
 
-a:not([class]) {
+a:not([class]) { // TODO: remove the not class to see what happens
   @include hb-link--inline;
+  // background-color: yellow;
 }
 
 h1:not([class]) {
@@ -69,7 +70,7 @@ h2:not([class]) {
   @include hb-heading-2;
 
   a.is-active,
-  a:not([class]) {
+  a:not([class]) {  // TODO: remove the not class to see what happens
     @include hb-link;
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -27,14 +27,15 @@
   }
 }
 
-// Used with the hs-external-link and fa-ext classes to add an external link icon
-@mixin hb-external-link-icon { // TODO: add two variables for color and hover states
+// Used alongside the hb-link--inline mixin when an external icon is needed.
+// And within the fa-ext class in block-layout.scss to add an external link icon.
+@mixin hb-external-link-icon {
   margin-right: hb-calculate-rems(20px);
 
   @include hb-colorful {
     position: relative;
 
-    &::after { // TODO: Refactor hb-pill external link once Kasey's QA work has been merged.
+    &::after {
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
       background-position: center;
@@ -61,6 +62,15 @@
         @include hb-icon-background('ext-link', 'tertiary-highlight');
       }
     }
+  }
+}
+
+// Return a specific color of the fa-ext icon
+@mixin hb-ext-icon-color($color) {
+  .fa-ext::after {
+    @include hb-icon-background('ext-link', $color);
+    background-repeat: no-repeat;
+    background-position: center;
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -28,20 +28,19 @@
 }
 
 // Used with the hs-external-link and fa-ext classes to add an external link icon
-@mixin hb-external-link-icon {
+@mixin hb-external-link-icon { // TODO: add two variables for color and hover states
   margin-right: hb-calculate-rems(20px);
 
   @include hb-colorful {
     position: relative;
 
-    &::after { // TODO: why was this before and not after? May need to refactor hb-pill external link once Kasey's QA work has been merged.
+    &::after { // TODO: Refactor hb-pill external link once Kasey's QA work has been merged.
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
       background-position: center;
       background-repeat: no-repeat;
       height: hb-calculate-rems(11px);
       width: hb-calculate-rems(11px);
-      vertical-align: middle;
       position: absolute;
       bottom: hb-calculate-rems(5px);
       margin-left: hb-calculate-rems(4px);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -34,9 +34,8 @@
   @include hb-colorful {
     position: relative;
 
-    &::after { // TODO: why was this before and not after?
+    &::after { // TODO: why was this before and not after? May need to refactor hb-pill external link once Kasey's QA work has been merged.
       content: '';
-      // background-color: hotpink;
       @include hb-icon-background('ext-link', 'tertiary');
       background-position: center;
       background-repeat: no-repeat;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -27,7 +27,9 @@
   }
 }
 
-// Used alongside the hb-link--inline mixin when an external icon is needed.
+// The external link icon base implementation which sets the sizing and spacing.
+// This has two use cases.
+// It is used alongside the hb-link--inline mixin when an external icon is needed. The WYSIWYG hs-external-link class is an example of this.
 // And within the fa-ext class in block-layout.scss to add an external link icon.
 @mixin hb-external-link-icon {
   margin-right: hb-calculate-rems(2px);
@@ -38,7 +40,7 @@
     &::after {
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
-      @include hb-global-color('background-color', 'white');
+      // @include hb-global-color('background-color', 'white');
       display: inline-block;
       position: relative;
       background-position: center right;
@@ -69,6 +71,8 @@
 }
 
 // Return a specific color of the fa-ext icon
+// This mixin can be used to trigger the icon to change colors when the
+// containing element it is associated with changes state (such as hover and/or focus).
 @mixin hb-ext-icon-color($color) {
   .fa-ext::after {
     @include hb-icon-background('ext-link', $color);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -42,7 +42,7 @@
       height: hb-calculate-rems(11px);
       width: hb-calculate-rems(11px);
       position: absolute;
-      bottom: hb-calculate-rems(5px);
+      bottom: hb-calculate-rems(3px);
       margin-left: hb-calculate-rems(4px);
     }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -52,7 +52,7 @@
 
     &:hover::after,
     &:focus::after {
-      @include hb-icon-background('ext-link', 'primary');
+      @include hb-icon-background('ext-link', 'tertiary-darken-20');
     }
 
     .hb-local-footer--dark & {

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -27,39 +27,39 @@
   }
 }
 
-// Used with the decanter-external-link class to add an external link icon
+// Used with the hs-external-link and fa-ext classes to add an external link icon
 @mixin hb-external-link-icon {
   margin-right: hb-calculate-rems(20px);
 
   @include hb-colorful {
     position: relative;
 
-    &::before {
+    &::after { // TODO: why was this before and not after?
       content: '';
+      // background-color: hotpink;
       @include hb-icon-background('ext-link', 'tertiary');
       background-position: center;
       background-repeat: no-repeat;
       height: hb-calculate-rems(11px);
       width: hb-calculate-rems(11px);
-      display: inline-block;
       vertical-align: middle;
       position: absolute;
-      top: hb-calculate-rems(4px);
-      right: hb-calculate-rems(-18px);
+      bottom: hb-calculate-rems(5px);
+      margin-left: hb-calculate-rems(4px);
     }
 
-    &:hover::before,
-    &:focus::before {
+    &:hover::after,
+    &:focus::after {
       @include hb-icon-background('ext-link', 'primary');
     }
 
     .hb-local-footer--dark & {
-      &::before {
+      &::after {
         @include hb-icon-background('ext-link', 'tertiary-reversed');
       }
 
-      &:hover::before,
-      &:focus::before {
+      &:hover::after,
+      &:focus::after {
         @include hb-icon-background('ext-link', 'tertiary-highlight');
       }
     }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -40,7 +40,7 @@
     &::after {
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
-      // @include hb-global-color('background-color', 'white');
+      @include hb-global-color('background-color', 'white');
       display: inline-block;
       position: relative;
       background-position: center right;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -40,7 +40,6 @@
     &::after {
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
-      @include hb-global-color('background-color', 'white');
       display: inline-block;
       position: relative;
       background-position: center right;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -30,7 +30,7 @@
 // Used alongside the hb-link--inline mixin when an external icon is needed.
 // And within the fa-ext class in block-layout.scss to add an external link icon.
 @mixin hb-external-link-icon {
-  margin-right: hb-calculate-rems(20px);
+  margin-right: hb-calculate-rems(2px);
 
   @include hb-colorful {
     position: relative;
@@ -38,13 +38,16 @@
     &::after {
       content: '';
       @include hb-icon-background('ext-link', 'tertiary');
-      background-position: center;
+      @include hb-global-color('background-color', 'white');
+      display: inline-block;
+      position: relative;
+      background-position: center right;
       background-repeat: no-repeat;
-      height: hb-calculate-rems(11px);
+      background-size: hb-calculate-rems(11px);
+      height: hb-calculate-rems(20px);
       width: hb-calculate-rems(11px);
-      position: absolute;
-      bottom: hb-calculate-rems(3px);
-      margin-left: hb-calculate-rems(4px);
+      margin-bottom: hb-calculate-rems(-5px);
+      padding-left: hb-calculate-rems(15px);
     }
 
     &:hover::after,
@@ -70,7 +73,7 @@
   .fa-ext::after {
     @include hb-icon-background('ext-link', $color);
     background-repeat: no-repeat;
-    background-position: center;
+    background-position: center right;
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -36,7 +36,6 @@
     &:focus {
       @include hb-global-color('color', 'black');
       @include hb-global-color('border-color', 'black');
-      box-shadow: none; // TODO: maybe remove in favor of background-image?
     }
   }
 }
@@ -63,7 +62,6 @@
       &:hover {
         @include hb-pairing-color('border-color', 'secondary-active');
         @include hb-global-color('background-color', 'white');
-        box-shadow: none; // TODO: maybe remove in favor of background-image?
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -46,11 +46,10 @@
     @include hb-global-color('color', 'black');
     display: inline-block;
     font-size: hb-calculate-rems(14px);
-    padding: hb-calculate-rems(3px) hb-calculate-rems(12px);
+    padding: hb-calculate-rems(1px) hb-calculate-rems(12px);
     text-decoration: none;
     border-radius: hb-calculate-rems(13px);
     border: 2px solid transparent;
-    line-height: 1;
     transition: background-color $hb-animation-duration $hb-animation-timing-function;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -56,7 +56,7 @@
 
   @if $link {
     @include hb-colorful {
-      @include hb-ext-link('black');
+      @include hb-ext-icon-color('black');
 
       &:focus,
       &:hover {

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -30,12 +30,13 @@
     border-bottom: $hb-thin-border;
     border-color: transparent;
     transition: 100ms ease-in-out;
+    background-image: none;
 
     &:hover,
     &:focus {
       @include hb-global-color('color', 'black');
       @include hb-global-color('border-color', 'black');
-      box-shadow: none;
+      box-shadow: none; // TODO: maybe remove in favor of background-image?
     }
   }
 }
@@ -56,12 +57,13 @@
   @if $link {
     @include hb-colorful {
       @include hb-ext-icon-color('black');
+      background-image: none;
 
       &:focus,
       &:hover {
         @include hb-pairing-color('border-color', 'secondary-active');
         @include hb-global-color('background-color', 'white');
-        box-shadow: none;
+        box-shadow: none; // TODO: maybe remove in favor of background-image?
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -42,7 +42,7 @@
 
 @mixin hb-pill($link: true) {
   @include hb-colorful {
-    @include hb-pairing-color('background-color', 'secondary-active');
+    @include hb-pairing-color('background-color', 'secondary-active'); // secondary-active // design pairing on color? This feels dark compared to what we had before the color pairing work. Perhaps use `tertiary-highlight-darken-10` instead?
     @include hb-global-color('color', 'black');
     display: inline-block;
     font-size: hb-calculate-rems(14px);
@@ -50,6 +50,7 @@
     text-decoration: none;
     border-radius: hb-calculate-rems(13px);
     border: 2px solid transparent;
+    // line-height: 1; // TODO: test - how does this affect things overall?
     transition: background-color $hb-animation-duration $hb-animation-timing-function;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.lists.scss
@@ -42,7 +42,7 @@
 
 @mixin hb-pill($link: true) {
   @include hb-colorful {
-    @include hb-pairing-color('background-color', 'secondary-active'); // secondary-active // design pairing on color? This feels dark compared to what we had before the color pairing work. Perhaps use `tertiary-highlight-darken-10` instead?
+    @include hb-pairing-color('background-color', 'secondary-active');
     @include hb-global-color('color', 'black');
     display: inline-block;
     font-size: hb-calculate-rems(14px);
@@ -50,7 +50,7 @@
     text-decoration: none;
     border-radius: hb-calculate-rems(13px);
     border: 2px solid transparent;
-    // line-height: 1; // TODO: test - how does this affect things overall?
+    line-height: 1;
     transition: background-color $hb-animation-duration $hb-animation-timing-function;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
@@ -84,4 +84,13 @@
   vertical-align: top;
   border: $hb-thin-border;
   @include hb-global-color('border-color', 'gray-medium');
+
+  a {
+    &:hover,
+    &:focus {
+      @include hb-colorful {
+        @include hb-ext-icon-color('tertiary-darken-20');
+      }
+    }
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
@@ -39,12 +39,14 @@
   @include hb-colorful {
     a:not([class]) {
       @include hb-pairing-color('color', 'secondary-highlight');
+      background-image: none;
     }
   }
 
   @include hb-traditional {
     a:not([class]) {
       @include hb-pairing-color('color', 'secondary');
+      background-image: none;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -215,6 +215,8 @@
     background-image: linear-gradient(to top, transparent 50%, var(--palette--tertiary-highlight) 50%);
 
     // For links with an icon
+    // Changes the value passed into background-image to
+    // create space for the external link space to exist
     @if $icon {
       // Fallback for IE
       background-image: linear-gradient(to left, transparent 16px, hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings) 16px);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -199,23 +199,27 @@
 }
 
 // Link style for main content that is not a heading
-@mixin hb-link--inline($icon: false) { // TODO: change to $ext-icon for clarity?
+@mixin hb-link--inline($icon: false) {
   // no font size by default
   @include hb-colorful {
     @include hb-pairing-color('color', 'tertiary');
-
-    // testing with Alternative #3
     background-size: 100% 200%;
     background-position-y: -100%;
     background-repeat: no-repeat;
 
     // For links without an icon
-    // TODO: write fallback for IE
+    // Fallback for IE
+    background-image: linear-gradient(to top, transparent 50%, hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings) 50%);
+
+    // Color Pairing Custom Variable
     background-image: linear-gradient(to top, transparent 50%, var(--palette--tertiary-highlight) 50%);
 
     // For links with an icon
     @if $icon {
-      // TODO: write fallback for IE
+      // Fallback for IE
+      background-image: linear-gradient(to left, transparent 16px, hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings) 16px);
+
+      // Color Pairing Custom Variable
       background-image: linear-gradient(to left, transparent 16px, var(--palette--tertiary-highlight) 16px);
     }
 
@@ -223,30 +227,13 @@
     &:hover,
     &:focus {
       @include hb-pairing-color('color', 'tertiary-darken-20');
-
-      // box-shadow: inset 0 hb-calculate-rems(-10px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
-      // box-shadow: inset 0 hb-calculate-rems(-10px) 0 var(--palette--tertiary-highlight);
-
-      // Alternative #1
-      // box-shadow: inset 0 hb-calculate-rems(-20px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
-      // box-shadow: inset 0 hb-calculate-rems(-20px) 0 var(--palette--tertiary-highlight);
-
-      // Alternative #2
-      // box-shadow: inset 0 hb-calculate-rems(-5px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
-      // box-shadow: inset 0 hb-calculate-rems(-5px) 0 var(--palette--tertiary-highlight);
-
-      // Alternative #3
       background-position-y: -50%;
-
-      // Alternative #4
-      // Apply box-shadow to a span wrapped around the text via JS
     }
   }
 
   .hb-local-footer & {
     &:focus,
     &:hover {
-      // box-shadow: none;
       background-image: none;
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -239,7 +239,7 @@
 }
 
 @mixin hb-ext-link($color) {
-  .fa-ext::before { // TODO: How does this work with ::after? May need to update after Kasey's work is merged.
+  .fa-ext::after { // TODO: was ::before
     @include hb-icon-background('ext-link', $color);
     background-repeat: no-repeat;
     background-position: center;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -184,7 +184,10 @@
 }
 
 @mixin hb-link {
+  // TODO: used on headings - update name for clarity?????
+  // hb-secondary-nav--heading
   // no font size by default
+  background-color: violet;
   @include hb-colorful {
     @include hb-global-color('color', 'black');
     font-weight: hb-theme-font-weight(semibold);
@@ -199,6 +202,7 @@
 
 @mixin hb-link--inline {
   // no font size by default
+  background-color: tomato;
   @include hb-colorful {
     @include hb-pairing-color('color', 'tertiary');
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -183,6 +183,7 @@
   }
 }
 
+// Link style for headings
 @mixin hb-link {
   // no font size by default
   @include hb-colorful {
@@ -197,9 +198,9 @@
   }
 }
 
+// Link style for main content that is not a heading
 @mixin hb-link--inline {
   // no font size by default
-  // background-color: tomato; // TODO: make sure all external links are usuing this mixin!
   @include hb-colorful {
     @include hb-pairing-color('color', 'tertiary');
 
@@ -227,23 +228,6 @@
         @include hb-pairing-color('color', 'tertiary-highlight', $important: true);
       }
     }
-  }
-}
-
-@mixin hb-ext-link($color) {
-  .fa-ext::before {
-    @include hb-icon-background('ext-link', $color);
-    background-repeat: no-repeat;
-    background-position: center;
-  }
-}
-
- // TODO: compare with hb-external-link-icon mixin and refactor as needed. Decide which to keep. This doesn't give a hover state and it only works when fa-ext exists. It does not work for WYWIWYG external links because they are missing the fa-ext class.
-@mixin hb-ext-link($color) {
-  .fa-ext::after {
-    @include hb-icon-background('ext-link', $color);
-    background-repeat: no-repeat;
-    background-position: center;
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -238,8 +238,9 @@
   }
 }
 
+ // TODO: compare with hb-external-link-icon mixin and refactor as needed. Decide which to keep. This doesn't give a hover state and it only works when fa-ext exists. It does not work for WYWIWYG external links because they are missing the fa-ext class.
 @mixin hb-ext-link($color) {
-  .fa-ext::after { // TODO: was ::before
+  .fa-ext::after {
     @include hb-icon-background('ext-link', $color);
     background-repeat: no-repeat;
     background-position: center;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -184,10 +184,7 @@
 }
 
 @mixin hb-link {
-  // TODO: used on headings - update name for clarity?????
-  // hb-secondary-nav--heading
   // no font size by default
-  background-color: violet;
   @include hb-colorful {
     @include hb-global-color('color', 'black');
     font-weight: hb-theme-font-weight(semibold);
@@ -202,7 +199,7 @@
 
 @mixin hb-link--inline {
   // no font size by default
-  background-color: tomato;
+  // background-color: tomato; // TODO: make sure all external links are usuing this mixin!
   @include hb-colorful {
     @include hb-pairing-color('color', 'tertiary');
 
@@ -235,6 +232,14 @@
 
 @mixin hb-ext-link($color) {
   .fa-ext::before {
+    @include hb-icon-background('ext-link', $color);
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+}
+
+@mixin hb-ext-link($color) {
+  .fa-ext::before { // TODO: How does this work with ::after? May need to update after Kasey's work is merged.
     @include hb-icon-background('ext-link', $color);
     background-repeat: no-repeat;
     background-position: center;

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -199,23 +199,55 @@
 }
 
 // Link style for main content that is not a heading
-@mixin hb-link--inline {
+@mixin hb-link--inline($icon: false) { // TODO: change to $ext-icon for clarity?
   // no font size by default
   @include hb-colorful {
     @include hb-pairing-color('color', 'tertiary');
 
+    // testing with Alternative #3
+    background-size: 100% 200%;
+    background-position-y: -100%;
+    background-repeat: no-repeat;
+
+    // For links without an icon
+    // TODO: write fallback for IE
+    background-image: linear-gradient(to top, transparent 50%, var(--palette--tertiary-highlight) 50%);
+
+    // For links with an icon
+    @if $icon {
+      // TODO: write fallback for IE
+      background-image: linear-gradient(to left, transparent 16px, var(--palette--tertiary-highlight) 16px);
+    }
+
+
     &:hover,
     &:focus {
       @include hb-pairing-color('color', 'tertiary-darken-20');
-      box-shadow: inset 0 hb-calculate-rems(-10px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
-      box-shadow: inset 0 hb-calculate-rems(-10px) 0 var(--palette--tertiary-highlight);
+
+      // box-shadow: inset 0 hb-calculate-rems(-10px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
+      // box-shadow: inset 0 hb-calculate-rems(-10px) 0 var(--palette--tertiary-highlight);
+
+      // Alternative #1
+      // box-shadow: inset 0 hb-calculate-rems(-20px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
+      // box-shadow: inset 0 hb-calculate-rems(-20px) 0 var(--palette--tertiary-highlight);
+
+      // Alternative #2
+      // box-shadow: inset 0 hb-calculate-rems(-5px) 0 hb-get-pairing-color('tertiary-highlight', $hb-colorful-default, $hc-colorful-pairings);
+      // box-shadow: inset 0 hb-calculate-rems(-5px) 0 var(--palette--tertiary-highlight);
+
+      // Alternative #3
+      background-position-y: -50%;
+
+      // Alternative #4
+      // Apply box-shadow to a span wrapped around the text via JS
     }
   }
 
   .hb-local-footer & {
     &:focus,
     &:hover {
-      box-shadow: none;
+      // box-shadow: none;
+      background-image: none;
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
@@ -30,7 +30,7 @@
   @include hb-body--medium;
 }
 
-.hb-link { // used on headlines
+.hb-link {
   @include hb-link;
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_fonts.scss
@@ -30,7 +30,7 @@
   @include hb-body--medium;
 }
 
-.hb-link {
+.hb-link { // used on headlines
   @include hb-link;
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
@@ -74,10 +74,11 @@
   a {
     @include hb-pill;
 
-    // If a link is an external icon, make space for it.
     .fa-ext {
       &::after {
         background-color: transparent;
+        height: hb-calculate-rems(11px); // center icon in pill
+        margin-bottom: 0; // center icon in pill
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
@@ -73,12 +73,13 @@
 .hb-pill-link-list {
   a {
     @include hb-pill;
+    background-image: none !important;
+    color: inherit !important;
 
     .fa-ext {
       &::after {
-        background-color: transparent;
-        height: hb-calculate-rems(11px); // center icon in pill
-        margin-bottom: 0; // center icon in pill
+        height: hb-calculate-rems(11px);
+        margin-bottom: 0;
       }
     }
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
@@ -76,7 +76,9 @@
 
     // If a link is an external icon, make space for it.
     .fa-ext {
-      padding-right: hb-calculate-rems(15px);
+      &::after {
+        background-color: transparent;
+      }
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_lists.scss
@@ -73,6 +73,11 @@
 .hb-pill-link-list {
   a {
     @include hb-pill;
+
+    // If a link is an external icon, make space for it.
+    .fa-ext {
+      padding-right: hb-calculate-rems(15px);
+    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_local-tasks.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_local-tasks.scss
@@ -23,7 +23,7 @@
       a {
         color: $hb-color--drupal-black;
         text-decoration: none;
-        box-shadow: none;
+        background-image: none;
       }
 
       &--active {

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -255,7 +255,7 @@ blockquote:nth-child(n) {
   }
 
   .hb-local-footer & {
-    margin: 0 0 2rem; // adjust blockquote browser spacing defaults when placed in the local footer
+    margin: 0 0 hb-calculate-rems(20px); // adjust blockquote browser spacing defaults when placed in the local footer
   }
 
   p {

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -57,11 +57,7 @@
   a:not([href]):not([class]) {
     border-bottom: 0;
     transition: none;
-
-    &:focus,
-    &:hover {
-      box-shadow: none;
-    }
+    background-image: none;
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -49,7 +49,7 @@
   // add icon to external links only
   p {
     a[href^="http"]:not([class]) {
-      @include hb-link--inline;
+      @include hb-link--inline($icon: true);
       @include hb-external-link-icon;
     }
   }
@@ -203,7 +203,7 @@
   }
 
   &-external-link {
-    @include hb-link--inline;
+    @include hb-link--inline($icon: true);
     @include hb-external-link-icon;
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -48,9 +48,10 @@
   }
   // add icon to external links only
   p {
-    a[href^="http"]:not([class]) {
+    a[href^="http"]:not([class]) { // TODO: refactor WIP
       @include hb-link--inline;
       @include hb-external-link-icon;
+      background-color: lightsteelblue;
     }
   }
   // jump to link target - remove link styles from anchor tag

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -48,10 +48,9 @@
   }
   // add icon to external links only
   p {
-    a[href^="http"]:not([class]) { // TODO: refactor WIP
+    a[href^="http"]:not([class]) {
       @include hb-link--inline;
       @include hb-external-link-icon;
-      background-color: lightsteelblue;
     }
   }
   // jump to link target - remove link styles from anchor tag


### PR DESCRIPTION
# [STN-294](https://sparkbox.atlassian.net/browse/STN-294) READY FOR REVIEW

## Summary
This PR fixes external link bugs and implements design tweaks to create consistency.

The external link styles in this PR have been reviewed by a designer.

:bug:
External link icon was missing hover styles on node detail pages.

:bug:
Within WYSIWYG main content, the external link icon was not positioned correctly when the link wrapped onto a second line.
_Example:_
<img width="818" alt="two_lines" src="https://user-images.githubusercontent.com/12678977/79123246-b7faec80-7d67-11ea-8a49-412a0be301f8.png">

:bug: + :art:
Update main content links to use underlines upon hover rather than border-bottom. This resolves a bug with the border-bottom extends beyond the text when the link text wraps unto a second line. It also creates design consistency across all links.
_Example:_
<img width="721" alt="update to underline" src="https://user-images.githubusercontent.com/12678977/79123411-1aec8380-7d68-11ea-8d0e-1e46fcc002c5.png">

🤖 
Refactor code base as needed to ensure external link styles are being applied consistently.

## This PR has been browser tested in
- [x] Safari
- [x] Chrome
- [x] Firefox (Mac & Windows)
- [x] Edge
- [x] IE
Firefox and IE have issues that need to be resolved. See comment below.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. In the CLI, run `npm run test` to confirm tests pass.
2. Confirm the following bugs have been squashed:

- [ ] Go to the [News Node Detail](http://economics.suhumsci.loc/news/joeys-test-news-item) page. Hover over the external link text. Confirm the external link icon darkens when hovering over the link text. _Note:_ The fix implemented should cover all node detail pages. For example, go to a person node detail page such as http://economics.suhumsci.loc/people/person-all-fields-filled and confirm the external link icon darkens when hovering over the link text.

- [ ] Go to the [QA Real Econ Content](http://economics.suhumsci.loc/qa/qa-real-econ-content) page. Scroll through the main content. Find an external link which wraps onto a second line. `Stanford Institute for Economic Policy Research (SIEPR)` is a good link to look for. Verify the the icon sits to the right of the link.

- [ ] Go to [QA Page](http://economics.suhumsci.loc/qa/qa-page). Scroll down the page until you find a section of horizontal news cards. Adjust the page width until the external link wraps unto a second line. Confirm the underline resolves the issue previously created by border-bottom.

- [ ] Review the link styles in EVERYWHERE! Look and notate any inconsistencies.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
