### PR TITLE
STN-542: Spotlight Adjustment

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
@@ -48,9 +48,9 @@ content:
     weight: 2
     label: hidden
     settings:
-      trim_length: 200
-      trim_type: chars
-      trim_suffix: ''
+      trim_length: 125
+      trim_type: words
+      trim_suffix: …
       wrap_class: trimmed
       more_text: More
       more_class: more-link

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
@@ -53,9 +53,9 @@ content:
     weight: 1
     label: hidden
     settings:
-      trim_length: 200
-      trim_type: chars
-      trim_suffix: ''
+      trim_length: 60
+      trim_type: words
+      trim_suffix: …
       wrap_class: trimmed
       more_text: More
       more_class: more-link


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This pull request adjusts the maximum amount of body text that displays in the spotlight pattern. An ellipses has been added for truncated text to signify that the text is being cut off.

- Short Spotlight: 60 words
- Tall Spotlight: 125 words

## Need Review By (Date)
9/17

## Urgency
Medium

## Steps to Test
1. Tests should pass
2. Import the new config `lando drush @sparkbox_sandbox.local config-import --partial`
3. Checkout the [Spotlight QA](http://sparkbox-sandbox.suhumsci.loc/qa/spotlight-qa) page and confirm the following:
    - [ ] Tall spotlights will only the first show 125 words followed by an ellipsis:
        <img width="923" alt="Screen Shot 2020-09-17 at 12 44 12 PM" src="https://user-images.githubusercontent.com/2486846/93502619-f97a5f80-f8e4-11ea-9b6b-624df7d88369.png">
    - [ ] Short spotlights will only the first show 60 words followed by an ellipsis:
        <img width="921" alt="Screen Shot 2020-09-17 at 12 44 53 PM" src="https://user-images.githubusercontent.com/2486846/93502654-0434f480-f8e5-11ea-9b27-499709b12370.png">
    - [ ] Spotlights with less than the maximum number of text do not have an ellipsis

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
