### PR TITLE
HSD8-825: Added event_series to event importer

### DIFF
--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -340,4 +340,5 @@ destination:
     - field_hs_event_speaker
     - field_hs_event_type
     - field_hs_event_video
+    - field_hs_event_series
 migration_dependencies: {  }

--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -117,10 +117,6 @@ source:
       name: event_series_body
       label: 'Event Series Body'
       selector: eventSeriesBody
-    -
-      name: event_series_id
-      label: 'Event Series ID'
-      selector: eventSeriesID
   ids:
     event_id:
       type: string

--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -340,5 +340,4 @@ destination:
     - field_hs_event_speaker
     - field_hs_event_type
     - field_hs_event_video
-    - field_hs_event_series
 migration_dependencies: {  }

--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -109,6 +109,18 @@ source:
       name: image
       label: 'Image URL'
       selector: imageUrl
+    -
+      name: event_series_title
+      label: 'Event Series Title'
+      selector: eventSeriesTitle
+    -
+      name: event_series_body
+      label: 'Event Series Body'
+      selector: eventSeriesBody
+    -
+      name: event_series_id
+      label: 'Event Series ID'
+      selector: eventSeriesID
   ids:
     event_id:
       type: string
@@ -289,6 +301,23 @@ process:
       value_key: field_media_video_embed_field
       values:
         name: drupal_video_name
+  field_hs_event_series:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: event_series_title
+    -
+      plugin: entity_generate
+      entity_type: node
+      bundle_key: type
+      bundle: hs_event_series
+      value_key: title
+      values:
+        title: event_series_title
+        body: event_series_body
+    -
+      plugin: default_value
+      default_value: null
 destination:
   plugin: 'entity:node'
   overwrite_properties:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
https://stanfordits.atlassian.net/browse/HSD8-825
[I created a new test export view](https://economics.stanford.edu/events/past-events/export-series-events) with the eventSeriesTitle and eventSeriesBody fields. [Edit view link.](https://economics.stanford.edu/admin/structure/views/view/hs_economics_events_export/edit/views_data_export_4)
Added configuration to import the Event Series.

## Notes
**NOTE:** The view and importer only include the first Event Series referenced by the Event node. The D8 sites only allow one reference and I haven’t seen an event with more than one, even though the field is set for unlimited references.
**NOTE:** I did not include the Event Series image in the importer

## Potential Issues
**ISSUE?:** The hs_events_importer module can be enabled while the hs_event_series module is disabled. Is including the event series data in the events module importer an issue?
**ISSUE?:** When I first pulled the repo and before I changed anything, I got an error when doing a config:import `Unexpected error during import with operation update for migrate_plus.migration.hs_events_image_importer: The entity does not have an ID.`

## Need Review By (Date)
7/7

## Urgency
Medium

## Steps to Test
1. Pull local stack and code
2. Import configuration changes `drush config:import -y`
3. Set the event importer migration url (admin/structure/migrate/events) to https://economics.stanford.edu/events/past-events/export-series-events
4. Run an import `drush migrate-import hs_events_importer --limit=25`
5. Check event series content was created and events are properly linked

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
