### PR TITLE
STN-728: Update Gradient Hero Slider config

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_gradient_hero_slider.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_gradient_hero_slider.default.yml
@@ -18,7 +18,7 @@ content:
     settings:
       title: Slide
       title_plural: Slides
-      edit_mode: open
+      edit_mode: closed
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0
@@ -28,7 +28,7 @@ content:
       features:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
-        duplicate: '0'
+        duplicate: duplicate
     third_party_settings: {  }
     region: content
 hidden:

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
+    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
@@ -36,6 +37,7 @@ settings:
       stanford_gallery: stanford_gallery
       hs_timeline_item: hs_timeline_item
       hs_collection: hs_collection
+      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: -34
@@ -56,8 +58,8 @@ settings:
         enabled: true
         weight: -32
       hs_gradient_hero_slider:
+        enabled: true
         weight: 27
-        enabled: false
       hs_hero_image:
         weight: -30
         enabled: false

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -7,7 +7,6 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_banner
     - paragraphs.paragraphs_type.hs_carousel
-    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_hero_image
     - paragraphs.paragraphs_type.hs_spotlight
   module:
@@ -33,7 +32,6 @@ settings:
       hs_carousel: hs_carousel
       hs_banner: hs_banner
       hs_spotlight: hs_spotlight
-      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: 12
@@ -54,8 +52,8 @@ settings:
         weight: 21
         enabled: false
       hs_gradient_hero_slider:
-        enabled: true
         weight: 27
+        enabled: false
       hs_hero_image:
         enabled: true
         weight: 3

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -4,9 +4,10 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_hs_row_components
+    - paragraphs.paragraphs_type.hs_callout_box
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
-    - paragraphs.paragraphs_type.hs_callout_box
+    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
     - paragraphs.paragraphs_type.hs_timeline
@@ -30,13 +31,14 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
-      hs_gradient_hero: hs_gradient_hero
       hs_callout_box: hs_callout_box
+      hs_gradient_hero: hs_gradient_hero
       hs_priv_text_area: hs_priv_text_area
       hs_row: hs_row
-      hs_collection: hs_collection
       hs_timeline: hs_timeline
       stanford_gallery: stanford_gallery
+      hs_collection: hs_collection
+      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: -35
@@ -56,6 +58,9 @@ settings:
       hs_gradient_hero:
         enabled: true
         weight: -32
+      hs_gradient_hero_slider:
+        enabled: true
+        weight: 27
       hs_hero_image:
         weight: -31
         enabled: false

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 13);
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 12);
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Updates the following configuration:
- Removes the component from component, hero, and row field selection.
- Adds duplicate option to slides
- Make the existing slide fields collapsed by default

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. pull down this branch
2. Import the new drupal config
3. The Gradient Hero Component should now not be on by default in the Hero, Component or Row areas of the site and will need to be re-enabled in those areas on Flexible Page Content-Type and Paragraph Rows Component to show up again as options.
4. To check the "Duplicate" option:
- Once that component is created you'll need to add one slide. after that slide is created you will have the option to duplicate that slide by clicking on the dot in the upper right-hand side of the slide fieldset.
![image](https://user-images.githubusercontent.com/9355698/117041628-0d8a9a00-acd9-11eb-8b55-a5b30b12e818.png)
5. Additionally, when entering the slides, you should verify that the slide fields within it are collapsed by default when editing existing sliders.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
