### PR TITLE
STN-675: WEST Gradient Hero --> configuration

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
@@ -1,0 +1,60 @@
+uuid: e05087b1-5c47-477e-8e0f-28c46b5c8981
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_body
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_image
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_link
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - link
+    - media_library
+    - text
+id: paragraph.hs_gradient_hero.default
+targetEntityType: paragraph
+bundle: hs_gradient_hero
+mode: default
+content:
+  field_hs_gradient_hero_align:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_hs_gradient_hero_body:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_hs_gradient_hero_image:
+    type: media_library_widget
+    weight: 0
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_hs_gradient_hero_link:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_hs_gradient_hero_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
@@ -10,7 +10,9 @@ dependencies:
     - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title
     - paragraphs.paragraphs_type.hs_gradient_hero
   module:
+    - allowed_formats
     - link
+    - maxlength
     - media_library
     - text
 id: paragraph.hs_gradient_hero.default
@@ -29,7 +31,15 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 200
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
     type: text_textarea
     region: content
   field_hs_gradient_hero_image:

--- a/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
@@ -80,9 +80,13 @@ content:
     weight: 1
     label: hidden
     settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
+      tag: h2
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    type: entity_title_heading
     region: overlay_text
 hidden:
   field_hs_gradient_hero_align: true

--- a/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
@@ -11,7 +11,10 @@ dependencies:
     - paragraphs.paragraphs_type.hs_gradient_hero
   module:
     - ds
+    - field_formatter_class
+    - hs_field_helpers
     - link
+    - stanford_media
     - text
 third_party_settings:
   ds:
@@ -48,13 +51,18 @@ content:
     type: text_default
     region: overlay_text
   field_hs_gradient_hero_image:
-    type: entity_reference_entity_view
+    type: media_responsive_image_formatter
     weight: 0
     label: hidden
     settings:
-      view_mode: default
+      view_mode: caption_credit
+      image_style: hero_image
       link: false
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
     region: image
   field_hs_gradient_hero_link:
     weight: 3

--- a/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
@@ -1,0 +1,81 @@
+uuid: c2e78457-ea88-44e0-a94e-2f952808a65d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_body
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_image
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_link
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - ds
+    - link
+    - text
+third_party_settings:
+  ds:
+    layout:
+      id: pattern_gradient-hero
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: _field
+          variant_field: field_hs_gradient_hero_align
+          variant_field_values:
+            default: content-default
+            right: content-right
+    regions:
+      image:
+        - field_hs_gradient_hero_image
+      overlay_text:
+        - field_hs_gradient_hero_title
+        - field_hs_gradient_hero_body
+        - field_hs_gradient_hero_link
+id: paragraph.hs_gradient_hero.default
+targetEntityType: paragraph
+bundle: hs_gradient_hero
+mode: default
+content:
+  field_hs_gradient_hero_body:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: overlay_text
+  field_hs_gradient_hero_image:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: image
+  field_hs_gradient_hero_link:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: overlay_text
+  field_hs_gradient_hero_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: overlay_text
+hidden:
+  field_hs_gradient_hero_align: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_gradient_hero.default.yml
@@ -14,8 +14,8 @@ dependencies:
     - field_formatter_class
     - hs_field_helpers
     - link
+    - smart_trim
     - stanford_media
-    - text
 third_party_settings:
   ds:
     layout:
@@ -46,9 +46,25 @@ content:
   field_hs_gradient_hero_body:
     weight: 2
     label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
+    settings:
+      trim_length: 200
+      trim_type: chars
+      trim_suffix: ''
+      wrap_class: trimmed
+      more_text: More
+      more_class: more-link
+      wrap_output: false
+      more_link: false
+      trim_options:
+        text: false
+        trim_zero: false
+      summary_handler: full
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      hs_field_helpers:
+        inline_contents: 0
+    type: smart_trim
     region: overlay_text
   field_hs_gradient_hero_image:
     type: media_responsive_image_formatter
@@ -56,7 +72,7 @@ content:
     label: hidden
     settings:
       view_mode: caption_credit
