### PR TITLE
feat(STN-419): Spotlight Paragraph Type and UI Pattern

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_spotlight.default.yml
@@ -1,0 +1,57 @@
+uuid: c60d2d61-1ad3-4494-a222-bec553a857f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_body
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_image
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_link
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_title
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - allowed_formats
+    - link
+    - media_library
+    - text
+id: paragraph.hs_spotlight.default
+targetEntityType: paragraph
+bundle: hs_spotlight
+mode: default
+content:
+  field_hs_spotlight_body:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
+    type: text_textarea
+    region: content
+  field_hs_spotlight_image:
+    type: media_library_widget
+    weight: 1
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_hs_spotlight_link:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_hs_spotlight_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_form_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_spotlight.default.yml
@@ -4,7 +4,9 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_body
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_display
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_image
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_image_align
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_link
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_title
     - paragraphs.paragraphs_type.hs_spotlight
@@ -19,7 +21,7 @@ bundle: hs_spotlight
 mode: default
 content:
   field_hs_spotlight_body:
-    weight: 0
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -29,15 +31,27 @@ content:
         hide_guidelines: '0'
     type: text_textarea
     region: content
+  field_hs_spotlight_display:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_hs_spotlight_image:
     type: media_library_widget
-    weight: 1
+    weight: 2
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
+  field_hs_spotlight_image_align:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_hs_spotlight_link:
-    weight: 3
+    weight: 4
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -45,7 +59,7 @@ content:
     type: link_default
     region: content
   field_hs_spotlight_title:
-    weight: 2
+    weight: -1
     settings:
       size: 60
       placeholder: ''

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
@@ -1,0 +1,110 @@
+uuid: 2b77dd38-89be-49bc-9335-fa1474646216
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_body
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_image
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_link
+    - field.field.paragraph.hs_spotlight.field_hs_spotlight_title
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - ds
+    - field_formatter_class
+    - hs_field_helpers
+    - link
+    - smart_trim
+    - stanford_media
+third_party_settings:
+  ds:
+    layout:
+      id: pattern_spotlight
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+          variant_field: field_hs_spotlight_body
+          variant_field_values:
+            default: ''
+    regions:
+      overlay_text:
+        - field_hs_spotlight_title
+        - field_hs_spotlight_body
+        - field_hs_spotlight_link
+      image:
+        - field_hs_spotlight_image
+id: paragraph.hs_spotlight.default
+targetEntityType: paragraph
+bundle: hs_spotlight
+mode: default
+content:
+  field_hs_spotlight_body:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: 200
+      trim_type: chars
+      trim_suffix: ''
+      wrap_class: trimmed
+      more_text: More
+      more_class: more-link
+      wrap_output: false
+      more_link: false
+      trim_options:
+        text: false
+        trim_zero: false
+      summary_handler: full
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    type: smart_trim
+    region: overlay_text
+  field_hs_spotlight_image:
+    type: media_responsive_image_formatter
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      image_style: hero_with_text
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    region: image
+  field_hs_spotlight_link:
+    weight: 2
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    type: link
+    region: overlay_text
+  field_hs_spotlight_title:
+    weight: 0
+    label: hidden
+    settings:
+      tag: h2
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    type: entity_title_heading
+    region: overlay_text
+hidden:
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
@@ -70,7 +70,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      image_style: hero_with_text
+      image_style: ''
       link: false
     third_party_settings:
       field_formatter_class:

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
@@ -1,8 +1,9 @@
-uuid: 2b77dd38-89be-49bc-9335-fa1474646216
+uuid: 09aaf0b7-62f4-4455-a97c-164d22e692f8
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_body
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_display
     - field.field.paragraph.hs_spotlight.field_hs_spotlight_image
@@ -14,6 +15,7 @@ dependencies:
     - ds
     - field_formatter_class
     - hs_field_helpers
+    - layout_builder
     - link
     - smart_trim
     - stanford_media
@@ -39,10 +41,13 @@ third_party_settings:
         - field_hs_spotlight_link
       image:
         - field_hs_spotlight_image
-id: paragraph.hs_spotlight.default
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.hs_spotlight.preview
 targetEntityType: paragraph
 bundle: hs_spotlight
-mode: default
+mode: preview
 content:
   field_hs_spotlight_body:
     weight: 1
