### PR TITLE
STBN-736:  Timeline Expand / Collapse Variant Checkbox Label

### DIFF
--- a/config/default/field.field.paragraph.hs_timeline.field_hs_field_add_expand_collap.yml
+++ b/config/default/field.field.paragraph.hs_timeline.field_hs_field_add_expand_collap.yml
@@ -9,7 +9,7 @@ id: paragraph.hs_timeline.field_hs_field_add_expand_collap
 field_name: field_hs_field_add_expand_collap
 entity_type: paragraph
 bundle: hs_timeline
-label: 'Add Expand/Collapse'
+label: 'Collapse by default'
 description: 'Enabling this checkbox hides the Description contents in collapsed area(s) which are displayed when expanded.'
 required: false
 translatable: false

--- a/docroot/themes/humsci/humsci_basic/patterns/timeline/timeline.ui_patterns.yml
+++ b/docroot/themes/humsci/humsci_basic/patterns/timeline/timeline.ui_patterns.yml
@@ -2,7 +2,7 @@ timeline:
   label: "Timeline"
   fields:
     add-expand-collapse:
-      label: "Add Expand/Collapse"
+      label: "Collapse by default"
       type: boolean
       description: When checked (true) all timeline items are collapsed on page load.
       preview: TRUE


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
When a user is adding a Vertical Timeline component to a flexible page, the label text for the checkbox to collapse all timeline items reads `Add Expand/Collapse`. The work in this PR updates the label text to `Expand by default`.

## Need Review By (Date)
5/3

## Urgency
medium

## Steps to Test
1. In your CLI, run `npm run test` and confirm all tests pass.
2. In order for the vertical timeline and timeline patterns to be recognized, you will need to clear your cache by running `lando drush @sparkbox_sandbox.local cr`. Run `lando drush @sparkbox_sandbox.local config-import --partial` to import the. updated config file.
3. To test, go to an existing flexible page with a vertical timeline component. Edit the timeline component. Find the checkbox that allows you to set the timeline to a collapsed state. Confirm that the label for the checkbox has changed from `Add Expand/Collapse` to `Collapse by default`.

<img width="736" alt="update description for expand collapse" src="https://user-images.githubusercontent.com/12678977/116709573-cdf14480-a99e-11eb-96c5-4d025d57cdab.png">
