### PR TITLE
fix(STN-477): extra padding on empty subcontent horizontal structured cards

### DIFF
--- a/docroot/themes/humsci/humsci_basic/patterns/date-stacked-horizontal-card/date-stacked-horizontal-card.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/date-stacked-horizontal-card/date-stacked-horizontal-card.html.twig
@@ -48,6 +48,7 @@
       </div>
     {% endif %}
 
+    {% if time or location or speaker %}
       <div class="hb-card__subcontent hb-card__subcontent--with-icons">
         {% if time %}
           <div class="hb-card__subcontent-detail hb-card__icon hb-card__icon--date">
@@ -78,6 +79,7 @@
 
         {% endif %}
       </div>
+    {% endif %}
 
     {% if description %}
       <div class="hb-card__description">


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
For Horizontal Date Structured cards for the colorful and traditional themes, even with the view settings -> pattern -> settings -> checkbox "Hide empty fields" checked", the subcontent region was still rendering, and causing undue padding to show up. I had to add a bit more logic to the template to make sure this didn't keep happening.

## Steps to Test
1. `npm run test` passes.
1. Run `lando drush @sparkbox_sandbox.local cr` to get the new pattern changes to date stacked horizontal cards. 
2. On the colorful and then traditional theme, or vice versa, ensure that for a page with date stacked vertical cards, and no fields (in the view) mapped to the "Time," "Speaker," or "Location" fields, that the `hb-card__subcontent hb-card__subcontent--with-icons` HTML does not render at all, and thus no undue padding is shown for the Colorful theme especially. Compare with this testing page: https://sparkbox-sandbox-prod.stanford.edu/qa/date-stacked-cards-without-items-icon-region

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
