### PR TITLE
Hotfix(STN-920): Revert back to top contextual class removal

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/block/block--hs-blocks-back-to-top-block.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/block/block--hs-blocks-back-to-top-block.html.twig
@@ -27,5 +27,5 @@
  */
 #}
 
-{% set attributes = attributes.addClass(['block-back-to-top']).removeClass(['hs-back-to-top']) %}
+{% set attributes = attributes.addClass(['block-back-to-top']) %}
 {% set title_attributes = title_attributes.addClass('visually-hidden') %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
On staging and production, the Back to Top button styling has disappeared along with the class of hs-back-to-top for the back to top button, which is just left as text. 

This work reverts the work done here: https://github.com/SU-HSDO/suhumsci/commit/68d743ab8877b5058f63db03036d6226d0e92527
(The template change, not the z-index)

To bring us back to where we had the back to top button broken in the Layout Builder menu for admin, but should function as it was prior on the normal page view.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. npm run test
2. Add a Back to Top block within a page via the Layout tab.
3. Verify the floating button appears at the bottom of the page as it was and is not just text link at the bottom.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
