### PR TITLE
docs(STN-373): Fill in documentation gaps

### DIFF
--- a/docroot/themes/humsci/humsci_basic/docs/color-pairings.md
+++ b/docroot/themes/humsci/humsci_basic/docs/color-pairings.md
@@ -1,0 +1,27 @@
+## Color Pairings
+A single theme can have multiple color pairings. The default pairing for the Colorful Theme is Ocean, and for the Traditional Theme is Cardinal.
+
+Color palettes for each theme are set in `/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss` and `/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss`.
+
+A user can update the color pairing in the Drupal admin by going to Appearance / Settings / Humsci Colorful (or Humsci Traditional). Under **Theme Specific Settings** you will find **Color Pairing** options. The theme setting affixes a color pairing class to the `<html>` element which is used to determine the values rendered in the CSS custom properties (variables).
+
+Details on how to implement a new color pairing can be found in the [scss README](/docroot/themes/humsci/humsci_basic/src/scss/README.md).
+
+### Colorful Theme
+
+| Name     | Class                |
+|----------|----------------------|
+| Ocean    | hc-pairing-ocean     |
+| Mountain | hc-pairing-mountain  |
+| Cardinal | hc-pairing-cardinal  |
+| Lake     | hc-pairing-lake      |
+| Canyon   | hc-pairing-canyon    |
+| Cliff    | hc-pairing-cliff     |
+
+### Traditional Theme
+
+| Name     | Class                |
+|----------|----------------------|
+| Cardinal | ht-pairing-cardinal  |
+| Blue Jay | ht-pairing-bluejay   |
+| Warbler  | ht-pairing-warbler   |

