### PR TITLE
STN-350: Status Messages

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
@@ -5,7 +5,6 @@ package: 'Humanities & Sciences'
 core: 8.x
 core_version_requirement: ^8
 libraries:
-  - humsci_basic/no-js
   - humsci_basic/base
 
 regions:
@@ -14,6 +13,7 @@ regions:
   search: Search
   menu: Menu
   help: Help
+  highlighted: Highlighted
   content: Content
   footer: Footer
   page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
@@ -3,3 +3,4 @@ base:
     scripts/build/scripts.js: {}
   dependencies:
     - core/modernizr
+    - classy/messages

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -170,6 +170,7 @@
   'utilities/wysiwyg-editor',
   'utilities/stretch-vertical-linked-card',
   'utilities/admin.contextual-links',
+  'utilities/admin.messages',
   'utilities/local-tasks', // Drupal admin task list
   'utilities/general',
   'utilities/lists',

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.messages.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.messages.scss
@@ -1,0 +1,3 @@
+.messages {
+  margin-top: hb-calculate-rems(40px);
+}

--- a/docroot/themes/humsci/humsci_basic/templates/core/status-messages.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/core/status-messages.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Theme override for status messages.
+ *
+ * Displays status, error, and warning messages, grouped by type.
+ *
+ * An invisible heading identifies the messages for assistive technology.
+ * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
+ * for info.
+ *
+ * Add an ARIA label to the contentinfo area so that assistive technology
+ * user agents will better describe this landmark.
+ *
+ * Available variables:
+ * - message_list: List of messages to be displayed, grouped by type.
+ * - status_headings: List of all status types.
+ * - display: (optional) May have a value of 'status' or 'error' when only
+ *   displaying messages of that specific type.
+ * - attributes: HTML attributes for the element, including:
+ *   - class: HTML classes.
+ *
+ * @see template_preprocess_status_messages()
+ */
+#}
+{% for type, messages in message_list %}
+  {%
+    set classes = [
+      'messages',
+      'messages--' ~ type,
+    ]
+  %}
+  <div{{ attributes.addClass(classes) }}>
+    {% if type == 'error' %}
+      <div role="alert">
+    {% endif %}
+      {% if status_headings[type] %}
+        <h2 class="visually-hidden">{{ status_headings[type] }}</h2>
+      {% endif %}
+      {% if messages|length > 1 %}
+        <ul class="messages__list">
+          {% for message in messages %}
+            <li class="messages__item">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        {{ messages|first }}
+      {% endif %}
+    {% if type == 'error' %}
+      </div>
+    {% endif %}
+  </div>
+{% endfor %}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -20,9 +20,10 @@
   </section>
 </header>
 
-{% if page.help %}
-  <div>
+{% if page.help or page.highlighted %}
+  <div id="help-region" class="hb-page-width">
     {{ page.help }}
+    {{ page.highlighted }}
   </div>
 {% endif %}
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request ensures that Drupal status messages display on the humsci_basic theme. Status messages are styled importing the `classy/messages` dependency.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Run `npm test` and ensure there are no failing tests
1. Run `npm start` to build assets
1. Check that there is no extra spacing above 
    <img width="1322" alt="Home_Page___Department_of_Economics" src="https://user-images.githubusercontent.com/2486846/83168765-011cbb00-a0e0-11ea-9c1f-cd1ec6525aea.png">
1. Clear the cache by opening the Devel menu and clicking _Clear Cache_
    <img width="1324" alt="Home_Page___Department_of_Economics" src="https://user-images.githubusercontent.com/2486846/83168937-4345fc80-a0e0-11ea-9434-cc9d818ed38a.png">
    Confirm that a styled status message pops up
    <img width="1325" alt="Home_Page___Department_of_Economics" src="https://user-images.githubusercontent.com/2486846/83169032-6d97ba00-a0e0-11ea-9aac-179fa16c197e.png">

1. Logged out pages should look unchanged


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
