### PR TITLE
HSD8-1077 Allow site managers ability to build unpublished menu items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -293,6 +293,7 @@
                 "https://www.drupal.org/project/config_ignore/issues/2865419": "https://www.drupal.org/files/issues/2020-07-20/config_ignore-wildcard_force_import.patch"
             },
             "drupal/core": {
+                "https://www.drupal.org/project/drupal/issues/2807629": "https://www.drupal.org/files/issues/2021-04-20/2807629-39.patch",
                 "https://www.drupal.org/project/drupal/issues/2999491": "https://www.drupal.org/files/issues/2020-10-06/2999491--reusable-title-display--56.patch",
                 "https://www.drupal.org/project/drupal/issues/2981837": "https://www.drupal.org/files/issues/2019-05-22/findMigrationDependencies-null-process-value-2981837-5.patch",
                 "https://www.drupal.org/project/drupal/issues/2925297": "https://www.drupal.org/files/issues/2019-09-26/core-typed_config_handle_missing_config-2925297-18.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c625835eed41ceedff48560b8c57b562",
+    "content-hash": "1bff54b6e1cd7777c3754920b171e6f4",
     "packages": [
         {
             "name": "acquia/blt",
@@ -7669,7 +7669,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/migrate_tools.git",
-                "reference": "9d9c02f1cb8fcd7afa83e8eb2eaf7def75673a4e"
+                "reference": "56d82b4fc111dd26f2c3a1e53c06015eb854df20"
             },
             "require": {
                 "drupal/core": "^8.8 | ^9",
@@ -7689,8 +7689,8 @@
                     "dev-5.x": "5.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-5.0+12-dev",
-                    "datestamp": "1609779021",
+                    "version": "8.x-5.0+13-dev",
+                    "datestamp": "1618603463",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -7716,6 +7716,10 @@
                     "name": "Lucas Hedding",
                     "homepage": "https://www.drupal.org/u/heddn",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
                 }
             ],
             "description": "Tools to assist in developing and running migrations.",
@@ -12529,16 +12533,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.5",
+            "version": "v4.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f"
+                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4432ba399e47c66624bc73c8c0f811e5c109576f",
-                "reference": "4432ba399e47c66624bc73c8c0f811e5c109576f",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
                 "shasum": ""
             },
             "require": {
@@ -12579,9 +12583,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
             },
-            "time": "2021-05-03T19:11:20+00:00"
+            "time": "2021-07-03T13:36:55+00:00"
         },
         {
             "name": "onlyextart/colorbox",
@@ -24392,12 +24396,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/blt-sws.git",
-                "reference": "0551c1ba4360f75075ffdad1f4f3a73467fe5ddf"
+                "reference": "76b0b25f9bbe3a8af820f0da83d4540dd7f9a882"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/blt-sws/zipball/0551c1ba4360f75075ffdad1f4f3a73467fe5ddf",
-                "reference": "0551c1ba4360f75075ffdad1f4f3a73467fe5ddf",
+                "url": "https://api.github.com/repos/SU-SWS/blt-sws/zipball/76b0b25f9bbe3a8af820f0da83d4540dd7f9a882",
+                "reference": "76b0b25f9bbe3a8af820f0da83d4540dd7f9a882",
                 "shasum": ""
             },
             "require": {
@@ -24425,7 +24429,7 @@
                 "issues": "https://github.com/SU-SWS/blt-sws/issues",
                 "source": "https://github.com/SU-SWS/blt-sws/tree/main"
             },
-            "time": "2021-06-14T16:06:07+00:00"
+            "time": "2021-07-02T16:59:51+00:00"
         },
         {
             "name": "su-sws/drupal-dev",

--- a/tests/codeception/acceptance/Install/InstallStateCest.php
+++ b/tests/codeception/acceptance/Install/InstallStateCest.php
@@ -65,4 +65,36 @@ class InstallStateCest {
     $I->canSeeNumberOfElements('#toolbar-item-shortcuts-tray a', 40);
   }
 
+  /**
+   * A site manager should be able to place a page under an unpublished page.
+   */
+  public function testUnpublishedMenuItems(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/node/add/hs_basic_page');
+    $I->fillField('Title', 'Unpublished Parent');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Unpublished Parent');
+    $I->uncheckOption('Publish');
+    $I->click('Save');
+    $I->canSee('Unpublished Parent', 'h1');
+    $I->canSee('Unpublished Parent', 'nav a[data-unpublished-node]');
+    $I->canSee('Unpublished');
+
+    $I->amOnPage('/node/add/hs_basic_page');
+    $I->fillField('Title', 'Child Page');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Child Page');
+    $I->selectOption('Parent link', '-- Unpublished Parent');
+    $I->click('Change parent (update list of weights)');
+    $I->uncheckOption('Publish');
+    $I->click('Save');
+    $I->canSee('Child Page', 'h1');
+    $I->canSee('Child Page', 'nav a[data-unpublished-node]');
+    $I->canSee('Unpublished');
+
+    $I->click('Edit', '.tabs__tab');
+    $I->click('Save');
+    $I->assertEquals('/unpublished-parent/child-page', $I->grabFromCurrentUrl());
+  }
+
 }

