### PR TITLE
HSD8-1153 Update hook to convert spotlights to spotlight sliders

### DIFF
--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -9,7 +9,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
-    - paragraphs.paragraphs_type.hs_sptlght_slder
+    - paragraphs.paragraphs_type.hs_spotlight
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
   module:
@@ -37,7 +37,7 @@ settings:
       hs_timeline_item: hs_timeline_item
       hs_webform: hs_webform
       hs_priv_collection: hs_priv_collection
-      hs_sptlght_slder: hs_sptlght_slder
+      hs_spotlight: hs_spotlight
     target_bundles_drag_drop:
       hs_accordion:
         weight: -40
@@ -79,9 +79,6 @@ settings:
         enabled: true
         weight: -28
       hs_spotlight:
-        weight: -27
-        enabled: false
-      hs_sptlght_slder:
         enabled: false
         weight: 99
       hs_testimonial:

--- a/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_hero.yml
@@ -9,7 +9,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_carousel
     - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_hero_image
-    - paragraphs.paragraphs_type.hs_spotlight
+    - paragraphs.paragraphs_type.hs_sptlght_slder
   module:
     - entity_reference_revisions
 _core:
@@ -33,7 +33,7 @@ settings:
       hs_carousel: hs_carousel
       hs_banner: hs_banner
       hs_hero_image: hs_hero_image
-      hs_spotlight: hs_spotlight
+      hs_sptlght_slder: hs_sptlght_slder
     target_bundles_drag_drop:
       hs_accordion:
         weight: -34
@@ -71,9 +71,9 @@ settings:
       hs_row:
         weight: -31
         enabled: false
-      hs_spotlight:
+      hs_sptlght_slder:
         enabled: true
-        weight: -35
+        weight: 0
       hs_testimonial:
         weight: -24
         enabled: false

--- a/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
+++ b/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
@@ -11,6 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
+    - paragraphs.paragraphs_type.hs_sptlght_slder
     - paragraphs.paragraphs_type.hs_timeline
   module:
     - entity_reference_revisions
@@ -36,6 +37,7 @@ settings:
       hs_clr_bnd: hs_clr_bnd
       hs_priv_collection: hs_priv_collection
       hs_timeline: hs_timeline
+      hs_sptlght_slder: hs_sptlght_slder
     target_bundles_drag_drop:
       hs_accordion:
         enabled: true
@@ -76,9 +78,9 @@ settings:
       hs_row:
         enabled: true
         weight: 13
-      hs_spotlight:
-        weight: 21
-        enabled: false
+      hs_sptlght_slder:
+        enabled: true
+        weight: 0
       hs_testimonial:
         weight: 34
         enabled: false

--- a/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
+++ b/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
@@ -11,7 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
-    - paragraphs.paragraphs_type.hs_sptlght_slder
+    - paragraphs.paragraphs_type.hs_spotlight
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
     - paragraphs.paragraphs_type.stanford_gallery
@@ -42,7 +42,7 @@ settings:
       hs_webform: hs_webform
       stanford_gallery: stanford_gallery
       hs_priv_collection: hs_priv_collection
-      hs_sptlght_slder: hs_sptlght_slder
+      hs_spotlight: hs_spotlight
     target_bundles_drag_drop:
       hs_accordion:
         weight: -41
@@ -84,9 +84,6 @@ settings:
         enabled: true
         weight: -28
       hs_spotlight:
-        weight: -35
-        enabled: false
-      hs_sptlght_slder:
         enabled: false
         weight: 99
       hs_testimonial:

--- a/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
+++ b/config/default/field.field.paragraph.hs_row.field_hs_row_components.yml
@@ -11,6 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
+    - paragraphs.paragraphs_type.hs_spotlight
     - paragraphs.paragraphs_type.hs_sptlght_slder
     - paragraphs.paragraphs_type.hs_timeline_item
     - paragraphs.paragraphs_type.hs_webform
@@ -45,6 +46,7 @@ settings:
       hs_priv_collection: hs_priv_collection
       hs_timeline_item: hs_timeline_item
       hs_sptlght_slder: hs_sptlght_slder
+      hs_spotlight: hs_spotlight
     target_bundles_drag_drop:
       hs_accordion:
         weight: -38
@@ -86,8 +88,8 @@ settings:
         enabled: true
         weight: -23
       hs_spotlight:
-        weight: -32
         enabled: false
+        weight: 99
       hs_sptlght_slder:
         enabled: false
         weight: 99

--- a/config/default/filter.format.basic_html_without_media.yml
+++ b/config/default/filter.format.basic_html_without_media.yml
@@ -31,6 +31,14 @@ filters:
     weight: 0
     settings:
       title: true
+  slick_filter:
+    id: slick_filter
+    provider: slick
+    status: false
+    weight: 4
+    settings:
+      optionset: default
+      media_switch: ''
   media_embed:
     id: media_embed
     provider: media
@@ -40,11 +48,3 @@ filters:
       default_view_mode: default
       allowed_media_types: {  }
       allowed_view_modes: {  }
-  slick_filter:
-    id: slick_filter
-    provider: slick
-    status: false
-    weight: 4
-    settings:
-      optionset: default
-      media_switch: ''

--- a/config/default/filter.format.minimal_html.yml
+++ b/config/default/filter.format.minimal_html.yml
@@ -33,6 +33,14 @@ filters:
     weight: 0
     settings:
       title: true
