### PR TITLE
fix(STN-489): .hs-well

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.general.scss
@@ -202,5 +202,4 @@
 
   padding: hb-calculate-rems(20px) hb-calculate-rems(18px);
   border: 0 none;
-  display: table;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -118,6 +118,11 @@
       }
     }
   }
+
+  // Only in the textarea, does the well get display: table for being floated
+  .hs-well {
+    display: table;
+  }
 }
 
 // Utility classes used in Content Type WYSIWYGs and in Text Area WYSIWYG components


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fixes hs-well for when it appears in the second sidebar for three column layouts.

**Browser Testing**
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE 11

**Code Climate**
- [x] Tests pass https://codeclimate.com/github/SU-HSDO/suhumsci/pull/669

## Steps to Test
1. `npm run test` passes in humci_basic.
2. Go to http://sparkbox-sandbox.suhumsci.loc/people/ran-abramitzky and ensure that for a block in the second sidebar with the class hs-well, it goes 100% of that sidebar width. Compare to the bug here: https://sparkbox-sandbox-stage.stanford.edu/people/ran-abramitzky
3. Ensure nothing has changed on this page: http://sparkbox-sandbox.suhumsci.loc/breakout-and-quote-styles (compare to stage)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