--- a/tests/codeception/acceptance/MenuItemsCest.php
+++ b/tests/codeception/acceptance/MenuItemsCest.php
@@ -22,6 +22,38 @@ class MenuItemsCest {
   }
 
   /**
+   * A site manager should be able to place a page under an unpublished page.
+   */
+  public function testUnpublishedMenuItems(AcceptanceTester $I){
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/node/add/hs_basic_page');
+    $I->fillField('Title', 'Unpublished Parent');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Unpublished Parent');
+    $I->uncheckOption('Publish');
+    $I->click('Save');
+    $I->canSee('Unpublished Parent', 'h1');
+    $I->canSee('Unpublished Parent', 'nav a[data-unpublished-node]');
+    $I->canSee('Unpublished');
+
+    $I->amOnPage('/node/add/hs_basic_page');
+    $I->fillField('Title', 'Child Page');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Child Page');
+    $I->selectOption('Parent link', '-- Unpublished Parent');
+    $I->click('Change parent (update list of weights)');
+    $I->uncheckOption('Publish');
+    $I->click('Save');
+    $I->canSee('Child Page', 'h1');
+    $I->canSee('Child Page', 'nav a[data-unpublished-node]');
+    $I->canSee('Unpublished');
+
+    $I->click('Edit', '.tabs__tab');
+    $I->click('Save');
+    $I->assertEquals('/unpublished-parent/child-page', $I->grabFromCurrentUrl());
+  }
+
+  /**
    * Get all relative url paths to test.
    *
    * @param \AcceptanceTester $I

--- a/tests/codeception/acceptance/MenuItemsCest.php
+++ b/tests/codeception/acceptance/MenuItemsCest.php
@@ -22,38 +22,6 @@ class MenuItemsCest {
   }
 
   /**
-   * A site manager should be able to place a page under an unpublished page.
-   */
-  public function testUnpublishedMenuItems(AcceptanceTester $I){
-    $I->logInWithRole('site_manager');
-    $I->amOnPage('/node/add/hs_basic_page');
-    $I->fillField('Title', 'Unpublished Parent');
-    $I->checkOption('Provide a menu link');
-    $I->fillField('Menu link title', 'Unpublished Parent');
-    $I->uncheckOption('Publish');
-    $I->click('Save');
-    $I->canSee('Unpublished Parent', 'h1');
-    $I->canSee('Unpublished Parent', 'nav a[data-unpublished-node]');
-    $I->canSee('Unpublished');
-
-    $I->amOnPage('/node/add/hs_basic_page');
-    $I->fillField('Title', 'Child Page');
-    $I->checkOption('Provide a menu link');
-    $I->fillField('Menu link title', 'Child Page');
-    $I->selectOption('Parent link', '-- Unpublished Parent');
-    $I->click('Change parent (update list of weights)');
-    $I->uncheckOption('Publish');
-    $I->click('Save');
-    $I->canSee('Child Page', 'h1');
-    $I->canSee('Child Page', 'nav a[data-unpublished-node]');
-    $I->canSee('Unpublished');
-
-    $I->click('Edit', '.tabs__tab');
-    $I->click('Save');
-    $I->assertEquals('/unpublished-parent/child-page', $I->grabFromCurrentUrl());
-  }
-
-  /**
    * Get all relative url paths to test.
    *
    * @param \AcceptanceTester $I


### PR DESCRIPTION
- 9.2.1
- Improved Certificate command by disabling any existing certs before enabling the new one
- Updated dependencies Jun 30 2021
- HSD8-1093 Fixed group blocks that have empty content
- HSD8-1077 Allow site managers ability to build unpublished menu items

# READY FOR REVIEW

## Summary
_[briefly summarize the changes here]_

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