@@ -73,7 +78,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      image_style: spotlight_portrait_responsive
+      image_style: landscape_rectangle
       link: false
     third_party_settings:
       field_formatter_class:

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_carousel
     - paragraphs.paragraphs_type.hs_hero_image
+    - paragraphs.paragraphs_type.hs_spotlight
   module:
     - entity_reference_revisions
 _core:
@@ -28,6 +29,7 @@ settings:
     target_bundles:
       hs_hero_image: hs_hero_image
       hs_carousel: hs_carousel
+      hs_spotlight: hs_spotlight
     target_bundles_drag_drop:
       hs_hero_image:
         enabled: true
@@ -35,4 +37,31 @@ settings:
       hs_carousel:
         enabled: true
         weight: 10
+      hs_accordion:
+        weight: 12
+        enabled: false
+      hs_postcard:
+        weight: 15
+        enabled: false
+      hs_private_files:
+        weight: 16
+        enabled: false
+      hs_priv_text_area:
+        weight: 17
+        enabled: false
+      hs_row:
+        weight: 18
+        enabled: false
+      hs_spotlight:
+        enabled: true
+        weight: 19
+      hs_text_area:
+        weight: 20
+        enabled: false
+      hs_view:
+        weight: 21
+        enabled: false
+      hs_webform:
+        weight: 22
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_body.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_body.yml
@@ -1,0 +1,29 @@
+uuid: bc97a245-cbef-4ea2-a431-238274d71f13
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_body
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    minimal_html: minimal_html
+    basic_html: '0'
+    basic_html_without_media: '0'
+    full_html: '0'
+    plain_text: '0'
+id: paragraph.hs_spotlight.field_hs_spotlight_body
+field_name: field_hs_spotlight_body
+entity_type: paragraph
+bundle: hs_spotlight
+label: Body
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_display.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_display.yml
@@ -1,0 +1,23 @@
+uuid: 26961ab6-fe0a-466a-858c-184e9650056e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_display
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - hs_field_helpers
+id: paragraph.hs_spotlight.field_hs_spotlight_display
+field_name: field_hs_spotlight_display
+entity_type: paragraph
+bundle: hs_spotlight
+label: Display
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: default
+default_value_callback: ''
+settings: {  }
+field_type: display_mode_field

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_image.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_image.yml
@@ -1,0 +1,28 @@
+uuid: f96a6371-7d3f-4dc5-b032-db022ae0dc1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_image
+    - media.type.image
+    - paragraphs.paragraphs_type.hs_spotlight
+id: paragraph.hs_spotlight.field_hs_spotlight_image
+field_name: field_hs_spotlight_image
+entity_type: paragraph
+bundle: hs_spotlight
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_image_align.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_image_align.yml
@@ -1,0 +1,23 @@
+uuid: d5e5c70f-66a8-413d-9819-d9926cfb6813
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_image_align
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - options
+id: paragraph.hs_spotlight.field_hs_spotlight_image_align
+field_name: field_hs_spotlight_image_align
+entity_type: paragraph
+bundle: hs_spotlight
+label: 'Image Alignment'
+description: 'Allows you to the position the image to the right or left side of the Spotlight.'
+required: false
+translatable: false
+default_value:
+  -
+    value: image-right
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_link.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_link.yml
@@ -1,0 +1,23 @@
+uuid: 96b22460-1396-4c65-aa83-f62874e10a5d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_link
+    - paragraphs.paragraphs_type.hs_spotlight
+  module:
+    - link
+id: paragraph.hs_spotlight.field_hs_spotlight_link
+field_name: field_hs_spotlight_link
+entity_type: paragraph
+bundle: hs_spotlight
+label: Link
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_title.yml
+++ b/config/default/field.field.paragraph.hs_spotlight.field_hs_spotlight_title.yml
@@ -1,0 +1,19 @@
+uuid: 3f423af8-9f32-46bc-af08-3fa1db7ceca9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_spotlight_title
+    - paragraphs.paragraphs_type.hs_spotlight
+id: paragraph.hs_spotlight.field_hs_spotlight_title
+field_name: field_hs_spotlight_title
+entity_type: paragraph
+bundle: hs_spotlight
+label: Title
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.paragraph.field_hs_spotlight_body.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_body.yml
@@ -1,0 +1,19 @@
+uuid: 578056f4-2f3a-435e-ad33-5cc976dc9a1e
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_hs_spotlight_body
+field_name: field_hs_spotlight_body
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_spotlight_display.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_display.yml
@@ -1,0 +1,27 @@
+uuid: 1a219b3f-9907-44e4-a2b6-927fb3491815
+langcode: en
+status: true
+dependencies:
+  module:
+    - hs_field_helpers
+    - paragraphs
+id: paragraph.field_hs_spotlight_display
+field_name: field_hs_spotlight_display
+entity_type: paragraph
+type: display_mode_field
+settings:
+  allowed_values:
+    -
+      value: default
+      label: 'Tall Spotlight'
+    -
+      value: preview
+      label: 'Short Spotlight'
+  allowed_values_function: ''
+module: hs_field_helpers
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_spotlight_image.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_image.yml
@@ -1,0 +1,20 @@
+uuid: 9ecb3ecf-1123-46d9-9b96-58c44d38a37d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_hs_spotlight_image
+field_name: field_hs_spotlight_image
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_spotlight_image_align.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_image_align.yml
@@ -1,0 +1,27 @@
+uuid: 7fa9d6d6-e00c-4471-97c0-dc8ef94aa617
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_hs_spotlight_image_align
+field_name: field_hs_spotlight_image_align
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: image-right
+      label: 'Right Aligned'
+    -
+      value: image-left
+      label: 'Left Aligned'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_spotlight_link.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_link.yml
@@ -1,0 +1,19 @@
+uuid: 3b0aefe0-e9da-4715-b82d-fd1eedf71b84
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_hs_spotlight_link
+field_name: field_hs_spotlight_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_spotlight_title.yml
+++ b/config/default/field.storage.paragraph.field_hs_spotlight_title.yml
@@ -1,0 +1,21 @@
+uuid: 4f5d5787-953b-494c-af99-bec4c570be11
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hs_spotlight_title
+field_name: field_hs_spotlight_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/image.style.hs_spotlight_large_portrait_600x720.yml
+++ b/config/default/image.style.hs_spotlight_large_portrait_600x720.yml
@@ -1,0 +1,17 @@
+uuid: 16aa7901-053d-46b1-b325-ac52a74a3249
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: hs_spotlight_large_portrait_600x720
+label: 'Spotlight Large Portrait (600x720)'
+effects:
+  ac8c68c8-c569-4e36-aa36-3728940af785:
+    uuid: ac8c68c8-c569-4e36-aa36-3728940af785
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 600
+      height: 720
+      crop_type: focal_point

