### PR TITLE
WIP feat(STN-248): traditional theme research and foundation

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -73,6 +73,7 @@
   //    If using features such as custom properties, those that are global
   //    custom properties should be described in this section.
   'settings/variables.colorful-pairings',
+  'settings/variables.traditional-pairings',
   'settings/variables.general',
   'settings/variables.fonts',
   'settings/variables.zindex',

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
@@ -19,7 +19,7 @@ a.button {
 
       &:hover {
         @include hb-pairing-color('color', 'secondary-darken-12');
-        @include hb-pairing-color('border-color', 'secondary-darken-12');
+        @include hb-pairing-color('border-bottom-color', 'secondary-darken-12');
       }
 
       &:focus {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
@@ -15,10 +15,7 @@
   }
 
   &__caption {
-    @include hb-colorful {
-      @include hb-global-color('color', 'gray-dark');
-    }
-
+    @include hb-global-color('color', 'gray-dark');
     font-size: hb-calculate-rems(14px);
     padding: hb-calculate-rems(20px) 0;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-row.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-row.scss
@@ -10,10 +10,7 @@
     content: '';
     display: block;
     height: hb-calculate-rems(11px);
-
-    @include hb-colorful {
-      @include hb-pairing-color('background-color', 'primary');
-    }
+    @include hb-pairing-color('background-color', 'primary');
 
     @include grid-media-min('md') {
       display: none;
@@ -39,10 +36,8 @@
       border: 0 none;
 
       @include grid-media-min('md') {
-        @include hb-colorful {
-          border: $hb-thin-border;
-          @include hb-global-color('border-color', 'gray-medium');
-        }
+        border: $hb-thin-border;
+        @include hb-global-color('border-color', 'gray-medium');
       }
     }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -38,8 +38,6 @@ html {
 }
 
 body {
-  @include hb-body--small;
-
   @include hb-colorful {
     font-family: $hb-colorful-font--sans;
   }
@@ -47,6 +45,8 @@ body {
   @include hb-traditional {
     font-family: $hb-traditional-font--sans;
   }
+
+  @include hb-body--small;
 
   @include grid-media-min('lg') {
     @include hb-body--medium;

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_base.scss
@@ -23,6 +23,13 @@
     --palette--tertiary-reversed-darken-10: #{hb-get-pairing-color("tertiary-reversed-darken-10", $hb-colorful-default, $hc-colorful-pairings)};
     --palette--tertiary-darken-20: #{hb-get-pairing-color("tertiary-darken-20", $hb-colorful-default, $hc-colorful-pairings)};
   }
+
+  @include hb-traditional {
+    // BASE
+    --palette--primary: #{hb-get-pairing-color("primary", $hb-traditional-default, $ht-traditional-pairings)};
+    --palette--secondary: #{hb-get-pairing-color("secondary", $hb-traditional-default, $ht-traditional-pairings)};
+    --palette--tertiary: #{hb-get-pairing-color("tertiary", $hb-traditional-default, $ht-traditional-pairings)};
+  }
 }
 
 html {
@@ -35,6 +42,10 @@ body {
 
   @include hb-colorful {
     font-family: $hb-colorful-font--sans;
+  }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--sans;
   }
 
   @include grid-media-min('lg') {

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -1,3 +1,5 @@
+// COLORFUL
+//
 // Set the default color pairing value
 // The default color pairing also serves as the fallback color
 // pairing for browsers that do not support CSS custom properties

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
@@ -2,6 +2,7 @@
 // Source Sans Pro
 $hb-colorful-font--sans: $su-font-sans;
 $hb-traditional-font--serif: $su-font-serif;
+$hb-traditional-font--sans: $su-font-sans;
 
 // Source Sans Pro Font Weights
 $hb-colorful-font-weights: (

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
@@ -1,10 +1,17 @@
 // Colorful Theme Fonts
 // Source Sans Pro
 $hb-colorful-font--sans: $su-font-sans;
+$hb-traditional-font--serif: $su-font-serif;
 
 // Source Sans Pro Font Weights
 $hb-colorful-font-weights: (
   regular: 400,
   semibold: 600,
   bold: 700
+);
+
+// Source Serif Pro Font Weights
+$hb-colorful-font-weights: (
+  regular: 400,
+  semibold: 600
 );

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
@@ -11,6 +11,8 @@ $hb-colorful-font-weights: (
   bold: 700
 );
 
+// Not sure this is needed (all font weights encompassed in above,
+// we could just make a theme generic font-weight array
 // Source Serif Pro Font Weights
 $hb-colorful-font-weights: (
   regular: 400,

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.fonts.scss
@@ -4,17 +4,9 @@ $hb-colorful-font--sans: $su-font-sans;
 $hb-traditional-font--serif: $su-font-serif;
 $hb-traditional-font--sans: $su-font-sans;
 
-// Source Sans Pro Font Weights
-$hb-colorful-font-weights: (
+// Source Sans Pro and Source Serif Pro Font Weights
+$hb-font-weights: (
   regular: 400,
   semibold: 600,
   bold: 700
-);
-
-// Not sure this is needed (all font weights encompassed in above,
-// we could just make a theme generic font-weight array
-// Source Serif Pro Font Weights
-$hb-colorful-font-weights: (
-  regular: 400,
-  semibold: 600
 );

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
@@ -1,5 +1,5 @@
 $hb-global-theme-list: ('airy', 'colorful', 'traditional');
-$hb-colorful-theme-variation-list: ('colorful-teal', 'colorful-mint');
+// $hb-colorful-theme-variation-list: ('colorful-teal', 'colorful-mint');
 
 $hb-grid-count: 12;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.general.scss
@@ -1,5 +1,4 @@
 $hb-global-theme-list: ('airy', 'colorful', 'traditional');
-// $hb-colorful-theme-variation-list: ('colorful-teal', 'colorful-mint');
 
 $hb-grid-count: 12;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -6,6 +6,8 @@
 $hb-traditional-default: 'default';
 
 // Each color pairing has a palette of color swatches
+// TODO: these are placeholder colors for now until
+// design is finalized.
 $ht-traditional-pairings: (
   "default": (
     "primary": $su-color-cardinal-red,
@@ -20,6 +22,8 @@ $ht-traditional-pairings: (
 );
 
 // Specific shades of gray that compliment traditional pairing palettes
+// TODO: these are placeholder colors for now until
+// design is finalized.
 $ht-traditional-globals: (
   "gray": $su-color-chocolate,
   "gray-dark": #413e39,

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -1,0 +1,30 @@
+// TRADITIONAL
+
+// Set the default color pairing value
+// The default color pairing also serves as the fallback color
+// pairing for browsers that do not support CSS custom properties
+$hb-traditional-default: 'default';
+
+// Each color pairing has a palette of color swatches
+$ht-traditional-pairings: (
+  "default": (
+    "primary": $su-color-cardinal-red,
+    "secondary": $su-color-sandhill,
+    "tertiary": $su-color-bright-red
+  ),
+  "light": (
+    "primary": $su-color-chocolate,
+    "secondary": $su-color-sandhill,
+    "tertiary": $su-color-cardinal-red
+  )
+);
+
+// Specific shades of gray that compliment traditional pairing palettes
+$ht-traditional-globals: (
+  "gray": $su-color-chocolate,
+  "gray-dark": #413e39,
+  "gray-medium": #d9d7d2,
+  "gray-light": #928B81,
+  "white": #fff,
+  "black": #000
+);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_functions.fonts.scss
@@ -2,7 +2,7 @@
 // Params: (variable-name), e.g. hb-theme-font-weight(semibold)
 // Could be extended for other themes later
 @function hb-theme-font-weight($weight) {
-  $result: map-get($hb-colorful-font-weights, $weight);
+  $result: map-get($hb-font-weights, $weight);
 
   @return $result;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.color-pairings.scss
@@ -21,6 +21,24 @@
       #{$property}: var(--palette--#{$color-swatch});
     }
   }
+
+  @include hb-traditional {
+    @if ($important) {
+      // scss-lint:disable ImportantRule
+      // Fallback for browsers that do not support CSS variables
+      #{$property}: hb-get-pairing-color($color-swatch, $hb-traditional-default, $ht-traditional-pairings) !important;
+
+      // All modern browsers that support CSS variables
+      #{$property}: var(--palette--#{$color-swatch}) !important;
+      // scss-lint:enable ImportantRule
+    } @else {
+      // Fallback for browsers that do not support CSS variables
+      #{$property}: hb-get-pairing-color($color-swatch, $hb-traditional-default, $ht-traditional-pairings);
+
+      // All modern browsers that support CSS variables
+      #{$property}: var(--palette--#{$color-swatch});
+    }
+  }
 }
 
 @mixin hb-global-color($property, $color-swatch, $important: false) {
@@ -29,6 +47,16 @@
       #{$property}: hb-get-global-color($color-swatch, $hc-colorful-globals) !important;
     } @else {
       #{$property}: hb-get-global-color($color-swatch, $hc-colorful-globals);
+    }
+  }
+
+  @include hb-traditional {
+    @if ($important) {
+      // scss-lint:disable ImportantRule
+      #{$property}: hb-get-global-color($color-swatch, $ht-traditional-globals) !important;
+      // scss-lint:enable ImportantRule
+    } @else {
+      #{$property}: hb-get-global-color($color-swatch, $ht-traditional-globals);
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.tables.scss
@@ -7,11 +7,10 @@
   border-collapse: collapse;
   font-size: hb-calculate-rems(13px);
   text-align: left;
+  border: $hb-thin-border;
+  @include hb-global-color('border-color', 'gray-medium');
 
   @include hb-colorful {
-    border: $hb-thin-border;
-    @include hb-global-color('border-color', 'gray-medium');
-
     .hb-local-footer--dark & {
       @include hb-global-color('color', 'black');
       @include hb-global-color('background-color', 'white');
@@ -27,50 +26,60 @@
 @mixin table-heading {
   position: sticky;
   top: 0;
+  @include hb-global-color('border-color', 'white');
+
+  a {
+    &:hover,
+    &:focus {
+      @include hb-global-color('color', 'white');
+      box-shadow: none;
+    }
+  }
 
   @include hb-colorful {
-    @include hb-global-color('border-color', 'white');
-
     a:not([class]) {
       @include hb-pairing-color('color', 'secondary-highlight');
+    }
+  }
 
-      &:hover,
-      &:focus {
-        @include hb-global-color('color', 'white');
-        box-shadow: none;
-      }
+  @include hb-traditional {
+    a:not([class]) {
+      @include hb-pairing-color('color', 'secondary');
     }
   }
 }
 
 // Table Rows
 @mixin table-head-row {
+  text-transform: uppercase;
+
   @include hb-colorful {
     // set themed color for header background color table variable
     @include hb-pairing-color('background-color', 'primary');
     @include hb-global-color('color', 'white');
     font-weight: hb-theme-font-weight(bold);
-    text-transform: uppercase;
 
     .hb-local-footer--dark & {
       @include hb-pairing-color('background-color', 'secondary-darken-12');
     }
   }
+
+  @include hb-traditional {
+    // set themed color for header background color table variable
+    @include hb-pairing-color('background-color', 'primary');
+    @include hb-global-color('color', 'white');
+    font-weight: hb-theme-font-weight(semibold);
+  }
 }
 
 @mixin table-row {
-  @include hb-colorful {
-    @include hb-global-color('background-color', 'gray-light');
-  }
+  @include hb-global-color('background-color', 'gray-light');
 }
 
 // Table Data
 @mixin table-data {
   padding: hb-calculate-rems(16px);
   vertical-align: top;
-
-  @include hb-colorful {
-    border: $hb-thin-border;
-    @include hb-global-color('border-color', 'gray-medium');
-  }
+  border: $hb-thin-border;
+  @include hb-global-color('border-color', 'gray-medium');
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -21,6 +21,18 @@
       font-size: hb-calculate-rems(48px);
     }
   }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--serif;
+    font-weight: hb-theme-font-weight(regular);
+    font-size: hb-calculate-rems(58px);
+    line-height: 117%;
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(40px);
+      line-height: 127%;
+    }
+  }
 }
 
 @mixin hb-heading-2 {
@@ -33,11 +45,35 @@
       font-size: hb-calculate-rems(38px);
     }
   }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--serif;
+    font-weight: hb-theme-font-weight(regular);
+    font-size: hb-calculate-rems(48px);
+    line-height: 112%;
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(33px);
+      line-height: 125%;
+    }
+  }
 }
 
 @mixin hb-heading-3 {
   @include hb-colorful {
     @include hb-block-heading;
+  }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--serif;
+    font-weight: hb-theme-font-weight(regular);
+    font-size: hb-calculate-rems(38px);
+    line-height: 110%;
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(27px);
+      line-height: 109%;
+    }
   }
 }
 
@@ -47,6 +83,17 @@
     font-size: hb-calculate-rems(20px);
     line-height: 122%;
   }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--serif;
+    font-weight: hb-theme-font-weight(regular);
+    font-size: hb-calculate-rems(32px);
+    line-height: 121%;
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(22px);
+    }
+  }
 }
 
 @mixin hb-heading-5 {
@@ -55,14 +102,28 @@
     font-size: hb-calculate-rems(18px);
     line-height: 124%;
   }
