### PR TITLE
Feat(STN-855): Lead Font Animation

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/js/shared/animation/page-scroll.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/animation/page-scroll.js
@@ -24,7 +24,8 @@ const classesToAnimate = [
   '.hb-gradient-hero__text',
   '.hb-gradient-hero__image-wrapper',
   '.field-hs-gradient-hero-image',
-  '.hs-font-splash'
+  '.hs-font-splash',
+  '.hs-font-lead'
 ];
 
 const showAnimation = document.querySelectorAll(classesToAnimate);
@@ -64,7 +65,7 @@ const loop = () => {
   scroll(loop);
 }
 
-if (animationEnhancements) {
+if (animationEnhancements.length) {
   // This ensures that elements animate if they are in the viewport on pageload
   loop();
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_keyframes.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_keyframes.text.scss
@@ -22,3 +22,24 @@
   }
 }
 
+@keyframes colorfulLeadFont {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translateY(8px);
+  }
+
+  100% {
+    opacity: 100%;
+    transform: scale(1) translateY();
+  }
+}
+
+@keyframes traditionalLeadFont {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_keyframes.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_keyframes.text.scss
@@ -30,7 +30,7 @@
 
   100% {
     opacity: 100%;
-    transform: scale(1) translateY();
+    transform: scale(1) translateY(0);
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.text.scss
@@ -421,33 +421,47 @@
 // Splash Font Animation
 @mixin hb-font-splash-animation {
   @include hb-traditional {
-    &.animate {
-      .hb-has-animation-enhancements & {
-        animation-timing-function: ease-in-out;
-        animation-duration: 1700ms;
-        animation-fill-mode: forwards;
-        animation-name: traditionalSplashFont;
-      }
-    }
+    @include hasAnimationEnhancements(ease-in-out, 1700ms, traditionalSplashFont);
   }
 
   @include hb-themes(('colorful', 'airy')) {
-    &.animate {
-      .hb-has-animation-enhancements & {
-        animation-timing-function: ease-in-out;
-        animation-duration: 2000ms;
-        animation-fill-mode: forwards;
-        animation-name: colorfulSplashFont;
-      }
-    }
+    @include hasAnimationEnhancements(ease-in-out, 2000ms, colorfulSplashFont);
   }
 
-  // Removes animation styles when Reduced Motion is enabled
+  @include reducedMotionPrefered;
+}
+
+// Lead Font Animation
+@mixin hb-font-lead-animation {
+  @include hb-traditional {
+    @include hasAnimationEnhancements(ease-in-out, 1700ms, traditionalLeadFont);
+  }
+
+  @include hb-themes(('colorful', 'airy')) {
+    @include hasAnimationEnhancements(ease-in-out, 2000ms, colorfulLeadFont);
+  }
+
+  @include reducedMotionPrefered;
+}
+
+// Removes animation styles when Reduced Motion is enabled
+@mixin reducedMotionPrefered {
   @media screen and (prefers-reduced-motion: reduce) {
     &.animate {
       .hb-has-animation-enhancements & {
         animation: none;
       }
+    }
+  }
+}
+
+@mixin hasAnimationEnhancements($timingFunction, $duration, $animationName) {
+  &.animate {
+    .hb-has-animation-enhancements & {
+      animation-timing-function: $timingFunction;
+      animation-duration: $duration;
+      animation-fill-mode: forwards;
+      animation-name: $animationName;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -159,8 +159,19 @@ $credits: (
   }
 }
 
+.hs-font-lead {
+  @include hb-font-lead-animation;
+}
+
 .hs-font-splash {
   @include hb-font-splash-animation;
+
+  @include hb-traditional {
+    ~ .hs-font-lead {
+      animation-duration: 1450ms !important;
+      animation-delay: 250ms;
+    }
+  }
 
   &,
   .infotext {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Add Lead Font Animations for Traditional & Colorful themes. Implemented `reducedMotionPrefered` and `hasAnimationEnhancements` mixins.

[STN-855](https://sparkbox.atlassian.net/browse/STN-855)

## Need Review By (Date)
asap

## Urgency
medium

**Notes:**
The description of the animations in the original card are a confusing to follow if you read all the way through. However, I have distilled this down to a few scenarios.
1. Traditional theme animations are `opacity` changes only.
    - If the Lead Font text is a sibling of Splash Font, it has an animation delay.
2. Colorful theme animations have opacity + transforms
    - If the Lead Font text is a sibling of Splash Font, there is NO animation delay.

## Steps to Test
1. `npm run test`
2. Create a content page with a Splash Font and a Lead Font in the same Text Area.
3. Create a separate Text Area with just a Lead Font.
4. Ensure Animation Enhancements are enabled on your active theme.
5. Observe animation behaviors
6. Switch themes and repeat
7. Confirm enabling Prefers Reduced Motion, still prevents the animations from running.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
