### PR TITLE
chore:  add callout box and gradient hero overrides to post update

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -107,3 +107,18 @@ function su_humsci_profile_post_update_9002() {
 function su_humsci_profile_post_update_9004() {
   _humsci_profile_disable_paragraph_type('hs_collection');
 }
+
+/**
+ * Disable the callout box paragraph type on older themes and rows.
+ */
+function su_humsci_profile_post_update_9005() {
+  _humsci_profile_disable_paragraph_type('hs_callout_box', FALSE);
+  _humsci_profile_disable_paragraph_type('hs_callout_box', TRUE, TRUE);
+}
+
+/**
+ * Disable the gradient hero paragraph type on all themes and rows.
+ */
+function su_humsci_profile_post_update_9006() {
+  _humsci_profile_disable_paragraph_type('hs_gradient_hero', TRUE, TRUE);
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adding functions for overriding the the paragraph components, Gradient Hero and Callout Box.

Callout Box:
- Should not be available on Legacy themes.
- Should be available on all current themes, but not available in the rows component.

Gradient Hero:
- Should not be available by default on Legacy, any current themes or row components.

## Need Review By (Date)
asap

## Urgency
high


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
