### PR TITLE
Chore: Enable gradient hero slider config by default

### DIFF
--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -7,7 +7,6 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
-    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
@@ -37,7 +36,6 @@ settings:
       stanford_gallery: stanford_gallery
       hs_timeline_item: hs_timeline_item
       hs_collection: hs_collection
-      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: -34
@@ -58,8 +56,8 @@ settings:
         enabled: true
         weight: -32
       hs_gradient_hero_slider:
-        enabled: true
         weight: 27
+        enabled: false
       hs_hero_image:
         weight: -30
         enabled: false

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.hs_basic_page
     - paragraphs.paragraphs_type.hs_banner
     - paragraphs.paragraphs_type.hs_carousel
+    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_hero_image
     - paragraphs.paragraphs_type.hs_spotlight
   module:
@@ -32,6 +33,7 @@ settings:
       hs_carousel: hs_carousel
       hs_banner: hs_banner
       hs_spotlight: hs_spotlight
+      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: 12
@@ -52,8 +54,8 @@ settings:
         weight: 21
         enabled: false
       hs_gradient_hero_slider:
+        enabled: true
         weight: 27
-        enabled: false
       hs_hero_image:
         enabled: true
         weight: 3

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -8,7 +8,6 @@ dependencies:
     - paragraphs.paragraphs_type.hs_clr_bnd
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
-    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
     - paragraphs.paragraphs_type.hs_timeline
@@ -40,7 +39,6 @@ settings:
       stanford_gallery: stanford_gallery
       hs_collection: hs_collection
       hs_clr_bnd: hs_clr_bnd
-      hs_gradient_hero_slider: hs_gradient_hero_slider
     target_bundles_drag_drop:
       hs_accordion:
         weight: -35
@@ -64,8 +62,8 @@ settings:
         enabled: true
         weight: -32
       hs_gradient_hero_slider:
-        enabled: true
         weight: 27
+        enabled: false
       hs_hero_image:
         weight: -31
         enabled: false

--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -14,7 +14,7 @@ class FlexiblePageCest {
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/hs_basic_page');
     $I->canSeeNumberOfElements('#edit-field-hs-page-hero-wrapper', 1);
-    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 13);
+    $I->canSeeNumberOfElements('#edit-field-hs-page-components-add-more input', 14);
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Postcard');
     $I->canSee('Card Title');


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This work updates the Gradient Hero Slider configuration so it is turned on in the Hero, Component regions of Flexible pages as well as Rows.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. If you have Gradient Hero Slider component turned on for the Component, Hero Regions and Rows, you should disable them before testing this branch.
2. You'll need to import the configuration for the Gradient Hero component using `lando drush @sparkbox_sandbox.local config-import --partial`
3. Once your import has run properly, you may want to update your database `lando drush @sparkbox_sandbox.local updb `and also clear cache `lando drush @sparkbox_sandbox.local cr`.
4. If you go to add a Flexible Page you should see that Gradient Hero Slider is now enabled in the Hero and Component region as well as Rows.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
