### PR TITLE
STN-728:  Duplicate for gradient slider

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_gradient_hero_slider.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_gradient_hero_slider.default.yml
@@ -28,7 +28,7 @@ content:
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
-        duplicate: '0'
+        duplicate: duplicate
     third_party_settings: {  }
     region: content
 hidden:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This adds the ability to duplicate to the slides within the Gradient Slider.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. pull down this branch
2. Import the new drupal config
3. After the new configuration has been imported, you'll want to create a Flexible Page with Gradient Hero Slider or go to a page with an existing slider you've already created.
4. Once that component is created you'll need to add one slide. after that slide is created you will have the option to duplicate that slide by clicking on the dot in the upper right-hand side of the slide fieldset.
![image](https://user-images.githubusercontent.com/9355698/117041628-0d8a9a00-acd9-11eb-8b55-a5b30b12e818.png)


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
