### PR TITLE
STN-638: Adds missing caption/credit config file

### DIFF
--- a/config/default/core.entity_view_display.media.image.caption_credit
+++ b/config/default/core.entity_view_display.media.image.caption_credit
@@ -1,0 +1,55 @@
+uuid: 15ad6e43-8ac9-497b-8266-38471752ba87
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.caption_credit
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_image_caption
+    - media.type.image
+    - responsive_image.styles.full_responsive
+  module:
+    - field_formatter_class
+    - hs_field_helpers
+    - layout_builder
+    - responsive_image
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: UHOBG3TcAwserLclcHcEOGnkPaJlP9n_tSpy7TmELFQ
+id: media.image.caption_credit
+targetEntityType: media
+bundle: image
+mode: caption_credit
+content:
+  field_media_image:
+    label: hidden
+    settings:
+      responsive_image_style: full_responsive
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 0
+    region: content
+  field_media_image_caption:
+    type: text_trimmed
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      trim_length: 120
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+hidden:
+  created: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true
+  


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR adds the missing captions/credit as outlined in the feedback for the [Sprint 29 PR](https://github.com/SU-HSDO/suhumsci/pull/762/files/7d6c3f7c29636d0c0d67f6e76dd39f771a4b43d9#diff-05d1f9a1cd953ae2bec1a052aa35555cbbab6a20f60b5e5033fb115ca5fb2d65).

This config file was created by going to Structure > Media types > Image > Manage Display.
Under `Custom display settings` the `Caption/Credit` box was selected.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
Follow the steps outlined the original [Create Caption/Credit view mode and styles PR(https://github.com/SU-HSDO/suhumsci/pull/753)] to ensure that the caption/credit works as expected.