-      image_style: hero_image
+      image_style: hero_with_text
       link: false
     third_party_settings:
       field_formatter_class:

--- a/config/default/core.entity_view_display.paragraph.hs_gradient_hero.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_gradient_hero.preview.yml
@@ -1,0 +1,30 @@
+uuid: 2a62c84d-ef78-44cd-b847-5afd760fbb0e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_body
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_image
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_link
+    - field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.hs_gradient_hero.preview
+targetEntityType: paragraph
+bundle: hs_gradient_hero
+mode: preview
+content: {  }
+hidden:
+  field_hs_gradient_hero_align: true
+  field_hs_gradient_hero_body: true
+  field_hs_gradient_hero_image: true
+  field_hs_gradient_hero_link: true
+  field_hs_gradient_hero_title: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -43,7 +43,7 @@ settings:
         weight: -26
         enabled: false
       hs_gradient_hero:
-        weight: 21
+        weight: -32
         enabled: false
       hs_hero_image:
         weight: -25

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_hs_page_components
     - node.type.hs_basic_page
+    - paragraphs.paragraphs_type.hs_gradient_hero
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
@@ -28,6 +29,7 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      hs_gradient_hero: hs_gradient_hero
       hs_priv_text_area: hs_priv_text_area
       hs_webform: hs_webform
       stanford_gallery: stanford_gallery
@@ -43,8 +45,8 @@ settings:
         weight: -26
         enabled: false
       hs_gradient_hero:
+        enabled: true
         weight: -32
-        enabled: false
       hs_hero_image:
         weight: -25
         enabled: false

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -42,6 +42,9 @@ settings:
       hs_carousel:
         weight: -26
         enabled: false
+      hs_gradient_hero:
+        weight: 21
+        enabled: false
       hs_hero_image:
         weight: -25
         enabled: false

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -7,7 +7,6 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_banner
     - paragraphs.paragraphs_type.hs_carousel
-    - paragraphs.paragraphs_type.hs_gradient_hero
     - paragraphs.paragraphs_type.hs_hero_image
     - paragraphs.paragraphs_type.hs_spotlight
   module:
@@ -33,7 +32,6 @@ settings:
       hs_carousel: hs_carousel
       hs_banner: hs_banner
       hs_spotlight: hs_spotlight
-      hs_gradient_hero: hs_gradient_hero
     target_bundles_drag_drop:
       hs_accordion:
         weight: 12
@@ -45,8 +43,8 @@ settings:
         enabled: true
         weight: 10
       hs_gradient_hero:
-        enabled: true
         weight: 21
+        enabled: false
       hs_hero_image:
         enabled: true
         weight: 3

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_banner
     - paragraphs.paragraphs_type.hs_carousel
+    - paragraphs.paragraphs_type.hs_gradient_hero
     - paragraphs.paragraphs_type.hs_hero_image
     - paragraphs.paragraphs_type.hs_spotlight
   module:
@@ -32,6 +33,7 @@ settings:
       hs_carousel: hs_carousel
       hs_banner: hs_banner
       hs_spotlight: hs_spotlight
+      hs_gradient_hero: hs_gradient_hero
     target_bundles_drag_drop:
       hs_accordion:
         weight: 12
@@ -42,6 +44,9 @@ settings:
       hs_carousel:
         enabled: true
         weight: 10
+      hs_gradient_hero:
+        enabled: true
+        weight: 21
       hs_hero_image:
         enabled: true
         weight: 3
@@ -60,13 +65,25 @@ settings:
       hs_spotlight:
         enabled: true
         weight: 19
+      hs_testimonial:
+        weight: 28
+        enabled: false
       hs_text_area:
         weight: 20
+        enabled: false
+      hs_timeline:
+        weight: 30
+        enabled: false
+      hs_timeline_item:
+        weight: 31
         enabled: false
       hs_view:
         weight: 21
         enabled: false
       hs_webform:
         weight: 22
