### PR TITLE
Fix: (STN-315):  lockup word break

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_masthead.scss
@@ -14,7 +14,6 @@
     &__line2,
     &__line3,
     &__line4 {
-      word-break: break-all;
       line-height: 1em;
     }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
word break CSS issue: 
- Revert to default Decanter behavior as I think that's for the best

## Steps to Test
1. Ensure `npm run test` works in humsci basic
2. check the lockup with different and longer lengths of words and make sure it behaves nicely down to 320px wide or so.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