--- a/docroot/themes/humsci/humsci_basic/docs/css-prefixing.md
+++ b/docroot/themes/humsci/humsci_basic/docs/css-prefixing.md
@@ -1,0 +1,10 @@
+## Prefixing of Class Names
+
+| Prefix | Platform | Naming Convention | Example |
+|--------|----------|-------------------|---------|
+| decanter- | [Decanter](https://github.com/SU-SWS/decanter) | decanter-[thing] | decanter-button |
+| su- | [Stanford Basic](https://github.com/SU-SWS/stanford_basic) | su-[thing] | su-button |
+| hs- | Humanities & Sciences | hs-[thing] | hs-button |
+| hb- | Humsci Basic Theme | hb-[thing] | hb-button |
+| hc- | Humsci Colorful Theme | hc-[thing] | hc-button |
+| ht- | Humsci Traditional Theme | ht-[thing] | ht-button |

--- a/docroot/themes/humsci/humsci_basic/docs/mixins.md
+++ b/docroot/themes/humsci/humsci_basic/docs/mixins.md
@@ -1,0 +1,43 @@
+## Sass Mixins
+Sass Mixins allow us to write clean, consistent code by defining styles that can be re-used throughout the project. Mixins are found under the `/src/scss/tools` directory.
+
+| Mixins |
+|--------|
+| Buttons |
+| [Color Pairings](#color-pairings) |
+| Forms |
+| [General](#general) |
+| Icons |
+| Layout |
+| Links |
+| Lists |
+| Menu Icons |
+| Tables |
+| Text |
+| [Themes](#themes) |
+
+### Color Pairings
+
+| Mixin | Description | Example |
+|-------|-------------|---------|
+| @mixin hb-pairing-color($property, $color-swatch, $important: false) { } | Applies a specific pairing color to a class. Used in place of the css property that needs to have a color pairing. | <code>.example { @include hb-pairing-color('background-color', 'primary', $important: true); }</code> |
+| @mixin hb-pairing-custom-properties($theme-list, $color-pairing) { } | Generates a list of custom properties for a specific color pairing. | <code>.example { @include hb-pairing-custom-properties($hc-colorful-pairings, $palette); }</code> |
+
+### General
+There are several general mixins within the project for tasks such as visually hiding content, clearing floats, etc. Only unique mixins that are specific to the Humsci Basic themes are listed below.
+
+| Mixin | Description | Example |
+|-------|-------------|---------|
+| @mixin psuedo-background-box($color, $height: 100%, $width: 100%) { } | Adds a background box psuedo element | <code>.example { @include psuedo-background-box('secondary', 50%, 8.75%); }</code> |
+| @mixin hb-colorful-text-bar($color, $height: hb-calculate-rems(4px), $width: hb-calculate-rems(65px)) { } | Applies a colorful bar above the text to a psuedo element. Created to be used on the Colorful Theme. | <code>.example { @include hb-colorful-text-bar('tertiary-reversed'); }</code> |
+| @mixin hb-vertical-card-background-block($white, $fallback, $background) { } | Adds a background linear gradient for use in the vertical linked card | <code>.example { @include hb-vertical-card-background-block(transparent, $white, var(--palette--primary-dark)); }</code> |
+| @mixin hb-well { } | Applies theme specific background styles for well components | <code>.example { @include hb-well; } </code> |
+
+### Themes
+
+| Mixin | Description | Example |
+|-------|-------------|---------|
+| @mixin hb-themes($theme-list) { } | Applies styles to multiple themes | <code>.example { @include hb-themes(('airy', 'colorful')) { display: block; }}</code> |
+| @mixin hb-colorful() { } | Applies styles to the Colorful theme | <code>.example { @include hb-colorful { display: block; }}</code> |
+| @mixin hb-traditional() { } | Applies styles to the Traditional theme | <code>.example { @include hb-traditional { display: inline; }}</code> |
+| @mixin hb-airy() { } | Applies styles to the Airy theme | <code>.example { @include hb-airy { display: flex; }}</code> |

--- a/docroot/themes/humsci/humsci_basic/docs/utility-classes.md
+++ b/docroot/themes/humsci/humsci_basic/docs/utility-classes.md
@@ -1,0 +1,128 @@
+## Utility Classes
+
+### Field Utility Classes
+Field Utility Classes are used to apply styles to a field in a view (Drupal Home / Administration / Structure / Views) or to a field within a block in layout builder.
+
+| Class                | Description         |
+|----------------------|---------------------|
+| hb-title             | Applies title styles to any heading (adds bar above for Colorful theme). Should not be used when hb-categories is used above the title. |
+| hb-heading-1         | Applies heading 1 styles |
+| hb-heading-2         | Applies heading 2 styles |
+| hb-heading-3         | Applies heading 3 styles |
+| hb-heading-4         | Applies heading 4 styles |
+| hb-heading-5         | Applies heading 5 styles |
+| hb-heading-6         | Applies heading 6 styles |
+| hb-body-small        | Applies the small body style |
+| hb-body-medium       | Applies the medium body style |
+| hb-link              | Applies the link style |
+| hb-link-inline       | Applies the inline link style |
+| hb-descriptor        | Applies the descriptor style |
+| hb-subtitle          | Applies the subtitle style |
+| hb-blockquote        | Applies the blockquote style |
+| hb-serif             | Applies the serif font style (for the Traditional Theme only)|
+| hb-text-align-left   | Aligns text to the left |
+| hb-text-align-center | Aligns text in the center |
+| hb-text-align-right  | Aligns text to the right |
+| hb-divider           | Applies a divider line below any field |
+| hb-highlighted-label | Applies the highlighted style to any label |
+| hb-pill              | Applies the pill style |
+| hb-categories        | Applies the categories style to any field with multiple items (can be linked) |
+| hb-pill-list         | Applies the pill style to any field with multiple items |
+| hb-pill-link-list    | Applies the pill link style to any field with multiple items that are links |
+<br>
+
+### Group Block Utility Classes
+Group Block Utility Classes are used to apply styles to node group blocks within the layout builder.
+
+| Class                     | Description                    |
+|---------------------------|--------------------------------|
+| hb-well                   | Adds a background to the block |
+| hb-borderless             | Adds a background to the block without a border |
+| hb-columns                | Puts fields inside the block into two columns |
+| hb-inline                 | Puts fields inside the block inline |
+| hb-inline-pipe            | Puts fields inside the block inline with pipes as spacers |
+| hb-main-body-detail-image | Used when images on detail pages are moved into the main body section. |
+<br>
+
+### WYSIWYG Platform Wide Text Area Classes
+| Class |
+|-------|
+| hs-font-splash |
+| hs-font-lead |
+| hs-short-line-length |
+| hs-caption |
+| hs-credits |
+| hs-button |
+| hs-button--big |
+| hs-seocondary-button |
+| hs-external-link |
+| hs-private-link |
+| hs-mailto-link |
+| hs-emphasized-text |
+| hs-more-link |
+| hs-table--borderless |
+| hs-well |
+<br>
+
+
+### Views
+| Class     | Description                                                                |
+|-----------|----------------------------------------------------------------------------|
+| hb-views-divider | Adds a line beneath the view (except the last row), goes 100% width |
+
+#### Card Image Widths in Views
+All images in card patterns have default widths defined:
+* 100% (12 columns) for vertical cards
+* 30% ( 5 columns) for horizontal and structured cards (starting at the md breakpoint)
+These styles can be overridden by adding utility classes to the entire view. `hb-card-image-*` classes follow a similar naming convention to the [Decanter Grid System](https://decanter.stanford.edu/page/layouts-grid-system/), including the responsive names.
+
+Classes are made responsive by adding the desired breakpoint (xs, sm, md, lg, xl, 2xl) after the `hb-card-image-`. **Example:** `hb-card-image-sm-4-of-12`
+
+For best practice, you might just want to use one responsive class if you'd like mobile styles to keep their defaults. To do this, you would just change an image's sytles on the medium breakpoint. **Example:** `hb-card-image-md-4-of-12`
+
+| Class                 |
+|-----------------------|
+| hb-card-image-1-of-12 |
+| hb-card-image-2-of-12 |
+| hb-card-image-3-of-12 |
+| hb-card-image-4-of-12 |
+| hb-card-image-5-of-12 |
+| hb-card-image-6-of-12 |
+| hb-card-image-7-of-12 |
+| hb-card-image-8-of-12 |
+| hb-card-image-9-of-12 |
+| hb-card-image-10-of-12 |
+| hb-card-image-11-of-12 |
+| hb-card-image-12-of-12 |
+<br>
+
+### Table Column Widths
+A set of utility classes that can added to a field in the table view.
+
+| Class                |
+|----------------------|
+| hb-table-col-1-of-12 |
+| hb-table-col-2-of-12 |
+| hb-table-col-3-of-12 |
+| hb-table-col-4-of-12 |
+| hb-table-col-5-of-12 |
+| hb-table-col-6-of-12 |
+| hb-table-col-7-of-12 |
+| hb-table-col-8-of-12 |
+| hb-table-col-9-of-12 |
+| hb-table-col-10-of-12 |
+| hb-table-col-11-of-12 |
+| hb-table-col-12-of-12 |
+
+Classes are made responsive by adding the desired breakpoint breakpoint (xs, sm, md, lg, xl, 2xl) after ` hb-table-col-`. **Example:** ` hb-table-col-sm-4-of-12`
+
+_Note:_ Classes must be added to the field only. Any classes added to the field and label will not be included in the markup. Field classes are added to the `td` element and semantically there cannot be another element wrapped around single `td` elements in order to add a wrapper class.
+
+* This does not work for table patterns (neither table, nor table row)
+<br>
+
+### Layout Builder "Components" region
+| Class                            | Description                                                                           |
+|----------------------------------|---------------------------------------------------------------------------------------|
+| hb-raised-cards                  | Adds a drop shadow behind any Card UI pattern used in the view |
+| hb-stretch-vertical-linked-cards | Stretches all vertical linked cards on a page to be the same height and adjusts the height of all card titles to be the same height |

--- a/docroot/themes/humsci/humsci_basic/readme.md
+++ b/docroot/themes/humsci/humsci_basic/readme.md
@@ -80,18 +80,27 @@ lando behat --tags='@global&&~@javascript'
 For more info, (including Lando setup details) see [these Behat testing notes](https://docs.google.com/document/d/11lEDdzDk5CYMKoXAON05LIlfmzbdk00tex6DNdo-U74/edit?ts=5eb32acf).
 
 ## Contributing
+### Github
+To make it easier to find work being done we should use the following naming conventions:
 
-### Commit Messages
+### Branch Names:
+`STN-XXX--descriptive-message`
 
-We are using a conventional commit message format, e.g.:
-
-`feat(STN-XX): descriptive message shorter than 80 chars`
+#### Commit Messages:
+`feat(STN-XXX): descriptive message shorter than 80 chars`
+`fix(STN-XXX): descriptive message shorter than 80 chars`
+`refactor(STN-XXX): descriptive message shorter than 80 chars`
+`chore(STN-XXX): descriptive message shorter than 80 chars`
 `docs(STN-XXX): descriptive message shorter than 80 chars`
 
 https://www.conventionalcommits.org/en/v1.0.0-beta.2/
 
-### Green Button Merging
+#### Pull Request Titles:
+`STN-XXX: Short Descriptive Titles`
 
+Pull request descriptions should follow the PR template that is generated when creating a new commit.
+
+#### Green Button Merging:
 After receiving a review and getting a PR approved, we do green-button merges for our PRs ("Rebase and Merge") because Github includes a link to the PR in our commit message header.
 
 ## Decanter Integration
@@ -101,3 +110,13 @@ This theme aims to **partially** integrate [Decanter](https://github.com/SU-SWS/
 - Import variables, function and mixins
 - Compile various helpers classes
 - Compile specific components such as Brand Bar, Logo, Lockup and Footer
+
+## CSS / Sass
+The CSS is organized using [Harry Roberts’](https://csswizardry.com) [Inverted Triangle CSS](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/) (ITCSS) organizational approach. This method is mixed with [Block Element Modifier](http://getbem.com/) (BEM) naming convention for class names throughout the Sass files.
+
+| Class References                                                                      |
+|---------------------------------------------------------------------------------------|
+| [Prefixing of Class Names](/docroot/themes/humsci/humsci_basic/docs/css-prefixing.md) |
+| [Utility Classes](/docroot/themes/humsci/humsci_basic/docs/utility-classes.md)        |
+| [Sass Mixins](/docroot/themes/humsci/humsci_basic/docs/mixins.md)                     |
+| [Color Pairings](/docroot/themes/humsci/humsci_basic/docs/color-pairings.md)          |

--- a/lando/README.md
+++ b/lando/README.md
@@ -27,6 +27,7 @@ _Prerequisite: Make sure you have added your SSH key in Acquia cloud, and that i
     127.0.0.1           symsys.suhumsci.loc
     ```
 4. Build your containers: `lando rebuild`
+    * Note: After running `lando rebuild` you should see a list a APPSERVER URLS. A `green` URL signifies the `.loc` domain has been added to your `/ect/hosts` file. If you see a `red` URL, go back to step 3 and add the `.loc` domain to your `/ect/hosts` file.
 5. Install your PHP dependencies: `lando composer install`
 6. Run `lando blt blt:init:settings` and confirm that it added a `local.settings.php` file to each of your `[my-multisite]/settings` folders (ex. `/docroot/sites/default/settings/local.settings.php`).
 7. Make sure the db settings in each of these `local.settings.php` files matches the settings in the `.lando.yml`. Note: the `database` service corresponds to the `default` multisite. The rest of the services have names that match their multisite. For example, for the default site, make sure that these values, and key-value pairs match:
@@ -43,7 +44,7 @@ _Prerequisite: Make sure you have added your SSH key in Acquia cloud, and that i
 1. In your `.lando.yml` file, uncomment the service for the site you want to run locally.
 2. Run `lando rebuild` (this needs to be run anytime you make changes to `.lando.yml`).
 3. Confirm that the password, database, and hostname values in `sites/[my-multisite]/settings/local.settings.php` correctly match the values in your `.lando.yml` file.
-3. Create a new file in `/docroot/sites` called `local.sites.php`. This adds new routing based on our local environments and local `sites/` folders. Add the following code there:
+4. Create a new file in `/docroot/sites` called `local.sites.php`. This adds new routing based on our local environments and local `sites/` folders. Add the following code there:
 ```
     <?php
     // This is required if you have localdev domains that are different from the
@@ -59,8 +60,10 @@ _Prerequisite: Make sure you have added your SSH key in Acquia cloud, and that i
     $sites["$sitename.suhumsci.loc"] = $site_dir; // Do we need to add more things to our sites array, to get requests to reach our multisites?
     }
 ```
-4. Sync the database and files with a copy from production: `lando blt drupal:sync --site=[my-multisite] --sync-files`.
-5. From now on, when you run a cache clear or try to get an admin link, you'll need to specify which Drupal site you are performing the action, for instance, for the default site: `lando drush @default.local cr` and for the economics site: `lando drush @economics.local uli`.
+5. Sync the database and files with a copy from production: `lando blt drupal:sync --site=[my-multisite] --sync-files`.
+6. From now on, when you run a cache clear or try to get an admin link, you'll need to specify which Drupal site you are performing the action, for instance, for the default site: `lando drush @default.local cr` and for the economics site: `lando drush @economics.local uli`.
+
+Troubleshooting Note for local sites: If multisite setup is causing you issues, try setting up the default setup first and then attempt a multisite configuration.
 
 ## Syncing from Staging
 In order to sync from a staging or dev site, you will have to do the following:
@@ -76,6 +79,14 @@ In order to sync from a staging or dev site, you will have to do the following:
 - `lando drush cr` - clear cache
 - `lando drush config-export` - export your local database settings
 - `lando drush config-import` - import new database settings to your local.
+
+Utilizing these commands with specific sites in your multisite setup looks like this: `lando drush @[]my-multisite] cr`.
+
+## Troubleshooting
+### Importing Configuration
+- If you run into issues importing new config files try running the command with the partial flag: `lando drush config-import --partial`.
+- If the partial flag doesn't work, you may be missing a dependency. Re-sync your whole database, then run `lando composer install`.
+- If you find yourself in a position where starting fresh is your best plan of action, `lando destroy` will completely clear your running lando instances for a clean start.
 
 ## Other useful links
 - [Lando Drupal 8 docs](https://docs.lando.dev/config/drupal8.html)


### PR DESCRIPTION
# READY FOR REVIEW

## Summary

### Update Lando README
While setting up `sparkbox-sandbox` locally I noticed that after I ran the `lando rebuild` command, the APPSERVER URL for `http://sparkbox-sandbox.suhumsci.loc/` was red. This seemed odd and I didn't understand what it meant. After a bit of debugging we discovered that it means the URL had not been added to my `/etc/hosts` file. This PR adds a note to step 4 of the Lando README to help clarify what `red` and `green` APPSERVER URLS mean in the hopes that they can debug any URL issues quicker.

### Adds SCSS/CSS documentation
New documentation includes: color pairings, css prefixing, mixins, and utility classes.

## Urgency
low

## Steps to Test
1. Review the information added to the Lando README and verify it makes sense.
