### PR TITLE
feat(hackday) : Hummingbird Color Pairing for Traditional 🐦

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
@@ -5,7 +5,6 @@ package: 'Humanities & Sciences'
 core: 8.x
 core_version_requirement: ^8
 libraries:
-  - humsci_basic/no-js
   - humsci_basic/base
 
 regions:
@@ -14,6 +13,7 @@ regions:
   search: Search
   menu: Menu
   help: Help
+  highlighted: Highlighted
   content: Content
   footer: Footer
   page_bottom: 'Page bottom'

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
@@ -3,3 +3,4 @@ base:
     scripts/build/scripts.js: {}
   dependencies:
     - core/modernizr
+    - classy/messages

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -170,6 +170,7 @@
   'utilities/wysiwyg-editor',
   'utilities/stretch-vertical-linked-card',
   'utilities/admin.contextual-links',
+  'utilities/admin.messages',
   'utilities/local-tasks', // Drupal admin task list
   'utilities/general',
   'utilities/lists',

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_card.scss
@@ -288,6 +288,10 @@
       padding: 0;
       top: 0;
       left: 0;
+
+      .ht-pairing-hummingbird & {
+        @include hb-pairing-color('color', 'tertiary');
+      }
     }
 
     &:only-child {
@@ -305,6 +309,10 @@
       font-size: hb-calculate-rems(14px);
       padding: hb-calculate-rems(10px);
       width: 100%;
+
+      .ht-pairing-hummingbird & {
+        @include hb-pairing-color('background-color', 'tertiary-reversed');
+      }
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
@@ -20,6 +20,10 @@
   @include hb-traditional {
     @include hb-pairing-color('background-color', 'tertiary-reversed');
     margin-bottom: hb-spacing-width();
+
+    .ht-pairing-hummingbird & {
+      @include hb-pairing-color('background-color', 'secondary-highlight');
+    }
   }
 
   &__img {

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_details.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_details.scss
@@ -12,6 +12,13 @@ summary {
   @include hb-pairing-color('background-color', 'secondary');
   @include hb-global-color('color', 'white');
 
+  @include hb-traditional {
+    .ht-pairing-hummingbird & {
+      @include hb-pairing-color('background-color', 'tertiary');
+      @include hb-pairing-color('border-color', 'tertiary');
+    }
+  }
+
   // This is to position everything correctly in browsers that do not support the
   // -webkit-details-marker pseudo element
   display: flex;

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -40,20 +40,20 @@ $ht-traditional-pairings: (
     "tertiary-darken-20": darken(#b1040e, 20%)
   ),
   "hummingbird": (
-    "primary": #600e0e,
-    "secondary": hotpink,
-    "tertiary": #b1040e,
-    "primary-hero-overlay": rgba(5, 38, 44, 0.92),
-    "primary-dark": darken(#600e0e, 10%),
-    "secondary-active": #b1040e,
-    "secondary-highlight": #daebed,
-    "secondary-highlight-darken": darken(#daebed, 20%),
-    "secondary-darken-12": darken(#8c1515, 12%),
-    "tertiary-highlight": #e9f5f6,
-    "tertiary-highlight-darken-10": darken(#e9f5f6, 10%),
-    "tertiary-reversed": #daebed,
-    "tertiary-reversed-darken-10": darken(#daebed, 10%),
-    "tertiary-darken-20": darken(#b1040e, 20%)
+    "primary": #820000,
+    "secondary": #b1040e,
+    "tertiary": #4d4f53,
+    "primary-hero-overlay": rgba(75, 0, 0, 0.92),
+    "primary-dark": darken(#820000, 10%),
+    "secondary-active": #4c4f53,
+    "secondary-highlight": #f0ece6,
+    "secondary-highlight-darken": darken(#f0ece6, 5%),
+    "secondary-darken-12": darken(#b1040e, 12%),
+    "tertiary-highlight": #faf8f6,
+    "tertiary-highlight-darken-10": darken(#ffa1a7, 10%),
+    "tertiary-reversed": #ff6972,
+    "tertiary-reversed-darken-10": darken(#b6b1a9, 10%),
+    "tertiary-darken-20": darken(#e64a53, 20%)
   )
 );
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -38,6 +38,22 @@ $ht-traditional-pairings: (
     "tertiary-reversed": #daebed,
     "tertiary-reversed-darken-10": darken(#daebed, 10%),
     "tertiary-darken-20": darken(#b1040e, 20%)
+  ),
+  "hummingbird": (
+    "primary": #600e0e,
+    "secondary": hotpink,
+    "tertiary": #b1040e,
+    "primary-hero-overlay": rgba(5, 38, 44, 0.92),
+    "primary-dark": darken(#600e0e, 10%),
+    "secondary-active": #b1040e,
+    "secondary-highlight": #daebed,
+    "secondary-highlight-darken": darken(#daebed, 20%),
+    "secondary-darken-12": darken(#8c1515, 12%),
+    "tertiary-highlight": #e9f5f6,
+    "tertiary-highlight-darken-10": darken(#e9f5f6, 10%),
+    "tertiary-reversed": #daebed,
+    "tertiary-reversed-darken-10": darken(#daebed, 10%),
+    "tertiary-darken-20": darken(#b1040e, 20%)
   )
 );
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -44,6 +44,11 @@
         $icon-color: hb-get-pairing-color($color, 'bluejay', $ht-traditional-pairings);
         background-image: svg(hc-get-icons($icon, $icon-color));
       }
+
+      .ht-pairing-hummingbird & {
+        $icon-color: hb-get-pairing-color($color, 'hummingbird', $ht-traditional-pairings);
+        background-image: svg(hc-get-icons($icon, $icon-color));
+      }
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.messages.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_admin.messages.scss
@@ -1,0 +1,3 @@
+.messages {
+  margin-top: hb-calculate-rems(40px);
+}

--- a/docroot/themes/humsci/humsci_basic/templates/core/status-messages.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/core/status-messages.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Theme override for status messages.
+ *
+ * Displays status, error, and warning messages, grouped by type.
+ *
+ * An invisible heading identifies the messages for assistive technology.
+ * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
+ * for info.
+ *
+ * Add an ARIA label to the contentinfo area so that assistive technology
+ * user agents will better describe this landmark.
+ *
+ * Available variables:
+ * - message_list: List of messages to be displayed, grouped by type.
+ * - status_headings: List of all status types.
+ * - display: (optional) May have a value of 'status' or 'error' when only
+ *   displaying messages of that specific type.
+ * - attributes: HTML attributes for the element, including:
+ *   - class: HTML classes.
+ *
+ * @see template_preprocess_status_messages()
+ */
+#}
+{% for type, messages in message_list %}
+  {%
+    set classes = [
+      'messages',
+      'messages--' ~ type,
+    ]
+  %}
+  <div{{ attributes.addClass(classes) }}>
+    {% if type == 'error' %}
+      <div role="alert">
+    {% endif %}
+      {% if status_headings[type] %}
+        <h2 class="visually-hidden">{{ status_headings[type] }}</h2>
+      {% endif %}
+      {% if messages|length > 1 %}
+        <ul class="messages__list">
+          {% for message in messages %}
+            <li class="messages__item">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        {{ messages|first }}
+      {% endif %}
+    {% if type == 'error' %}
+      </div>
+    {% endif %}
+  </div>
+{% endfor %}

--- a/docroot/themes/humsci/humsci_basic/templates/page.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/page.html.twig
@@ -20,9 +20,10 @@
   </section>
 </header>
 
-{% if page.help %}
-  <div>
+{% if page.help or page.highlighted %}
+  <div id="help-region" class="hb-page-width">
     {{ page.help }}
+    {{ page.highlighted }}
   </div>
 {% endif %}
 

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
@@ -109,7 +109,7 @@
         // Many of the colors on the Cardinal and Blue Jay palettes are the same.
         // Test a color that is not the same between the two palettes.
         $test: hb-get-pairing-color('secondary-highlight', 'hummingbird', $ht-traditional-pairings);
-        $expect: #daebed;
+        $expect: #f0ece6;
 
         @include assert-equal($test, $expect, 'The Hummingbird color pairing primary color value either does not match or does not exist.');
       }

--- a/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/tests/sass-specs/tools/_functions.color-pairings.scss
@@ -100,6 +100,21 @@
       }
     }
   }
+
+  // HUMMINGBIRD
+  @include describe('When given a valid key value,') {
+
+    @include describe('the hb-get-pairing-color() function') {
+      @include it('returns the Traditional Hummingbird palette.') {
+        // Many of the colors on the Cardinal and Blue Jay palettes are the same.
+        // Test a color that is not the same between the two palettes.
+        $test: hb-get-pairing-color('secondary-highlight', 'hummingbird', $ht-traditional-pairings);
+        $expect: #daebed;
+
+        @include assert-equal($test, $expect, 'The Hummingbird color pairing primary color value either does not match or does not exist.');
+      }
+    }
+  }
 }
 
 @include describe('HB Traditional Global Color Function') {

--- a/docroot/themes/humsci/humsci_traditional/theme-settings.php
+++ b/docroot/themes/humsci/humsci_traditional/theme-settings.php
@@ -29,6 +29,7 @@ function humsci_traditional_form_system_theme_settings_alter(array &$form, FormS
     '#options' => [
       'cardinal' => t('Cardinal'),
       'bluejay' => t('Blue Jay'),
+      'hummingbird' => t('Hummingbird'),
     ],
     '#default_value' => theme_get_setting('theme_color_pairing'),
   ];


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
A new color pairing of `Hummingbird` for the Traditional theme.

## Screenshots
### Hero | Horizontal cards | Date Stacked Horizontal cards | Dark Local Footer
![hero](https://user-images.githubusercontent.com/12678977/83305920-a06cab80-a1cf-11ea-981d-07187c8d6d5c.png)

### Home | Vertical cards | Vertical postcards | Carousel | Vertical Linked Cards w/o image or copy | Date Stacked Vertical Cards
![home](https://user-images.githubusercontent.com/12678977/83306123-03f6d900-a1d0-11ea-9bb8-cc8339a186c7.png)

### QA Cards | Bright Brand Bar & Footer | Default Local Footer
![qa cards](https://user-images.githubusercontent.com/12678977/83306520-b169ec80-a1d0-11ea-9153-4d005463e03d.png)

### Table
![table](https://user-images.githubusercontent.com/12678977/83306995-a5caf580-a1d1-11ea-90ae-224c0ba778e5.png)

### Dark Local Footer Hover States
![dark footer hover states](https://user-images.githubusercontent.com/12678977/83307031-baa78900-a1d1-11ea-8620-80207c8aca53.png)

### Default Local Footer Hover States
![default footer hover states](https://user-images.githubusercontent.com/12678977/83307045-c004d380-a1d1-11ea-80f7-8dbde2ce3f71.png)

### Navigation
![nav](https://user-images.githubusercontent.com/12678977/83307080-d317a380-a1d1-11ea-810f-0b9da0039d68.png)

### Accordion in a Well
![accordion in a well](https://user-images.githubusercontent.com/12678977/83307092-d90d8480-a1d1-11ea-81a8-62053e370c9f.png)

### Pills
![pills](https://user-images.githubusercontent.com/12678977/83307100-df9bfc00-a1d1-11ea-820e-fb9929e90ac7.png)