+        enabled: false
+      stanford_gallery:
+        weight: 34
         enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -63,25 +63,13 @@ settings:
       hs_spotlight:
         enabled: true
         weight: 19
-      hs_testimonial:
-        weight: 28
-        enabled: false
       hs_text_area:
         weight: 20
-        enabled: false
-      hs_timeline:
-        weight: 30
-        enabled: false
-      hs_timeline_item:
-        weight: 31
         enabled: false
       hs_view:
         weight: 21
         enabled: false
       hs_webform:
         weight: 22
-        enabled: false
-      stanford_gallery:
-        weight: 34
         enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align.yml
@@ -1,0 +1,23 @@
+uuid: 513417e1-1917-4f29-bc7b-a929ac615d0d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_gradient_hero_align
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - options
+id: paragraph.hs_gradient_hero.field_hs_gradient_hero_align
+field_name: field_hs_gradient_hero_align
+entity_type: paragraph
+bundle: hs_gradient_hero
+label: 'Gradient Hero Alignment'
+description: 'The content within the Gradient Hero defaults to the left. Select Right Aligned to position the content to the right side of the Gradient Hero.'
+required: false
+translatable: false
+default_value:
+  -
+    value: content-default
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_align.yml
@@ -13,7 +13,7 @@ entity_type: paragraph
 bundle: hs_gradient_hero
 label: 'Gradient Hero Alignment'
 description: 'The content within the Gradient Hero defaults to the left. Select Right Aligned to position the content to the right side of the Gradient Hero.'
-required: false
+required: true
 translatable: false
 default_value:
   -

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_body.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_body.yml
@@ -1,0 +1,29 @@
+uuid: d1f6e33d-0eba-4fed-8d13-63b77186f2b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_gradient_hero_body
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    minimal_html: minimal_html
+    basic_html: '0'
+    basic_html_without_media: '0'
+    full_html: '0'
+    plain_text: '0'
+id: paragraph.hs_gradient_hero.field_hs_gradient_hero_body
+field_name: field_hs_gradient_hero_body
+entity_type: paragraph
+bundle: hs_gradient_hero
+label: 'Gradient Hero Body'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_image.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_image.yml
@@ -1,0 +1,28 @@
+uuid: 0117ac66-6c30-451b-b696-01c2b32121f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_gradient_hero_image
+    - media.type.image
+    - paragraphs.paragraphs_type.hs_gradient_hero
+id: paragraph.hs_gradient_hero.field_hs_gradient_hero_image
+field_name: field_hs_gradient_hero_image
+entity_type: paragraph
+bundle: hs_gradient_hero
+label: 'Gradient Hero Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_link.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_link.yml
@@ -1,0 +1,23 @@
+uuid: 6e3ce8ba-0ad3-4d76-982b-9816ce62af4f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_gradient_hero_link
+    - paragraphs.paragraphs_type.hs_gradient_hero
+  module:
+    - link
+id: paragraph.hs_gradient_hero.field_hs_gradient_hero_link
+field_name: field_hs_gradient_hero_link
+entity_type: paragraph
+bundle: hs_gradient_hero
+label: 'Gradient Hero Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title.yml
+++ b/config/default/field.field.paragraph.hs_gradient_hero.field_hs_gradient_hero_title.yml
@@ -1,0 +1,19 @@
+uuid: e7a2a2ae-9d29-47a0-91bb-f54f7c4b0a2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_gradient_hero_title
+    - paragraphs.paragraphs_type.hs_gradient_hero
+id: paragraph.hs_gradient_hero.field_hs_gradient_hero_title
+field_name: field_hs_gradient_hero_title
+entity_type: paragraph
+bundle: hs_gradient_hero
+label: 'Gradient Hero Title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_hs_row_components
+    - paragraphs.paragraphs_type.hs_gradient_hero
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
     - paragraphs.paragraphs_type.hs_timeline
@@ -27,6 +28,7 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      hs_gradient_hero: hs_gradient_hero
       hs_priv_text_area: hs_priv_text_area
       hs_row: hs_row
       hs_timeline: hs_timeline