+  slick_filter:
+    id: slick_filter
+    provider: slick
+    status: false
+    weight: 4
+    settings:
+      optionset: default
+      media_switch: ''
   media_embed:
     id: media_embed
     provider: media
@@ -42,11 +50,3 @@ filters:
       default_view_mode: default
       allowed_media_types: {  }
       allowed_view_modes: {  }
-  slick_filter:
-    id: slick_filter
-    provider: slick
-    status: false
-    weight: 4
-    settings:
-      optionset: default
-      media_switch: ''

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -165,7 +165,7 @@ function su_humsci_profile_post_update_9014() {
 }
 
 /**
- * Implements hook_post_update_NAME().
+ * Convert spotlights to spotlight slideshows.
  */
 function su_humsci_profile_post_update_9200() {
   $spotlights = \Drupal::entityTypeManager()
@@ -213,4 +213,15 @@ function su_humsci_profile_post_update_9200() {
     }
     $parent->set($parent_field, $parent_values)->save();
   }
+  
+  _su_humsci_profile_enable_paragraph('paragraph', 'hs_collection', 'field_hs_collection_items', 'hs_sptlght_slder');
+  _su_humsci_profile_enable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_sptlght_slder');
+  _su_humsci_profile_enable_paragraph('node', 'hs_basic_page', 'field_hs_page_hero', 'hs_sptlght_slder');
+  _su_humsci_profile_enable_paragraph('node', 'hs_private_page', 'field_hs_priv_page_components', 'hs_sptlght_slder');
+  
+  _su_humsci_profile_disable_paragraph('paragraph', 'hs_row', 'field_hs_row_components', 'hs_spotlight');
+  _su_humsci_profile_disable_paragraph('paragraph', 'hs_collection', 'field_hs_collection_items', 'hs_spotlight');
+  _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_spotlight');
+  _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_hero', 'hs_spotlight');
+  _su_humsci_profile_disable_paragraph('node', 'hs_private_page', 'field_hs_priv_page_components', 'hs_spotlight');
 }

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -178,7 +178,7 @@ function su_humsci_profile_post_update_9200() {
     $parent_type = $spotlight->get('parent_type')->getString();
     $parent_id = $spotlight->get('parent_id')->getString();
 
-    if (!\Drupal::entityTypeManager()->hasDefinition($parent_type)) {
+    if (!$parent_type || !\Drupal::entityTypeManager()->hasDefinition($parent_type)) {
       continue;
     }
     $parent = \Drupal::entityTypeManager()

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -177,10 +177,17 @@ function su_humsci_profile_post_update_9200() {
     $parent_field = $spotlight->get('parent_field_name')->getString();
     $parent_type = $spotlight->get('parent_type')->getString();
     $parent_id = $spotlight->get('parent_id')->getString();
+
+    if (!\Drupal::entityTypeManager()->hasDefinition($parent_type)) {
+      continue;
+    }
     $parent = \Drupal::entityTypeManager()
       ->getStorage($parent_type)
       ->load($parent_id);
 
+    if (!$parent) {
+      continue;
+    }
     $parent_values = $parent->get($parent_field)->getValue();
 
     $new_spotlight = \Drupal::entityTypeManager()

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -188,6 +188,9 @@ function su_humsci_profile_post_update_9200() {
     if (!$parent) {
       continue;
     }
+    _su_humsci_profile_enable_paragraph($parent_type, $parent->bundle(), $parent_field, 'hs_sptlght_slder');
+    _su_humsci_profile_disable_paragraph($parent_type, $parent->bundle(), $parent_field, 'hs_spotlight');
+
     $parent_values = $parent->get($parent_field)->getValue();
 
     $new_spotlight = \Drupal::entityTypeManager()
@@ -213,12 +216,12 @@ function su_humsci_profile_post_update_9200() {
     }
     $parent->set($parent_field, $parent_values)->save();
   }
-  
+
   _su_humsci_profile_enable_paragraph('paragraph', 'hs_collection', 'field_hs_collection_items', 'hs_sptlght_slder');
   _su_humsci_profile_enable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_sptlght_slder');
   _su_humsci_profile_enable_paragraph('node', 'hs_basic_page', 'field_hs_page_hero', 'hs_sptlght_slder');
   _su_humsci_profile_enable_paragraph('node', 'hs_private_page', 'field_hs_priv_page_components', 'hs_sptlght_slder');
-  
+
   _su_humsci_profile_disable_paragraph('paragraph', 'hs_row', 'field_hs_row_components', 'hs_spotlight');
   _su_humsci_profile_disable_paragraph('paragraph', 'hs_collection', 'field_hs_collection_items', 'hs_spotlight');
   _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_spotlight');


### PR DESCRIPTION
- 9.2.8
- Set aria-hidden attribute to "true"
- feat(STN-858): add .ptype-hs-priv-collection to list of classes getting width, margin-bottom, margin-top styles to override Drupal settings
- fix(STN-877): remove color band from private collections (#964)
- Fix(STN-841):  Collections paragraph type spacing to match Rows (#959)
- Display contextual links on block content
- feat(STN-835): spotlight slider (#966)
- HSD8-1152 Automate content staging (#969)
- HSD8-1153 Update hook to convert spotlights to spotlight sliders

# READY FOR REVIEW

## Summary
_[briefly summarize the changes here]_

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
