### PR TITLE
STN-476 :  Footer Block Configuration

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -12,20 +12,25 @@ use Drupal\node\Entity\Node;
  * Implements hook_preprocess_block().
  */
 function humsci_basic_preprocess_block(&$vars) {
+  // The following code block (lines 16 - 30) is an adaptation of the code found within the su_humsci theme preprocess block. `docroot/themes/humsci/su_humsci_theme/su_humsci_theme.theme`
+
   $block_ids = ['local_tasks_block'];
 
   if (in_array($vars['elements']['#plugin_id'], $block_ids)) {
     $vars['attributes']['class'][] = 'decanter-grid';
   }
 
-  // Change the block label to the block description so that users can change
-  // the block label without needing the permission to administer blocks. The
-  // role would only need the "Edit any block content" permission.
+  // The default permissions for the block label only allow developers to change
+  // the block title. In order to allow site owners to change the block label,
+  // it must be updated to block description.
+  // Change the block label to the block description so that users (such as site owners)
+  // can change the block label without needing the permission to administer blocks.
+  // The role would only need the "Edit any block content" permission.
   if ($vars['base_plugin_id'] == 'block_content') {
     /** @var \Drupal\block_content\Entity\BlockContent $block */
     $block = $vars['content']['#block_content'];
-    $info = $block->get('info')->get(0)->getValue();
-    $vars['label'] = reset($info) ?: $vars['label'];
+    $description = $block->get('info')->get(0)->getValue();
+    $vars['label'] = reset($description) ?: $vars['label'];
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -8,6 +8,26 @@
 use Drupal\Component\Utility\Html;
 use Drupal\node\Entity\Node;
 
+/**
+ * Implements hook_preprocess_block().
+ */
+function humsci_basic_preprocess_block(&$vars) {
+  $block_ids = ['local_tasks_block'];
+
+  if (in_array($vars['elements']['#plugin_id'], $block_ids)) {
+    $vars['attributes']['class'][] = 'decanter-grid';
+  }
+
+  // Change the block label to the block description so that users can change
+  // the block label without needing the permission to administer blocks. The
+  // role would only need the "Edit any block content" permission.
+  if ($vars['base_plugin_id'] == 'block_content') {
+    /** @var \Drupal\block_content\Entity\BlockContent $block */
+    $block = $vars['content']['#block_content'];
+    $info = $block->get('info')->get(0)->getValue();
+    $vars['label'] = reset($info) ?: $vars['label'];
+  }
+}
 
  /**
  * Prepares variables for the field.html.twig template.
@@ -143,4 +163,3 @@ function _humsci_basic_check_link_access(array &$link_items) {
     }
   }
 }
-


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR adds a preprocess hook to the Humsci Basic theme that changes the block label to the block description so that users can change the block label without needing permission. This emulates the functionality currently in place for the su_humsci theme.

## Need Review By (Date)
5/7/2020

## Urgency
medium

## Steps to Test
1. Because the work in this PR targets `site owners`, I recommend testing / masquerading as a `site owner`.
2. Go to Users > Masquerade
3. Enter `Howard` and click `Switch`
4. Go to the homepage and scroll down to the local footer.
5. Click on the contextual link beside `Contact us` and select `Edit`
6. Change the value of `Block description` to `You are awesome` or anything you choose and click `Save`
7. Check the local footer to confirm the title has updated.
8. When you have finished testing, click `Unmasquerade` in the Drupal admin toolbar.
