### PR TITLE
STN-481: Colorful Default Pairing Update

### DIFF
--- a/config/default/humsci_colorful.settings.yml
+++ b/config/default/humsci_colorful.settings.yml
@@ -8,7 +8,7 @@ lockup:
   line5: ''
 global_footer_variant_classname: default
 local_footer_variant_classname: default
-theme_color_pairing: ocean
+theme_color_pairing: cardinal
 _core:
   default_config_hash: SBITMklqo6d-OX4gaHZdWNykJqGeKbcUiQlDrEFspHg
 features:

--- a/docroot/themes/humsci/humsci_colorful/config/install/humsci_colorful.settings.yml
+++ b/docroot/themes/humsci/humsci_colorful/config/install/humsci_colorful.settings.yml
@@ -1,6 +1,0 @@
-brand_bar_variant_classname: default
-lockup:
-  option: default
-global_footer_variant_classname: default
-local_footer_variant_classname: default
-theme_color_pairing: ocean

--- a/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
+++ b/docroot/themes/humsci/humsci_traditional/config/install/humsci_traditional.settings.yml
@@ -1,6 +1,0 @@
-brand_bar_variant_classname: default
-lockup:
-  option: default
-global_footer_variant_classname: default
-local_footer_variant_classname: default
-theme_color_pairing: cardinal


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request updates the default color pairing for the Colorful them to Cardinal. There is also a bit of housekeeping deleting the old theme settings files that in the theme directories. Theme settings have been moved to the config directory.

## Need Review By (Date)
08/13

## Urgency
low

## Steps to Test
Because config changes are ignored by existing sites we won't be able to test that new sites will use Cardinal by default until a new site is created. We can, however, test that we don't break existing sites.

1.  - [x] Run `npm test`.
2. - [x] Set your local site to use the Colorful theme and choose a color pairing something other than Ocean or Cardinal.
3. - [x] Run `lando drush @sparkbox_sandbox.local config-import --partial`.
4. - [x] Refresh the local site and confirm that the theme setting for color pairing has not changed. (You may also want to clear the cache for good measure).

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