--- a/config/default/image.style.hs_spotlight_small_portrait_300x360.yml
+++ b/config/default/image.style.hs_spotlight_small_portrait_300x360.yml
@@ -1,0 +1,17 @@
+uuid: 8d1fdd13-80f5-41b5-9e3a-2db79c020bf6
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: hs_spotlight_small_portrait_300x360
+label: 'Spotlight Small Portrait (300x360)'
+effects:
+  b320ba16-5b8e-473b-a6a9-dc4880d07daa:
+    uuid: b320ba16-5b8e-473b-a6a9-dc4880d07daa
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 300
+      height: 360
+      crop_type: focal_point

--- a/config/default/paragraphs.paragraphs_type.hs_spotlight.yml
+++ b/config/default/paragraphs.paragraphs_type.hs_spotlight.yml
@@ -1,0 +1,10 @@
+uuid: f72e7c64-1534-4cab-9753-cb9f587d7865
+langcode: en
+status: true
+dependencies: {  }
+id: hs_spotlight
+label: Spotlight
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/default/responsive_image.styles.spotlight_portrait_responsive.yml
+++ b/config/default/responsive_image.styles.spotlight_portrait_responsive.yml
@@ -1,0 +1,24 @@
+uuid: 3edabf88-0085-45a6-8bb6-bb6bf7893be4
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.hs_spotlight_large_portrait_600x720
+    - image.style.hs_spotlight_small_portrait_300x360
+  module:
+    - stanford_media
+id: spotlight_portrait_responsive
+label: 'Spotlight Portrait Responsive'
+image_style_mappings:
+  -
+    breakpoint_id: stanford_media.lg
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: hs_spotlight_large_portrait_600x720
+  -
+    breakpoint_id: stanford_media.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: hs_spotlight_small_portrait_300x360
+breakpoint_group: stanford_media
+fallback_image_style: hs_spotlight_small_portrait_300x360

