### PR TITLE
STN-732:  Add Photo Album Grid Lightbox / Colorbox Styles

### DIFF
--- a/config/default/colorbox.settings.yml
+++ b/config/default/colorbox.settings.yml
@@ -1,5 +1,5 @@
 custom:
-  style: plain
+  style: example2
   activate: 0
   transition_type: elastic
   transition_speed: 350

--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -173,6 +173,7 @@
   'components/pattern.callout-box',
   'components/pattern.color-band',
   'components/pattern.photo-album-slider',
+  'components/pattern.photo-album-grid',
 
   // =====================================================================
   // 7. Admin

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
@@ -110,7 +110,7 @@
       @include hb-traditional {
         @include hb-icon-background('minus', 'black');
       }
-  
+
       @include hb-themes(('colorful', 'airy')) {
         @include hb-icon-background('minus', 'primary');
       }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
@@ -86,20 +86,39 @@
   top: 0;
   height: hb-calculate-rems(44px);
 
-  &::before { // TODO: test with caret icon - replace with X
+  &::before {
     @include hb-traditional {
-      @include hb-icon-background('slider-caret', 'black');
+      @include hb-icon-background('plus', 'black');
     }
 
     @include hb-themes(('colorful', 'airy')) {
-      @include hb-icon-background('slider-caret', 'primary');
+      @include hb-icon-background('plus', 'primary');
     }
 
     content: '';
-    height: hb-calculate-rems(15px);
-    width: hb-calculate-rems(8.5px);
+    height: hb-calculate-rems(20px);
+    width: hb-calculate-rems(20px);
     position: absolute;
-    transition: hb-transition(transform); // necessary????
+    top: hb-calculate-rems(12px);
+    right: hb-calculate-rems(12px);
+    transform: rotate(-45deg);
+    transition: hb-transition(transform);
+  }
+
+  &:hover {
+    &::before {
+      @include hb-traditional {
+        @include hb-icon-background('minus', 'black');
+      }
+  
+      @include hb-themes(('colorful', 'airy')) {
+        @include hb-icon-background('minus', 'primary');
+      }
+
+      height: hb-calculate-rems(2px);
+      top: hb-calculate-rems(21px);
+      transform: rotate(0deg);
+    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
@@ -105,7 +105,8 @@
     transition: hb-transition(transform);
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     &::before {
       @include hb-traditional {
         @include hb-icon-background('minus', 'black');

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.photo-album-grid.scss
@@ -1,0 +1,125 @@
+// Photo Album Grid Colorbox Styles
+#cboxPrevious,
+#cboxNext,
+#cboxClose {
+  @include hb-global-color('background', 'white');
+  width: hb-calculate-rems(44px);
+  opacity: 50%;
+  transition: hb-transition(opacity);
+
+  &:hover {
+    opacity: 60%;
+  }
+
+  &:focus {
+    opacity: 100%;
+  }
+
+  // additional focus styles for keyboard users only
+  // that compliments browser default styles
+  &:focus-visible {
+    opacity: 100%;
+    outline: 5px auto -webkit-focus-ring-color; // Chrome only
+  }
+}
+
+
+
+#cboxPrevious,
+#cboxNext {
+  top: 50%;
+  bottom: 50%;
+  transform: translate(0, -50%);
+  height: hb-calculate-rems(88px);
+
+  // shared arrow properties
+  &::before {
+    @include hb-traditional {
+      @include hb-icon-background('slider-caret', 'black');
+    }
+
+    @include hb-themes(('colorful', 'airy')) {
+      @include hb-icon-background('slider-caret', 'primary');
+    }
+
+    content: '';
+    height: hb-calculate-rems(30px);
+    width: hb-calculate-rems(17px);
+    position: absolute;
+    top: hb-calculate-rems(29px);
+    transition: hb-transition(transform);
+  }
+}
+
+#cboxPrevious {
+  left: 0;
+  border-radius: 0 hb-calculate-rems(88px) hb-calculate-rems(88px) 0;
+
+  &::before {
+    transform: scaleX(-1);
+    left: hb-calculate-rems(8px);
+  }
+
+  &:hover {
+    &::before {
+      transform: scaleX(-1) translateX(2px);
+    }
+  }
+}
+
+#cboxNext {
+  right: 0;
+  border-radius: hb-calculate-rems(88px) 0 0 hb-calculate-rems(88px);
+
+  &::before {
+    right: hb-calculate-rems(8px);
+  }
+
+  &:hover {
+    &::before {
+      transform: translateX(2px);
+    }
+  }
+}
+
+#cboxClose {
+  top: 0;
+  height: hb-calculate-rems(44px);
+
+  &::before { // TODO: test with caret icon - replace with X
+    @include hb-traditional {
+      @include hb-icon-background('slider-caret', 'black');
+    }
+
+    @include hb-themes(('colorful', 'airy')) {
+      @include hb-icon-background('slider-caret', 'primary');
+    }
+
+    content: '';
+    height: hb-calculate-rems(15px);
+    width: hb-calculate-rems(8.5px);
+    position: absolute;
+    transition: hb-transition(transform); // necessary????
+  }
+}
+
+#cboxContent,
+#cboxLoadedContent {
+  background: transparent;
+}
+
+// caption / credit
+#cboxTitle {
+  position: relative;
+  top: 0;
+  float: unset !important;
+
+  p {
+    @include hb-caption-credit;
+    width: calc(85% - 0.75rem);
+
+    @include grid-media-min('sm') {
+      width: calc(85% - 1.325rem);
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
As a Site Manager, or Contributor, I want the styles of the Photo Album with a Lightbox modal to match the look and feel of the Colorful and Traditional themes.

## Need Review By (Date)
7/23

## Urgency
medium

## Steps to Test
1. In your CLI, run `npm run test` and confirm our tests continue to pass.
2. Next run `lando drush @sparkbox_sandbox.local cr` and then `lando drush @sparkbox_sandbox.local cim --partial` to clear the cache and ensure that you are seeing the updated configuration file and styles.
3. To review the work in this PR you will need to use a page which has the photo album component. If you have synced with staging recently you can use https://sparkbox-sandbox-stage.stanford.edu/qa-photo-grid. Note that I would add more photos to test a variety of sizes and image without caption/credits. Or you can create a new flexible page and add a photo album slider. [Components > Photo Album. Under Style choose Display Mode of Grid.] I recommend creating a grid with several images with and without caption/credits.
4. Review the following:
    - [x] Previous and next button styles match those also used on the photo album slider and gradient hero slider components.
     - [x] The lightbox works and displays correctly when logged in and logged out.
     - [x] Previous, next, and close buttons are keyboard accessible.
     - [x] Images in the lightbox can be navigated to and thru via the arrow keys.
     - [x] Caption/Credits display as expected in photo grids and lightbox elements.
