### PR TITLE
Chore: Add config override hs_timeline paragraph component

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -167,3 +167,45 @@ function su_humsci_profile_post_update_8290() {
   $field->set('settings', $settings);
   $field->save();
 }
+
+/**
+ * Disable the new timeline paragraph type on older themes.
+ */
+function su_humsci_profile_post_update_9001() {
+  $theme = \Drupal::config('system.theme')->get('default');
+  $newer_themes = [
+    'humsci_airy',
+    'humsci_basic',
+    'humsci_colorful',
+    'humsci_traditional',
+  ];
+  if (in_array($theme, $newer_themes)) {
+    return;
+  }
+
+  /** @var \Drupal\field\FieldConfigInterface $field */
+  $field = \Drupal::entityTypeManager()
+    ->getStorage('field_config')
+    ->load('node.hs_basic_page.field_hs_page_components');
+  $settings = $field->getSettings();
+  $settings['handler_settings']['target_bundles']['hs_timeline_item'] = 'hs_timeline_item';
+  $settings['handler_settings']['target_bundles_drag_drop']['hs_timeline'] = [
+    'enabled' => TRUE,
+    'weight' => 99,
+  ];
+  $field->set('settings', $settings);
+  $field->save();
+
+  /** @var \Drupal\field\FieldConfigInterface $field */
+  $field = \Drupal::entityTypeManager()
+    ->getStorage('field_config')
+    ->load('paragraph.hs_row.field_hs_row_components');
+  $settings = $field->getSettings();
+  $settings['handler_settings']['target_bundles']['hs_timeline_item'] = 'hs_timeline_item';
+  $settings['handler_settings']['target_bundles_drag_drop']['hs_timeline'] = [
+    'enabled' => TRUE,
+    'weight' => 99,
+  ];
+  $field->set('settings', $settings);
+  $field->save();
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR adds a config override for the hs_timeline Paragraph component which is within the [Sparkbox Sprint 37](https://github.com/SU-HSDO/suhumsci/tree/sparkbox-sprint-37).

Config files for reference:
https://github.com/SU-HSDO/suhumsci/blob/3751f4ccad6bdeb0c697dd60427fd57a1c76bc6e/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml

https://github.com/SU-HSDO/suhumsci/blob/3751f4ccad6bdeb0c697dd60427fd57a1c76bc6e/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml

## Need Review By (Date)
asap

## Urgency
high


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