--- a/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
@@ -1,18 +1,25 @@
 {%- set attributes = attributes.addClass('hb-spotlight') -%}
 
 {% if variant %}
-  {% set variant_class = "hb-spotlight--color-#{variant}" %}
+  {# left / right could be variants #}
+  {# but will we want color variants too? then one should be another field #}
+  {% set variant_class = "hb-spotlight--color-#{variant}" %} 
   {% set attributes = attributes.addClass(variant_class) %}
 {% endif %}
 
 {% spaceless %}
   <div{{ attributes }}>
-    <div class="hb-spotlight__image-wrapper">
-      {{ image }}
-    </div>
-
-    <div class="hb-spotlight__text">
-      {{ overlay_text }}
+    <div class="hb-spotlight__wrapper">
+      {% if overlay_text %}
+        <div class="hb-spotlight__text">
+          {{ overlay_text }}
+        </div>
+      {% endif %}
+      {% if image %}
+        <div class="hb-spotlight__image-wrapper">
+          {{ image }}
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endspaceless %}

--- a/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
@@ -1,0 +1,18 @@
+{%- set attributes = attributes.addClass('hb-spotlight') -%}
+
+{% if variant %}
+  {% set variant_class = "hb-spotlight--color-#{variant}" %}
+  {% set attributes = attributes.addClass(variant_class) %}
+{% endif %}
+
+{% spaceless %}
+  <div{{ attributes }}>
+    <div class="hb-spotlight__image-wrapper">
+      {{ image }}
+    </div>
+
+    <div class="hb-spotlight__text">
+      {{ overlay_text }}
+    </div>
+  </div>
+{% endspaceless %}

--- a/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.html.twig
@@ -1,23 +1,21 @@
 {%- set attributes = attributes.addClass('hb-spotlight') -%}
 
 {% if variant %}
-  {# left / right could be variants #}
-  {# but will we want color variants too? then one should be another field #}
-  {% set variant_class = "hb-spotlight--color-#{variant}" %} 
+  {% set variant_class = "hb-spotlight--image-#{variant}" %} 
   {% set attributes = attributes.addClass(variant_class) %}
 {% endif %}
 
 {% spaceless %}
   <div{{ attributes }}>
     <div class="hb-spotlight__wrapper">
-      {% if overlay_text %}
-        <div class="hb-spotlight__text">
-          {{ overlay_text }}
-        </div>
-      {% endif %}
       {% if image %}
         <div class="hb-spotlight__image-wrapper">
           {{ image }}
+        </div>
+      {% endif %}
+      {% if overlay_text %}
+        <div class="hb-spotlight__text">
+          {{ overlay_text }}
         </div>
       {% endif %}
     </div>

--- a/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.ui_patterns.yml
@@ -3,7 +3,11 @@ spotlight:
   description: ""
   variants:
     default:
-      label: Default
+      label: Image Right
+      description: Shows image on the right side.
+    left:
+      label: Image Left
+      description: Shows image on the left side.
   fields:
     image:
       label: "Image"

--- a/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/spotlight/spotlight.ui_patterns.yml
@@ -1,0 +1,20 @@
+spotlight:
+  label: "Spotlight"
+  description: ""
+  variants:
+    default:
+      label: Default
+  fields:
+    image:
+      label: "Image"
+      preview:
+        theme: image
+        uri: "http://placecorgi.com/2000/800"
+        width: 2000
+        height: 800
+      type: mixed
+    overlay_text:
+      label: "Overlay Text"
+      type: mixed
+      preview: "<h2>Etiam sollicitudin</h2><p>ipsum eu pulvinar rutrum, tellus ipsum laoreet sapien, quis venenatis ante odio sit amet eros. Lorem ipsum dolor sit amet</p><a class=\"decanter-button\">augue augue mollis justo.</a>"
+  use: "@humsci_basic/spotlight/spotlight.html.twig"

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -154,6 +154,7 @@
   'components/block-layout',
   'components/pattern.table-pattern',
   'components/pattern.table-row',
+  'components/pattern.spotlight',
   'components/not-layout-builder-main-content',
   'components/pager',
   'components/buttons',

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.hero.scss
@@ -132,37 +132,7 @@
     }
 
     h2 {
-      font-weight: hb-theme-font-weight(semibold);
-      font-size: hb-calculate-rems(27px);
-      line-height: 117%;
-      margin: 0 0 hb-spacing-width('md');
-
-      @include grid-media-min('md') {
-        @include hb-heading-2;
-        margin: 0 0 hb-spacing-width();
-      }
-
-      @include grid-media-min('lg') {
-        @include hb-heading-1;
-      }
-
-      @include hb-traditional {
-        line-height: 112%;
-
-        @include grid-media-min('md') {
-          font-size: hb-calculate-rems(33px);
-          line-height: 112%;
-        }
-
-        @include grid-media-min('lg') {
-          font-size: hb-calculate-rems(38px);
-          line-height: 112%;
-        }
-
-        @include grid-media-min('xl') {
-          font-size: hb-calculate-rems(48px);
-        }
-      }
+      @include hb-hero-title;
     }
 
     ul {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
@@ -1,6 +1,6 @@
 .hb-spotlight {
   padding: hb-spacing-width('md') 0;
-  margin: hb-spacing-width() 0 hb-spacing-width();
+  margin: hb-spacing-width() 0;
 
   @include hb-themes(('colorful', 'airy')) {
     @include hb-global-color('background-color', 'gray-light');

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
@@ -43,6 +43,11 @@
       &-spotlight-title {
         h2 {
           @include hb-hero-title;
+          margin: 0 0 hb-spacing-width('xs');
+
+          @include grid-media-min('md') {
+            margin: 0 0 hb-spacing-width('xs');
+          }
         }
       }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
@@ -22,13 +22,23 @@
 
   &__wrapper {
     @include hb-page-width;
-    display: flex;
-    flex-direction: column-reverse;
+    display: block;
 
     @include grid-media-min('md') {
       display: flex;
-      flex-direction: row;
       align-items: center;
+    }
+
+    .hb-spotlight--image-default & {
+      @include grid-media-min('md') {
+        flex-direction: row-reverse;
+      }
+    }
+
+    .hb-spotlight--image-left & {
+      @include grid-media-min('md') {
+        flex-direction: row;
+      }
     }
   }
 
@@ -37,6 +47,12 @@
       flex-basis: 50%;
       flex-grow: 1;
       max-width: 75%;
+    }
+
+    .hb-spotlight--image-left & {
+      @include grid-media-min('md') {
+        margin-left: hb-spacing-width();
+      }
     }
 
     .field-hs {
@@ -67,8 +83,14 @@
     margin-bottom: hb-spacing-width('md');
 
     @include grid-media-min('md') {
-      margin-left: hb-spacing-width();
       width: 50%;
+      margin-bottom: 0;
+    }
+
+    .hb-spotlight--image-default & {
+      @include grid-media-min('md') {
+        margin-left: hb-spacing-width();
+      }
     }
 
     img {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.spotlight.scss
@@ -1,0 +1,73 @@
+.hb-spotlight {
+  padding: hb-spacing-width('md') 0;
+  margin: hb-spacing-width() 0 hb-spacing-width();
+
+  @include hb-themes(('colorful', 'airy')) {
+    @include hb-global-color('background-color', 'gray-light');
+  }
+
+  @include hb-traditional {
+    @include hb-pairing-color('background-color', 'tertiary-highlight');
+  }
+
+  @include grid-media-min('md') {
+    padding: hb-calculate-rems(2 * hb-spacing-width('default', false)) 0;
+  }
+
+  .hs-full-width & {
+    // Special negative margin for the Spotlight
+    // to get rid of the vertical padding on all basic pages
+    margin: calc(-1 * #{hb-spacing-width()}) 0 hb-spacing-width();
+  }
+
+  &__wrapper {
+    @include hb-page-width;
+    display: flex;
+    flex-direction: column-reverse;
+
+    @include grid-media-min('md') {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  &__text {
+    @include grid-media-min('md') {
+      flex-basis: 50%;
+      flex-grow: 1;
+      max-width: 75%;
+    }
+
+    .field-hs {
+      &-spotlight-title {
+        h2 {
+          @include hb-hero-title;
+        }
+      }
+
+      &-spotlight-link {
+        margin-top: hb-spacing-width('md');
+
+        a,
+        button {
+          @include hb-button;
+          padding: hb-calculate-rems(4px) hb-calculate-rems(20px);
+        }
+      }
+    }
+  }
+
+  &__image-wrapper {
+    margin-bottom: hb-spacing-width('md');
+
+    @include grid-media-min('md') {
+      margin-left: hb-spacing-width();
+      width: 50%;
+    }
+
+    img {
+      width: 100%;
+    }
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -229,3 +229,38 @@
     font-size: hb-calculate-rems(18px);
   }
 }
+
+@mixin hb-hero-title {
+  font-weight: hb-theme-font-weight(semibold);
+  font-size: hb-calculate-rems(27px);
+  line-height: 117%;
+  margin: 0 0 hb-spacing-width('md');
+
+  @include grid-media-min('md') {
+    @include hb-heading-2;
+    margin: 0 0 hb-spacing-width();
+  }
+
+  @include grid-media-min('lg') {
+    @include hb-heading-1;
+  }
+
+  @include hb-traditional {
+    line-height: 112%;
+
+    @include grid-media-min('md') {
+      font-size: hb-calculate-rems(33px);
+      line-height: 112%;
+    }
+
+    @include grid-media-min('lg') {
+      font-size: hb-calculate-rems(38px);
+      line-height: 112%;
+    }
+
+    @include grid-media-min('xl') {
+      font-size: hb-calculate-rems(48px);
+    }
+  }
+}
+

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -231,7 +231,6 @@
 }
 
 @mixin hb-hero-title {
-  font-weight: hb-theme-font-weight(semibold);
   font-size: hb-calculate-rems(27px);
   line-height: 117%;
   margin: 0 0 hb-spacing-width('md');
@@ -245,7 +244,12 @@
     @include hb-heading-1;
   }
 
+  @include hb-themes(('airy', 'colorful')) {
+    font-weight: hb-theme-font-weight(semibold);
+  }
+
   @include hb-traditional {
+    font-weight: hb-theme-font-weight(regular);
     line-height: 112%;
 
     @include grid-media-min('md') {

--- a/tests/behat/features/install/content/BasicPage.feature
+++ b/tests/behat/features/install/content/BasicPage.feature
@@ -50,7 +50,7 @@ Feature: Install State Basic Page
     Given I am logged in as a user with the "Contributor" role
     Then I am on "/node/add/hs_basic_page"
     And I should see 1 "#edit-field-hs-page-hero-wrapper" elements
-    And I should see 8 "#edit-field-hs-page-components-add-more input" elements
+    And I should see 9 "#edit-field-hs-page-components-add-more input" elements
     Then I fill in "Title" with "Demo Basic Page"
     And I press "Add Postcard"
     And I should see "Card Title"


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds new paragraph type and UI pattern for the H&S Spotlight. **This is a platform wide change.**

Figma designs: https://www.figma.com/file/bG42fKKioEcnJ0ORKkLL5E/%E2%9A%99%EF%B8%8F-Traditional-Theme---Working?node-id=4909%3A3

### TODO
- [x] Design Review

### Browser Testing
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] IE11 (not perfect on mobile, but I think this passes silver level)

## Steps to Test
1. `npm run test passes`
2. Import the new config in this branch by running: `lando drush @economics.local config-import --partial`
3. Cache clear and add a new basic page. Check that you can add and see:
 - [x] a Spotlight paragraph in the "Hero Image" section of the basic page
 - [x] a Spotlight paragraph in the "Components" section of the basic page
4. Add a new Spotlight to the "hero image" section:
 - [x] Check that by default, spotlights are set to "Tall spotlight" for the display  field and "Right aligned" for the image alignment field
- [x] check that this spotlight renders at full width at the top of the page, with the image to the right side, and with a portrait image style
5. Add another Spotlight in the "Components" section of the basic page:
- set to "short spotlight" for the display  field and "left aligned" for the image alignment field
- [x] check that this spotlight renders at limited width in the main content portion of the page, with the image to the left side, and with a landscape image style
6. 
- [x] Feel free to try out a few other variations with spotlights with/without body text, an image, a title, a link etc.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
