### PR TITLE
Fix(STN-877): config updates private collections

### DIFF
--- a/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_items.yml
+++ b/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_items.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.paragraph.field_hs_collection_items
     - paragraphs.paragraphs_type.hs_accordion
-    - paragraphs.paragraphs_type.hs_clr_bnd
     - paragraphs.paragraphs_type.hs_postcard
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
@@ -28,7 +27,6 @@ settings:
     negate: 0
     target_bundles:
       hs_accordion: hs_accordion
-      hs_clr_bnd: hs_clr_bnd
       hs_postcard: hs_postcard
       hs_priv_text_area: hs_priv_text_area
       hs_timeline: hs_timeline
@@ -46,8 +44,8 @@ settings:
         weight: 25
         enabled: false
       hs_clr_bnd:
-        enabled: true
         weight: 26
+        enabled: false
       hs_collection:
         weight: 27
         enabled: false

--- a/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_per_row.yml
+++ b/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_per_row.yml
@@ -13,9 +13,11 @@ entity_type: paragraph
 bundle: hs_priv_collection
 label: 'Items Per Row'
 description: ''
-required: false
+required: true
 translatable: true
-default_value: {  }
+default_value:
+  -
+    value: 1
 default_value_callback: ''
 settings: {  }
 field_type: list_integer


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Update field configurations to achieve:
* Color band is no longer available for Private Collections
* Items Per Row is a required field
* Items Per Row defaults to 1

## Urgency
low

## Steps to Test
1. Create a private page
2. Add a new collection and confirm that Items Per Row defaults to 1 and is now required.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
