### PR TITLE
STN-807  Bug:  Photo album breakpoint

### DIFF
--- a/config/default/image.style.hs_slideshow_small_1000x750.yml
+++ b/config/default/image.style.hs_slideshow_small_1000x750.yml
@@ -1,7 +1,17 @@
 uuid: df96e3c0-7817-4a96-ab83-a21810cf88f0
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hs_slideshow_small_1000x750
 label: 'Slideshow Small (1000x750)'
-effects: {  }
+effects:
+  3d51e750-4a35-4e0d-832d-85da3bc4ae44:
+    uuid: 3d51e750-4a35-4e0d-832d-85da3bc4ae44
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1000
+      height: 750
+      crop_type: focal_point

--- a/config/default/responsive_image.styles.slideshow_responsive.yml
+++ b/config/default/responsive_image.styles.slideshow_responsive.yml
@@ -7,7 +7,6 @@ dependencies:
     - image.style.hs_slideshow_medium_1500x1125
     - image.style.hs_slideshow_small_1000x750
     - image.style.hs_slideshow_xsmall_800x600
-    - image.style.responsive_large
   module:
     - stanford_media
 id: slideshow_responsive
@@ -34,4 +33,4 @@ image_style_mappings:
     image_mapping_type: image_style
     image_mapping: hs_slideshow_xsmall_800x600
 breakpoint_group: stanford_media
-fallback_image_style: responsive_large
+fallback_image_style: hs_slideshow_large_2000x1500


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
At the medium breakpoint, the image is not conforming to the 4:3 aspect ratio.

I discovered the image style for "Slideshow Small" was not scaling and cropping correct to size and also updated the fallback image on the Responsive Slideshow style to use the large Slideshow image style instead of the responsive style with no height. 

https://sparkbox.atlassian.net/browse/STN-807

## Need Review By (Date)
7/6

## Urgency
medium

## Steps to Test
1. npm run test
2. Import the new Drupal config: `lando drush @sparkbox_sandbox.local cim --partial`
Note: This will wipe out any unsaved config you may have changed.
3. Check out the image style here: http://sparkbox-sandbox.suhumsci.loc/admin/config/media/image-styles/manage/hs_slideshow_small_1000x750
4. Verify the fallback style for the Responsive Image Style here: http://sparkbox-sandbox.suhumsci.loc/admin/config/media/responsive-image-style/slideshow_responsive
5. Create a slideshow using portrait and landscape images in the slider.
6. Check the breakpoint at about 983px to 773px, that was the area that was grabbing a fallback and not cropping correctly.
7. If it grabs the 1000x750 style and doesn't change the image ratio it should be all fixed up.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