@@ -42,8 +44,8 @@ settings:
         weight: -33
         enabled: false
       hs_gradient_hero:
+        enabled: true
         weight: -32
-        enabled: false
       hs_hero_image:
         weight: -31
         enabled: false

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -41,6 +41,9 @@ settings:
       hs_carousel:
         weight: 12
         enabled: false
+      hs_gradient_hero:
+        weight: 21
+        enabled: false
       hs_hero_image:
         weight: 13
         enabled: false

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -33,37 +33,37 @@ settings:
       stanford_gallery: stanford_gallery
     target_bundles_drag_drop:
       hs_accordion:
-        weight: 11
+        weight: -35
         enabled: false
       hs_banner:
-        weight: 16
+        weight: -34
         enabled: false
       hs_carousel:
-        weight: 12
+        weight: -33
         enabled: false
       hs_gradient_hero:
-        weight: 21
+        weight: -32
         enabled: false
       hs_hero_image:
-        weight: 13
+        weight: -31
         enabled: false
       hs_postcard:
-        weight: 14
+        weight: -30
         enabled: false
       hs_priv_text_area:
         enabled: true
         weight: 16
       hs_row:
         enabled: true
-        weight: 17
+        weight: -27
       hs_spotlight:
-        weight: 23
+        weight: -26
         enabled: false
       hs_testimonial:
-        weight: 24
+        weight: -25
         enabled: false
       hs_text_area:
-        weight: 18
+        weight: -24
         enabled: false
       hs_timeline:
         enabled: true
@@ -72,12 +72,12 @@ settings:
         weight: 27
         enabled: false
       hs_view:
-        weight: 19
+        weight: -22
         enabled: false
       hs_webform:
-        weight: 20
+        weight: -21
         enabled: false
       stanford_gallery:
         enabled: true
-        weight: 28
+        weight: -20
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph_row.hs_flexible_page.field_hs_flexible_components.yml
+++ b/config/default/field.field.paragraph_row.hs_flexible_page.field_hs_flexible_components.yml
@@ -38,6 +38,9 @@ settings:
       hs_carousel:
         enabled: true
         weight: 15
+      hs_gradient_hero:
+        weight: 21
+        enabled: false
       hs_hero_image:
         weight: 16
         enabled: false
@@ -56,13 +59,25 @@ settings:
       hs_spotlight:
         weight: 21
         enabled: false
+      hs_testimonial:
+        weight: 28
+        enabled: false
       hs_text_area:
         weight: 22
+        enabled: false
+      hs_timeline:
+        weight: 30
+        enabled: false
+      hs_timeline_item:
+        weight: 31
         enabled: false
       hs_view:
         weight: 23
         enabled: false
       hs_webform:
         weight: 24
+        enabled: false
+      stanford_gallery:
+        weight: 34
         enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph_row.hs_flexible_page.field_hs_flexible_components.yml
+++ b/config/default/field.field.paragraph_row.hs_flexible_page.field_hs_flexible_components.yml
@@ -59,25 +59,13 @@ settings:
       hs_spotlight:
         weight: 21
         enabled: false
-      hs_testimonial:
-        weight: 28
-        enabled: false
       hs_text_area:
         weight: 22
-        enabled: false
-      hs_timeline:
-        weight: 30
-        enabled: false
-      hs_timeline_item:
-        weight: 31
         enabled: false
       hs_view:
         weight: 23
         enabled: false
       hs_webform:
         weight: 24
-        enabled: false
-      stanford_gallery:
-        weight: 34
         enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.storage.paragraph.field_hs_gradient_hero_align.yml
