### PR TITLE
Fix(STN-891):  Global message banner icon

### DIFF
--- a/docroot/modules/humsci/hs_layouts/patterns/alert/alert.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/alert/alert.html.twig
@@ -34,7 +34,7 @@
 {# Create the HTML for the Alert Icon #}
 {% if alert_icon|render_clean is empty %}
   {%- set alert_icon -%}
-    <i class="su-fas {{ fa_class }}"></i>
+    <i class="fas {{ fa_class }}"></i>
   {%- endset -%}
 {% endif %}
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
The icon in the Global message banner doesn’t render on prod/live sites. 

Sparkbox has investigated and determined the Font Awesome icon class is different (still inheriting the campus product class). 

https://sparkbox.atlassian.net/browse/STN-891

## Need Review By (Date)
10/14

## Urgency
medium

## Steps to Test
1. Add Global Banner to your site, which is found here: http://sparkbox-sandbox.suhumsci.loc/admin/config/system/global-message
2. Make sure the displays correctly, verify one of the default classes is correct on the icon, `fas` instead of `su-fas`.
3. Swap the Global Message banner between the different types of global messages and verify each of those icons load correctly.

## Verification
1. Verify each of the global message icons are loading correctly with Browser Stack using Windows browsers as well as the standard browser testing.
2. Make sure these icons work on both themes correctly.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
