### PR TITLE
STN: 173  Simplify Templates

### DIFF
--- a/docroot/themes/humsci/humsci_basic/patterns/date-stacked-horizontal-card/date-stacked-horizontal-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/date-stacked-horizontal-card/date-stacked-horizontal-card.html.twig
@@ -7,15 +7,13 @@
 %}
 
 {%- set attributes = attributes.addClass(classes) -%}
-{%- set url = url|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><img>')|trim -%}
 
 <div{{ attributes }}>
 
   {% if image or month or day %}
     <div class="hb-card__graphics">
 
-      {% if has_image is not empty %}
+      {% if image %}
         <div class="hb-card__img">
           {{ image }}
         </div>
@@ -52,24 +50,24 @@
           <div class="hb-card__subcontent-detail hb-card__icon hb-card__icon--date">
             {% if time['#sources'] %}
               {% for field in time['#sources'] %}
-                {% if field|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+                {% if field %}
                   {{ field }}
                 {% endif %}
               {% endfor %}
             {% else %}
-              {% if time|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+              {% if time %}
                 {{ time }}
               {% endif %}
             {% endif %}
           </div>
 
-          {% if location|render|striptags('<drupal-render-placeholder><a>')|trim %}
+          {% if location %}
             <div class="hb-card__subcontent-detail hb-card__icon hb-card__icon--location">
               {{ location }}
             </div>
           {% endif %}
 
-          {% if speaker|render|striptags('<drupal-render-placeholder><a>')|trim %}
+          {% if speaker %}
             <div class="hb-card__subcontent-detail hb-card__icon hb-card__icon--speaker">
               {{ speaker }}
             </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
@@ -1,13 +1,11 @@
 {% set attributes = attributes.addClass('hb-card') %}
-{%- set url = url|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><img>')|trim -%}
 
 <div{{ attributes }}>
 
   {% if image or month or day %}
     <div class="hb-card__graphics">
 
-      {% if has_image is not empty %}
+      {% if image %}
         <div class="hb-card__img">
           {{ image }}
         </div>
@@ -44,14 +42,14 @@
 
         {% if time['#sources'] %}
           {% for field in time['#sources'] %}
-            {% if field|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+            {% if field %}
               <div class="hb-card__subcontent-item">
                 {{ field }}
               </div>
             {% endif %}
           {% endfor %}
         {% else %}
-          {% if time|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+          {% if time %}
             <div class="hb-card__subcontent-item">
               {{ time }}
             </div>
@@ -61,13 +59,13 @@
       </div>
     {% endif %}
 
-    {% if location|render|trim %}
+    {% if location %}
       <div class="hb-card__location">
         {{ location }}
       </div>
     {% endif %}
 
-    {% if speaker|render|trim %}
+    {% if speaker %}
       <div class="hb-card__highlighted">
         {{ speaker }}
       </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/horizontal-card/horizontal-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/horizontal-card/horizontal-card.html.twig
@@ -6,12 +6,10 @@
  %}
 
 {%- set attributes = attributes.addClass(classes) -%}
-{%- set url = url|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><span><div><picture><source><img>')|trim -%}
 
 <div{{ attributes }}>
 
-  {% if has_image is not empty %}
+  {% if image %}
     <div class="hb-card__img hb-card__graphics">
       {{ image }}
     </div>
@@ -28,21 +26,19 @@
       </div>
     {% endif %}
 
-    {% if date or time|render|trim or location|render|trim %}
-      {#  create array and cycle through with pipes? #}
-      {# /set will probably work - not sure abt arrays #}
+    {% if date or time or location %}
       {% set general_variants = {'date': date, 'time': time, 'location': location} %}
 
       <div class="hb-card__subcontent">
         {% for key, variant in general_variants %}
-          {% if variant|render|striptags('<drupal-render-placeholder><a>')|trim %}
+          {% if variant %}
             <div class="hb-card__subcontent-item">{{ variant }}</div>
           {% endif %}
         {% endfor %}
       </div>
     {% endif %}
 
-    {% if speaker|render|trim %}
+    {% if speaker %}
       <div class="hb-card__highlighted">
         {{ speaker }}
       </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/structured-card/structured-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/structured-card/structured-card.html.twig
@@ -7,12 +7,9 @@
 %}
 
 {%- set attributes = attributes.addClass(classes) -%}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><span><div><picture><source><img>')|trim -%}
-{%- set has_columns = columns|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set has_categories = category|render|striptags('<drupal-render-placeholder>')|trim -%}
 
 <div{{ attributes }}>
-  {% if has_image is not empty %}
+  {% if image %}
     <div class="hb-card__img">{{ image }}</div>
   {% endif %}
 
@@ -31,12 +28,12 @@
       <div class="hb-card__description">{{ description }}</div>
     {% endif %}
 
-    {% if has_columns is not empty %}
+    {% if columns %}
 
       {% if columns['#sources'] %}
         <div class="hb-card__columns">
           {% for columns_field in columns['#sources'] %}
-            {% if columns_field|render|striptags('<drupal-render-placeholder>')|trim %}
+            {% if columns_field %}
               {{ columns_field }}
             {% endif %}
           {% endfor %}
@@ -47,12 +44,12 @@
 
     {% endif %}
 
-    {% if has_categories is not empty %}
+    {% if category %}
 
       {% if category['#sources'] %}
         <div class="hb-card__category">
           {% for category_field in category['#sources'] %}
-            {% if category_field|render|striptags('<drupal-render-placeholder>')|trim %}
+            {% if category_field %}
               {{ category_field }}
             {% endif %}
           {% endfor %}

--- a/docroot/themes/humsci/humsci_basic/patterns/table-pattern/table-pattern.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/table-pattern/table-pattern.html.twig
@@ -62,7 +62,7 @@
   </div>
 </div>
 
-  {% if caption | render | striptags | trim %}
+  {% if caption %}
     <div class="hb-table-pattern__caption">
       {{ caption }}
     </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/vertical-card/vertical-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/vertical-card/vertical-card.html.twig
@@ -1,10 +1,8 @@
 {%- set attributes = attributes.addClass('hb-card') -%}
-{%- set url = url|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><span><div><picture><source><img>')|trim -%}
 
 <div{{ attributes }}>
 
-  {% if has_image is not empty %}
+  {% if image %}
     <div class="hb-card__img hb-card__graphics">
       {{ image }}
     </div>
@@ -26,14 +24,14 @@
 
         {% if subcontent['#sources'] %}
           {% for field in subcontent['#sources'] %}
-            {% if field|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+            {% if field %}
               <div class="hb-card__subcontent-item">
                 {{ field }}
               </div>
             {% endif %}
           {% endfor %}
         {% else %}
-          {% if time|render|striptags('<drupal-render-placeholder><a>')|trim  %}
+          {% if time %}
             <div class="hb-card__subcontent-item">
               {{ subcontent }}
             </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/vertical-link-card/vertical-link-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/vertical-link-card/vertical-link-card.html.twig
@@ -1,9 +1,7 @@
 {% set attributes = attributes.addClass('hb-vertical-linked-card') %}
-{%- set has_image = image|render|striptags('<drupal-render-placeholder><img>')|trim -%}
-{%- set has_description = description|render|striptags('<drupal-render-placeholder><img>')|trim -%}
 
 <div{{ attributes }}>
-  {% if has_image %}
+  {% if image %}
     <div class="hb-vertical-linked-card__img">
       {{ image }}
     </div>
@@ -11,11 +9,11 @@
 
   {% if title %}
     <h2 class="hb-vertical-linked-card__title">
-      {{ title|render|striptags|trim|raw }}
+      {{ title }}
     </h2>
   {% endif %}
 
-  {% if has_description %}
+  {% if description %}
     <div class="hb-vertical-linked-card__description">
       {{ description }}
     </div>


### PR DESCRIPTION
# [STN-173](https://sparkbox.atlassian.net/browse/STN-350) READY FOR REVIEW

## Summary
Simplify templates as a result of the `empty fields` bugfix.

## Need Review By (Date)
5/29

## Urgency
medium

## Steps to Test
1. In the CLI, run `npm run test` and confirm all of the Sass tests pass.
<br>

2. In order to review the changes in this PR you need the [patch created by Mike](https://github.com/SU-HSDO/suhumsci/pull/587) for the `ui_patterns` module.
* In your text editor, locate the `ui_patterns` module directory and delete it. `docroot/modules/contrib/ui_patterns`.
* In your CLI, run `lando composer install`. This will reinstall the `ui_patterns` module with the patch.
<br>

3. Now that the patch is available, confirm the Drupal settings which hide empty fields work as expected. There are two ways to hide empty fields in Drupal.
    1. Go to http://economics.suhumsci.loc/about/news. Click on the contextual link to edit the list `view`.  Under `Format` > Click on Show: `Settings`. Check the box for `Hide empty fields`. Apply & Save. _NOTE_ Do not use this on date stacked cards. It removes the decorative arrow link.

    ![option 1 check on format show settings](https://user-images.githubusercontent.com/12678977/83181851-7940ac00-a0f3-11ea-9052-6fbb645b00ca.png)

    2. When editing a `view`, you can individually set fields to hide when there are no results. Under Fields > Content: News Image (or whichever field you need to hide if empty) > No Results Behavior > check the box for `Hide if empty`

    ![option 2 check no results behavior hide if empty](https://user-images.githubusercontent.com/12678977/83182323-2f0bfa80-a0f4-11ea-9224-fcc0be707094.png)

Use the dev inspector tools to confirm `if` statements are working correctly. The following is a screenshot of two date stacked vertical cards, one with and one without an image.

<img width="799" alt="comparison" src="https://user-images.githubusercontent.com/12678977/83183469-db021580-a0f5-11ea-83fb-1301337e45ea.png">

<br>
4. Confirm the patch works correctly by reviewing the following templates:

- [x] Date stacked horizontal card
_**Lindsay**: This one concerns me a bit that it acts differently. Maybe we can come back to this bug at some point.
I would like to understand the difference a bit better at least._

* http://economics.suhumsci.loc/seminars-workshops/upcoming-seminars-and-events
View > Upcoming Seminars and Workshops display. Visually it looks fine but empty fields are rendering. You will need to update the pattern settings or date, time, location, and speaker fields No Results Behavior to check Hide if empty
* http://economics.suhumsci.loc/qa/date-stacked-horizontal-card The view displayed on this page must be updated! In the view go to Format > Show: Settings > check Hide empty fields

- [x] Date stacked vertical card
_**Lindsay**: This one concerns me a bit that it acts differently. Maybe we can come back to this bug at some point.
I would like to understand the difference a bit better at least_

* http://economics.suhumsci.loc 
Bottom of page under This week’s events, seminars, and graduate student workshops
Need to check no results box for images, date, date-time, location, speaker, and description (body). Do not check Format Show: Settings > hide empty fields as it makes the arrow disappear
If you make changes to a field, such as removing the location. Make sure all characters, including spaces, have been removed.

- [x] Vertical card
* http://economics.suhumsci.loc
Vertical cards are located under Spotlights
Postcards located under Welcome to the Department of Economics

- [x] Horizontal card
* Views → http://economics.suhumsci.loc/about/news
Page 3 has a horizontal card with no image.
* Postcards → http://economics.suhumsci.loc/qa/qa-cards 

- [x] Structured card
* http://economics.suhumsci.loc/people/faculty  

- [x] Vertical Linked Card
* http://economics.suhumsci.loc/qa/qa-cards  _so this is fine as a postcard, but this page: http://economics.suhumsci.loc/research/research-fields appears broken_ 


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