+++ b/config/default/field.storage.paragraph.field_hs_gradient_hero_align.yml
@@ -1,0 +1,27 @@
+uuid: 8db8180c-d7b8-4416-94c1-db85e092d75c
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_hs_gradient_hero_align
+field_name: field_hs_gradient_hero_align
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: content-default
+      label: 'Left Aligned (Default)'
+    -
+      value: content-right
+      label: 'Right Aligned'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_gradient_hero_body.yml
+++ b/config/default/field.storage.paragraph.field_hs_gradient_hero_body.yml
@@ -1,0 +1,19 @@
+uuid: 04562150-ff3e-44ac-a232-e46d510ce699
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_hs_gradient_hero_body
+field_name: field_hs_gradient_hero_body
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_gradient_hero_image.yml
+++ b/config/default/field.storage.paragraph.field_hs_gradient_hero_image.yml
@@ -1,0 +1,20 @@
+uuid: 339c49df-731b-461c-9ad2-3143368dcbf6
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_hs_gradient_hero_image
+field_name: field_hs_gradient_hero_image
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_gradient_hero_link.yml
+++ b/config/default/field.storage.paragraph.field_hs_gradient_hero_link.yml
@@ -1,0 +1,19 @@
+uuid: 735e2ec1-7254-4051-8bde-8a0cfd396266
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_hs_gradient_hero_link
+field_name: field_hs_gradient_hero_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_hs_gradient_hero_title.yml
+++ b/config/default/field.storage.paragraph.field_hs_gradient_hero_title.yml
@@ -1,0 +1,21 @@
+uuid: e18b9f20-f853-4015-ba63-a4e7246fe49d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hs_gradient_hero_title
+field_name: field_hs_gradient_hero_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.hs_gradient_hero.yml
+++ b/config/default/paragraphs.paragraphs_type.hs_gradient_hero.yml
@@ -1,0 +1,10 @@
+uuid: b11bbbcc-2cb9-4f9c-b674-5b8c19294fa6
+langcode: en
+status: true
+dependencies: {  }
+id: hs_gradient_hero
+label: 'Gradient Hero'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
@@ -1,0 +1,26 @@
+{%- set attributes = attributes.addClass('hb-gradient-hero') -%}
+
+{% if variant %}
+  {% set variant_class = "hb-gradient-hero--content-#{variant}" %} 
+  {% set attributes = attributes.addClass(variant_class) %}
+{% endif %}
+
+{% spaceless %}
+  <div{{ attributes }}>
+    <div class="hb-gradient-hero__wrapper">
+      {% if image %}
+        <div class="hb-gradient-hero__image-wrapper">
+          {{ image }}
+        </div>
+      {% endif %}
+      {% if overlay_text %}
+        <div class="hb-gradient-hero__text">
+          {{ overlay_text }}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endspaceless %}
+
+{# TODO: if statement to left / right content alignment #}
+{# TODO: update so gradient hero can be accessed in the hero section #}

--- a/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
@@ -21,6 +21,3 @@
     </div>
   </div>
 {% endspaceless %}
-
-{# TODO: if statement to left / right content alignment #}
-{# TODO: update so gradient hero can be accessed in the hero section #}

--- a/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
+++ b/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.html.twig
@@ -1,6 +1,6 @@
 {%- set attributes = attributes.addClass('hb-gradient-hero') -%}
 
-{% if variant %}
+{% if variant == 'right' %}
   {% set variant_class = "hb-gradient-hero--content-#{variant}" %} 
   {% set attributes = attributes.addClass(variant_class) %}
 {% endif %}

--- a/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.ui_patterns.yml
@@ -3,11 +3,11 @@ gradient-hero:
   description: ""
   variants:
     default:
-      label: Content Right
-      description: Displays text content on the right side.
-    left:
       label: Content Left
       description: Displays text content on the left side.
+    right:
+      label: Content Right
+      description: Displays text content on the right side.
   fields:
     image:
       label: "Image"

--- a/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/gradient-hero/gradient-hero.ui_patterns.yml
@@ -1,0 +1,25 @@
+gradient-hero:
+  label: "Gradient Hero"
+  description: ""
+  variants:
+    default:
+      label: Content Right
+      description: Displays text content on the right side.
+    left:
+      label: Content Left
+      description: Displays text content on the left side.
+  fields:
+    image:
+      label: "Image"
+      preview:
+        theme: image
+        uri: "http://placecorgi.com/2000/800"
+        width: 2000
+        height: 800
+      type: mixed
+    overlay_text:
+      label: "Overlay Text"
+      type: mixed
+      preview: "<h2>Etiam sollicitudin</h2><p>ipsum eu pulvinar rutrum, tellus ipsum laoreet sapien, quis venenatis ante odio sit amet eros. Lorem ipsum dolor sit amet</p><a class=\"decanter-button\">augue augue mollis justo.</a>"
+  use: "@humsci_basic/gradient-hero/gradient-hero.html.twig"
+  

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 11);
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 12;
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 13;
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 12);
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 12);
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 11);
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 12;
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 13;
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');