+
+  @include hb-traditional {
+    font-family: $hb-traditional-font--serif;
+    font-weight: hb-theme-font-weight(regular);
+    font-size: hb-calculate-rems(20px);
+    line-height: 117%;
+  }
 }
 
 @mixin hb-heading-6 {
+  text-transform: uppercase;
+
   @include hb-colorful {
-    text-transform: uppercase;
     font-weight: hb-theme-font-weight(semibold);
     font-size: hb-calculate-rems(16px);
     line-height: 128%;
+  }
+
+  @include hb-traditional {
+    font-weight: hb-theme-font-weight(semibold);
+    font-size: hb-calculate-rems(16px);
+    line-height: 117%;
   }
 }
 
@@ -82,22 +143,25 @@
     font-size: hb-calculate-rems(15px);
     line-height: 131%;
   }
+
+  @include hb-traditional {
+    text-transform: uppercase;
+    font-weight: hb-theme-font-weight(semibold);
+    font-size: hb-calculate-rems(15px);
+    line-height: 131%;
+  }
 }
 
 @mixin hb-body--small {
-  @include hb-colorful {
-    font-weight: hb-theme-font-weight(regular);
-    font-size: hb-calculate-rems(16px);
-    line-height: 122%;
-  }
+  font-weight: hb-theme-font-weight(regular);
+  font-size: hb-calculate-rems(16px);
+  line-height: 122%;
 }
 
 @mixin hb-body--medium {
-  @include hb-colorful {
-    font-weight: hb-theme-font-weight(regular);
-    font-size: hb-calculate-rems(18px);
-    line-height: 127%;
-  }
+  font-weight: hb-theme-font-weight(regular);
+  font-size: hb-calculate-rems(18px);
+  line-height: 127%;
 }
 
 @mixin hb-link--hover-style($box-shadow-color, $border-color) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_color-pairings.scss
