### PR TITLE
Chore: Disable color band on legacy post update

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -166,3 +166,11 @@ function su_humsci_profile_post_update_9008() {
   _humsci_profile_disable_page_paragraph('hs_gradient_hero_slider');
   _humsci_profile_disable_row_paragraph('hs_gradient_hero_slider');
 }
+
+/**
+ * Disable the color band paragraph type on older themes and older theme rows only.
+ */
+function su_humsci_profile_post_update_9009() {
+  _humsci_profile_disable_page_paragraph('hs_clr_bnd', FALSE);
+  _humsci_profile_disable_row_paragraph('hs_clr_bnd');
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR updates the post update hook to include disable the Color Band paragraph component for older themes and all theme rows.

## Need Review By (Date)
asap

## Urgency
high


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
