### PR TITLE
HSD8-1172 Disable rows and enable photo album

### DIFF
--- a/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
+++ b/config/default/field.field.node.hs_basic_page.field_hs_page_components.yml
@@ -76,8 +76,8 @@ settings:
         enabled: true
         weight: -29
       hs_row:
-        enabled: true
-        weight: -28
+        enabled: false
+        weight: 99
       hs_spotlight:
         enabled: false
         weight: 99
@@ -99,7 +99,4 @@ settings:
       hs_webform:
         enabled: true
         weight: -22
-      stanford_gallery:
-        weight: -31
-        enabled: false
 field_type: entity_reference_revisions

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.post_update.php
@@ -168,6 +168,9 @@ function su_humsci_profile_post_update_9014() {
  * Convert spotlights to spotlight slideshows.
  */
 function su_humsci_profile_post_update_9200() {
+  if (_su_humsci_profile_is_legacy_theme()) {
+    return;
+  }
   $spotlights = \Drupal::entityTypeManager()
     ->getStorage('paragraph')
     ->loadByProperties(['type' => 'hs_spotlight']);
@@ -227,4 +230,16 @@ function su_humsci_profile_post_update_9200() {
   _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_spotlight');
   _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_hero', 'hs_spotlight');
   _su_humsci_profile_disable_paragraph('node', 'hs_private_page', 'field_hs_priv_page_components', 'hs_spotlight');
+}
+
+/**
+ * Disable row and enable photo album.
+ */
+function su_humsci_profile_post_update_9201() {
+  if (_su_humsci_profile_is_legacy_theme()) {
+    return;
+  }
+
+  _su_humsci_profile_disable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'hs_row');
+  _su_humsci_profile_enable_paragraph('node', 'hs_basic_page', 'field_hs_page_components', 'stanford_gallery');
 }


### PR DESCRIPTION
- 9.2.12
- HSD8-1153 Update hook to convert spotlights to spotlight sliders
- HSD8-1169 Fix error when editing content type
- Feat(STN-771): vertical timeline raised cards (#977)
- STN-723:  Add documentation on configuration deploys (#916)
- fix(STN-891): fix class on global message alert (#980)
- Feat(STN-882):  remove icon feature flag (#979)
- fix(STN-875): default images not loading (#983)
- Fixed `blt drupal:sync` command with mysql 8
- HSD8-1172 Disable rows and enable photo album

# READY FOR REVIEW

## Summary
_[briefly summarize the changes here]_

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
