### PR TITLE
STN-524: Fix Lead and Splash Font Margin in Lists

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -148,12 +148,16 @@
     line-height: 127%;
     @include hb-global-color('color', 'gray-dark');
 
+    @include grid-media-min('lg') {
+      font-size: hb-calculate-rems(22px);
+    }
+
     .hb-local-footer--dark & {
       @include hb-global-color('color', 'gray-light');
     }
 
-    @include grid-media-min('lg') {
-      font-size: hb-calculate-rems(22px);
+    li & {
+      margin: hb-calculate-rems(-3px) 0 0;
     }
   }
 
@@ -174,6 +178,10 @@
 
     @include hb-traditional {
       @include hb-pairing-color('color', 'primary');
+    }
+
+    li & {
+      margin: hb-calculate-rems(-3px) 0 0;
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
When the lead and splash font styles are used on text in ordered and unordered list items they still have their margin which causes extra spacing above and below the text. This also means that the number/bullet point are not associated with the text and look like they are floating off in space.

**Example of incorrect spacing:**
![0e529f19-5b4e-4b71-9544-b177c377700d](https://user-images.githubusercontent.com/2486846/91354489-d283ae80-e7ba-11ea-860b-3b65c136db7d.png)

## Need Review By (Date)
08/27

## Urgency
low

## Steps to Test
1. Ensure that all tests pass
2. Sync your local environment with staging
3. Checkout the code examples on the [QA Text Area](http://sparkbox-sandbox.suhumsci.loc/qa-text-area) page.
4. Confirm that:
    - [x] There are no changes to the normal text in ordered and unordered lists
    - [x] The lead and splash fonts in the Traditional theme match the following:
        ![Screen Shot 2020-08-26 at 4 33 25 PM](https://user-images.githubusercontent.com/2486846/91354691-1aa2d100-e7bb-11ea-9854-2663a51e7c6a.png)
    - [x] The lead and splash fonts in the Colorful theme match the following:
        ![Screen Shot 2020-08-26 at 4 34 53 PM](https://user-images.githubusercontent.com/2486846/91354744-2bebdd80-e7bb-11ea-83c6-bbeaad891da7.png)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