@@ -1,4 +1,4 @@
-// Generate Color Palette Classes
+// Generate Color Palette Classes for Colorful
 @each $palette, $color-swatches in $hc-colorful-pairings {
   // These are the classes that update the CSS --palette variable.
   // They should be applied to the parent element.
@@ -23,5 +23,18 @@
     --palette--tertiary-reversed: #{hb-get-pairing-color("tertiary-reversed", $palette, $hc-colorful-pairings)};
     --palette--tertiary-reversed-darken-10: #{hb-get-pairing-color("tertiary-reversed-darken-10", $palette, $hc-colorful-pairings)};
     --palette--tertiary-darken-20: #{hb-get-pairing-color("tertiary-darken-20", $palette, $hc-colorful-pairings)};
+  }
+}
+
+// Generate Color Palette Classes for Traditional
+@each $palette, $color-swatches in $ht-traditional-pairings {
+  // These are the classes that update the CSS --palette variable.
+  // They should be applied to the parent element.
+  // Note: If a ht-pairing- class is not applied, ht-pairing-default will apply as the default / fallback color pairing.
+  .ht-pairing-#{$palette} {
+    // BASE
+    --palette--primary: #{hb-get-pairing-color("primary", $palette, $ht-traditional-pairings)};
+    --palette--secondary: #{hb-get-pairing-color("secondary", $palette, $ht-traditional-pairings)};
+    --palette--tertiary: #{hb-get-pairing-color("tertiary", $palette, $ht-traditional-pairings)};
   }
 }

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
@@ -1,4 +1,4 @@
-@include describe('HB Color Pairing Function') {
+@include describe('HB Colorful Color Pairing Function') {
 
   // OCEAN
   @include describe('When given a valid key value,') {
@@ -54,7 +54,7 @@
   }
 }
 
-@include describe('HB Global Color Function') {
+@include describe('HB Colorful Global Color Function') {
 
   // GRAY
   @include describe('When given a valid key value,') {
@@ -63,6 +63,51 @@
       @include it('returns the Colorful Global Gray.') {
         $test: hb-get-global-color('gray', $hc-colorful-globals);
         $expect: #b6b1a9;
+
+        @include assert-equal($test, $expect, 'The global color value gray either does not match or does not exist.');
+      }
+    }
+  }
+}
+
+@include describe('HB Traditional Color Pairing Function') {
+
+  // DEFAULT
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Traditional Default palette.') {
+        $test: hb-get-pairing-color('primary', 'default', $ht-traditional-pairings);
+        $expect: #8c1515;
+
+        @include assert-equal($test, $expect, 'The Default color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
+
+  // LIGHT
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Traditional Light palette.') {
+        $test: hb-get-pairing-color('primary', 'light', $ht-traditional-pairings);
+        $expect: #2F2424;
+
+        @include assert-equal($test, $expect, 'The Light color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
+}
+
+@include describe('HB Traditional Global Color Function') {
+
+  // GRAY
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-global-color() function') {
+      @include it('returns the Traditional Global Gray.') {
+        $test: hb-get-global-color('gray', $ht-traditional-globals);
+        $expect: #2F2424;
 
         @include assert-equal($test, $expect, 'The global color value gray either does not match or does not exist.');
       }

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_mixins.color-pairings.scss
@@ -1,11 +1,11 @@
 // Describe what you're testing
 @include describe('Color Pairing mixin') {
 
-  // Default Colorful
+  // Default Colorful Pairing - Ocean
   // Other color pairings cannot be tested as the CSS variables
   // for other pairing are only set via a class applied to
   // the HTML tag.
-  @include describe('hb-pairing-color() mixin') {
+  @include describe('hb-pairing-color() mixin for the Colorful Theme') {
 
     @include it('returns the property and value for a color pairing') {
       @include assert {
@@ -18,12 +18,32 @@
       }
     }
   }
+
+  // Default Traditional Pairing - Default
+  // Other color pairings cannot be tested as the CSS variables
+  // for other pairing are only set via a class applied to
+  // the HTML tag.
+  @include describe('hb-pairing-color() mixin for the Traditional Theme') {
+    $hb-current-theme: 'traditional' !global;
+
+    @include it('returns the property and value for a color pairing') {
+      @include assert {
+        @include output {
+          @include hb-pairing-color('color', 'primary');
+        }
+        @include contains {
+          color: #8c1515;
+        }
+      }
+    }
+  }
 }
 
 @include describe('Global colors mixin') {
 
   // Global colors
-  @include describe('hb-global-color() mixin') {
+  @include describe('hb-global-color() mixin for the Colorful Theme') {
+    $hb-current-theme: 'colorful' !global;
 
     @include it('returns the property and value for a global color') {
       @include assert {
@@ -32,6 +52,21 @@
         }
         @include contains {
           color: #413e39;
+        }
+      }
+    }
+  }
+
+  @include describe('hb-global-color() mixin for the Traditional Theme') {
+    $hb-current-theme: 'traditional' !global;
+
+    @include it('returns the property and value for a global color') {
+      @include assert {
+        @include output {
+          @include hb-global-color('color', 'gray');
+        }
+        @include contains {
+          color: #2f2424;
         }
       }
     }

--- a/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
+++ b/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
@@ -2,3 +2,5 @@ brand_bar_variant_classname: default
 lockup:
   option: default
 global_footer_variant_classname: default
+local_footer_variant_classname: default
+theme_color_pairing: default

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.theme
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.theme
@@ -2,5 +2,31 @@
 
 /**
  * @file
- * Functions to support theming in the HumSci Airy theme.
+ * Functions to support theming in the HumSci Traditional theme.
  */
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Prepares variables for the html.html.twig template.
+ */
+function humsci_traditional_preprocess_html(&$vars) {
+
+  // Theme color pairing setting to set the way the Traditional theme will appear.
+  $color_pairing = theme_get_setting('theme_color_pairing');
+  if ($color_pairing) {
+    // Set html_attributes for html DOM element
+    $vars['html_attributes']->addClass('ht-pairing-' . $color_pairing);
+  }
+}
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function humsci_traditional_preprocess_page(&$vars) {
+  // Variant setting for the local footer.
+  $lfv = theme_get_setting('local_footer_variant_classname');
+  if ($lfv) {
+    $vars['local_footer_variant_classname'] = 'hb-local-footer--' . $lfv;
+  }
+}

--- a/docroot/themes/humsci/humsci_traditional/theme-settings.php
+++ b/docroot/themes/humsci/humsci_traditional/theme-settings.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Provides an additional config form for theme settings.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+// Set theme name to use in the key values.
+$theme_name = \Drupal::theme()->getActiveTheme()->getName();
+
+/**
+ * Implements hook_form_system_theme_settings_alter().
+ *
+ * Form override for theme settings.
+ */
+function humsci_traditional_form_system_theme_settings_alter(array &$form, FormStateInterface $form_state) {
+  // Traditional theme color pairing setting
+  // theme_color_pairing
+  $form['options_settings']['humsci_traditional_color_pairing'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Color Pairing'),
+  ];
+
+  $form['options_settings']['humsci_traditional_color_pairing']['theme_color_pairing'] = [
+    '#type' => 'select',
+    '#title' => t('Color Pairing'),
+    '#options' => [
+      'ocean' => t('Default'),
+      'mountain' => t('Light')
+    ],
+    '#default_value' => theme_get_setting('theme_color_pairing'),
+  ];
+
+  // Local Footer
+  $form['options_settings']['humsci_traditional_local_footer'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Local Footer Settings'),
+  ];
+
+  $form['options_settings']['humsci_traditional_local_footer']['local_footer_variant_classname'] = [
+    '#type' => 'select',
+    '#title' => t('Local Footer Variant'),
+    '#options' => [
+      'default' => '- Default -',
+      'dark' => t('Dark'),
+    ],
+    '#default_value' => theme_get_setting('local_footer_variant_classname'),
+  ];
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Humsci Traditional theme research and foundation.

- Set up new humsci traditional color pairing functions, base classes and CSS custom properties, and Sass-true specs.
- Added in fonts used in humsci traditional, as well as mixins for basic typography, like headings and body fonts.
- Added theme PHP settings and config for humsci traditional to enable setting a local footer and theme pairing setting (this is effectively applying a ‘ht-traditional-default’ class to the HTML element on the page).
- Did a proof of concept on how simple it was to get something like the table pattern looking good in the humsci traditional theme.


## Steps to Test
1. Is there anything else crucial missing for traditional theme development?

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
