### PR TITLE
fix(STN-295): Basic Page New Width Config

### DIFF
--- a/config/default/core.entity_view_display.node.hs_basic_page.default.yml
+++ b/config/default/core.entity_view_display.node.hs_basic_page.default.yml
@@ -20,8 +20,8 @@ third_party_settings:
         layout_id: three_column
         layout_settings:
           label: ''
-          section_width: ''
-          region_widths: ''
+          section_width: hs-full-width
+          region_widths: center
         components:
           13b1ba92-73e2-42fc-8cd2-e4743faf8899:
             uuid: 13b1ba92-73e2-42fc-8cd2-e4743faf8899


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
On a fresh site install, the layout settings for the basic node page were not set to full width, even though it appeared they were.

We never exported the default new layout builder setting for the basic page after we changed the value. 

Originally, the full width page setting was equal to null or an empty string, but in a PR a few weeks/months ago we changed it to 'hs-full-width'. 

On a fresh install, the default value was installed as '' (empty string) so no default width was selected for a basic page.

TODO - we can delete this old branch trying to fix this issue: https://github.com/SU-HSDO/suhumsci/compare/sparkbox-sprint-16...fix-295--hero-db?expand=1

## Steps to Test
1. Ensure `npm run test` passes in humsci_basic
2. Pull down this branch and do a fresh local site sync. Go to add a new basic page, and a new hero section. (DO NOT touch any layout settings). Save the page and you should see the hero take up the full width by default.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