### PR DESCRIPTION
# [STN-675](https://sparkbox.atlassian.net/browse/STN-675) READY FOR REVIEW

## Summary
The work in this PR creates a Gradient Hero component that allows to highlight imagery in the Hero Region and Components region on a page. This PR focuses on creating the new gradient hero paragraph type, styles are not included.

_Note:_ Timeline and timeline item are referenced in the configuration files. I did not remove them because I assumed that the work on the timeline will probably be merged before this PR is. If that is not the case, I can remove any references to timeline.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. In your CLI, run npm run test and confirm all tests pass.
2. In order for the gradient hero paragraph to be recognized, you will need to clear your cache by running `lando drush @sparkbox_sandbox.local cr`. Run `lando drush @sparkbox_sandbox.local config-import --partial` to import the config files.
3. To test a gradient, create a new flexible page or open an existing one. Under Components add a Gradient Hero. Fill in all the fields.
4. By default, the gradient hero should not be available via the components dropdown when creating a flexible page. In order to test the work in this PR you will need to go to the Component Settings for a Flexible Page and `uncheck` the `Gradient Hero` under `Reference Type`. Be sure to revert this change when you are done testing the scenarios listed below. Quick link:  http://sparkbox-sandbox.suhumsci.loc/admin/structure/types/manage/hs_basic_page/fields/node.hs_basic_page.field_hs_page_components
5. By default, the gradient hero should also not be available via the row component dropdown. In order to test the gradient hero within a row, you will need to go to the Component Settings for a Flexible Page for Rows and `uncheck` the `Gradient Hero` under `Reference Type`. Again be sure to revert this change when testing is complete. Quick link: http://sparkbox-sandbox.suhumsci.loc/admin/structure/paragraphs_type/hs_row/fields
6. To test the gradient hero in the hero section of a flexible page, you must add it to the hero image settings configuration. Under this quick link: http://sparkbox-sandbox.suhumsci.loc/admin/structure/types/manage/hs_basic_page/fields/node.hs_basic_page.field_hs_page_hero `check` the `Gradient Hero` under `Reference Type`. Remember to revert this change when testing is complete.

Test the following scenarios:
- [x] A gradient hero within the hero component section at the top of a page.
- [x] A gradient hero within the main content section of a page.
- [x] The gradient hero contains the following fields: image, title, body, link, and align
- [x] A gradient hero with default alignment to the left. Open your browser's dev tools and confirm that the class of `hb-hero-gradient--content-default` co-exists beside the pattern's class of `hb-gradient-hero`.
- [x] A gradient hero where the alignment has been changed to `-None-` also has the `hb-hero-gradient--content-default` class.
- [x] A gradient hero where the alignment has been set to `Right Aligned` should have the class of `hb-hero-gradient--content-right`.
- [x] Add a caption / credit to a gradient hero image. It should display the correct caption / credit styles (white text on a black background that fades to transparent.)
- [x] The gradient hero is keyboard accessible.
- [x] The addition of the gradient hero paragraph type does not affect any of the existing paragraph types.
- [x] The gradient hero can be added to the Colorful and Traditional themes.

## Expected results of adding a gradient hero to a flexible page. Note there are no styles.
<img width="1354" alt="gradient hero" src="https://user-images.githubusercontent.com/12678977/113316692-a09c7280-92dc-11eb-9c06-35827b02164d.png">
