### PR TITLE
Feat(STN-702): Bug fix dropdown menu bar

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/menus/macros/nav-menu.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/menus/macros/nav-menu.twig
@@ -3,7 +3,7 @@
  * Macro for creating nested menus in the main navigation.
  */
 #}
-{% macro nav_menu(items, menu_level, class_prefix) %}
+{% macro nav_menu(items, menu_level, class_prefix, parents) %}
   {% import _self as menus %}
   <ul class="{{ class_prefix }}__menu {{ class_prefix }}__menu-lv{{ menu_level }}">
   {% for item in items %}
@@ -23,7 +23,6 @@
     {% else %}
       {% set link_attributes = link_attributes.setAttribute('href', item.url|render) %}
     {% endif %}
-
 
     {# Item Attributes #}
     {% set list_attributes = create_attribute() %}
@@ -51,7 +50,7 @@
 
         {% if item.below %}
           <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}">
-            {{ menus.nav_menu(item.below, menu_level + 1, class_prefix) }}
+            {{ menus.nav_menu(item.below, menu_level + 1, class_prefix, parents|merge([loop.index])) }}
           </div>
         {% endif %}
       {% else %}
@@ -62,11 +61,11 @@
         {{ link(item.title, item.url, link_attributes) }}
 
         {% if item.below %}
-          <button class="{{ class_prefix }}__button hb-nested-toggler" id="{{ item.title|replace({' ': ''}) }}{{ menu_level }}" aria-expanded="true">
+          <button class="{{ class_prefix }}__button hb-nested-toggler" id="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ parents|join('-')|clean_id }}" aria-expanded="true">
             Toggle {{ item.title }}
           </button>
-          <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}">
-            {{ menus.nav_menu(item.below, menu_level + 1, class_prefix) }}
+          <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ parents|join('-')|clean_id }}">
+            {{ menus.nav_menu(item.below, menu_level + 1, class_prefix, parents|merge([loop.index])) }}
           </div>
         {% endif %}
       {% endif %}

--- a/docroot/themes/humsci/humsci_basic/templates/menus/menu--main.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/menus/menu--main.html.twig
@@ -26,7 +26,7 @@
   {% endblock %}
   {% spaceless %}
   {% if items is iterable %}
-    {{ menus.nav_menu(items, 1, 'hb-main-nav') }}
+    {{ menus.nav_menu(items, 1, 'hb-main-nav', []) }}
   {% else %}
     {# If custom markup is provided, emit it as-is #}
     {{ items }}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
On the Public Policy site, we are seeing a gray bar on the bottom of one of the menu items in the desktop size menu. That same menu on mobile has the child links always showing for that parent link and the "+" and "-" icon just spins and doesn't do anything.

Example:  https://publicpolicy-prod.stanford.edu 

![image](https://user-images.githubusercontent.com/9355698/112025686-cd49d080-8b0b-11eb-9cd8-6ee27e24ffdc.png)
![image](http://g.recordit.co/D2m0rI1V2q.gif)

JIRA Card: https://sparkbox.atlassian.net/browse/STN-702

What was uncovered from the investigation is that links with the same name that also happens to be parent links share the same `id` attribute, which is causing the `AriaLabeledBy` for the dropdown to not function correctly, therefore not applying the `Aria-Hidden `attribute to the child menu div to hide it properly in mobile or desktop.

The Approach:
I added an array loop called "parents" to the main menu macro, that adds the parent link position to the end of the id and the AriaLabeledBy, this should keep the id's and labels from ever being duplicates of each other as it will add an additional from each parent level and menu position to the id/arialabeledby keeping them unique throughout.

## Need Review By (Date)
3/22

## Urgency
medium

## Steps to Test
1. npm run test
2. Create a local menu link within the lower links that have the same name and then also give them each at least one child link. These links should be able to be external or internal links with no issues. I added a new link under About and an additional link with the same name under QA.
3. Verify that the gray bar that once appeared in the desktop menu under the second instance of the same menu link name parent.
4. Verify that the mobile menu works correctly with all parent links and does show and hide properly using the "+" and "-" button.
5. Also verify you do not see any additional issues from the work that was applied here, not within the main nav, mobile or our sidebar nav that are on the site just for testing purposes to make sure this work didn't break any previously functional pieces.
6. This should work the same on both themes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
