### PR TITLE
STN-759:  Update gradient hero link to use linkit field

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_gradient_hero.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_gradient_hero
   module:
     - allowed_formats
-    - link
+    - linkit
     - maxlength
     - media_library
     - text
@@ -54,8 +54,12 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-    third_party_settings: {  }
-    type: link_default
+      linkit_profile: default
+    third_party_settings:
+      maxlength:
+        maxlength_js: 80
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+    type: linkit
     region: content
   field_hs_gradient_hero_title:
     weight: 1


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
The Gradient Hero link field wasn't using Linkit (autocomplete for existing pages).

JIRA Card: https://sparkbox.atlassian.net/browse/STN-759

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. check branches
2. You'll need to import the configuration for the Gradient Hero component using `lando drush @sparkbox_sandbox.local config-import --partial`
3. Once your import has run properly, you may want to update your database  `lando drush @sparkbox_sandbox.local updb` and also clear cache  `lando drush @sparkbox_sandbox.local cr`.
4. Since Gradient hero slider is disabled at this time, [you'll need to turn it on for flexible page to be able to test it](http://sparkbox-sandbox.suhumsci.loc/admin/structure/types/manage/hs_basic_page/fields/node.hs_basic_page.field_hs_page_components).
5. After you've enabled that paragraph type, please create a Flexible page using a Gradient Hero Slider paragraph component.
6. Verify that the link field does an autocomplete search for internal pages/articles using the linkit module.
7. Also verify it has an 80 character count that shows up when you start to type in the link text field. (This is the same functionality as Postcard, if you'd like to compare.)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
