### PR TITLE
Test(STN-913):  Mobile main nav tests

### DIFF
--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -86,4 +86,47 @@ class FlexiblePageCest {
     $I->canSeeNumberOfElements('.slick img', 1);
   }
 
+   /**
+   * Verify main menu links at mobile size
+   */
+  public function testMobileMenu(FunctionalTester $I) {
+    // Check standard menu item links
+    $I->amOnPage('/');
+    $I->resizeWindow(800, 1100);
+    $I->seeElement('.hb-main-nav');
+
+    // This try/catch keeps the toggle consistent between environment testing.
+    // It will check for the visible element and continue steps for either scenario.
+    try {
+      $I->waitForElementVisible('.hb-main-nav__link');
+      // Continue to do this if it's present
+      $I->seeElement('.hb-main-nav__link');
+      $I->click('.hb-main-nav__link');
+      echo 'If you see this, the menu was open and the link was clicked.';
+
+    } catch (\Exception $e) {
+      // Do this if it's not present.
+      echo 'If you see this, the menu needs toggled.';
+      $I->click('button.hb-main-nav__toggle');
+      $I->waitForElementVisible('.hb-main-nav__link');
+      $I->seeElement('.hb-main-nav__link');
+      $I->click('.hb-main-nav__link');
+    }
+
+    // Check nested menu item links
+    $I->click('.hb-main-nav__toggle');
+    $I->click('.hb-nested-toggler');
+    $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    $I->click('.hb-main-nav__menu-lv2 a');
+
+    // Check standard menu item links for logged in users
+    $I->logInWithRole('contributor');
+    $I->amOnPage('node/add/hs_basic_page');
+    $I->fillField('Title', 'Demo Basic Page');
+    $I->click('Save');
+    $I->canSeeInCurrentUrl('/demo-basic-page');
+    $I->click('.hb-main-nav__toggle');
+    $I->seeElement('.hb-main-nav__menu');
+    $I->click('.hb-main-nav__link');
+  }
 }

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -115,7 +115,7 @@ class FlexiblePageCest {
     }
 
     // Check nested menu item links
-    // $I->makeScreenshot('before_toggle');
+    $I->makeScreenshot('before_toggler');
     // $I->click('.hb-main-nav__toggle');
     // $I->waitForElementVisible('.hb-nested-toggler');
     // $I->click('.hb-nested-toggler');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -115,13 +115,13 @@ class FlexiblePageCest {
     }
 
     // Check nested menu item links
-    $I->makeScreenshot('before_toggle');
-    $I->click('.hb-main-nav__toggle');
-    $I->waitForElementVisible('.hb-nested-toggler');
-    $I->click('.hb-nested-toggler');
-    $I->makeScreenshot('after_toggle');
-    $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-    $I->click('.hb-main-nav__menu-lv2 a');
+    // $I->makeScreenshot('before_toggle');
+    // $I->click('.hb-main-nav__toggle');
+    // $I->waitForElementVisible('.hb-nested-toggler');
+    // $I->click('.hb-nested-toggler');
+    // $I->makeScreenshot('after_toggle');
+    // $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    // $I->click('.hb-main-nav__menu-lv2 a');
 
     // Check standard menu item links for logged in users
     $I->logInWithRole('contributor');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -88,6 +88,7 @@ class FlexiblePageCest {
 
    /**
    * Verify main menu links at mobile size
+   * @group z
    */
   public function testMobileMenu(FunctionalTester $I) {
     // Check standard menu item links
@@ -114,8 +115,10 @@ class FlexiblePageCest {
     }
 
     // Check nested menu item links
+    $I->makeScreenshot('before_toggle');
     $I->click('.hb-main-nav__toggle');
     $I->click('.hb-nested-toggler');
+    $I->makeScreenshot('after_toggle');
     $I->waitForElementVisible('.hb-main-nav__menu-lv2');
     $I->click('.hb-main-nav__menu-lv2 a');
 

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -117,8 +117,8 @@ class FlexiblePageCest {
     // Check nested menu item links
     $I->makeScreenshot('before_toggle');
     $I->click('.hb-main-nav__toggle');
+    $I->waitForElementVisible('.hb-nested-toggler');
     $I->click('.hb-nested-toggler');
-    $I->wait(30);
     $I->makeScreenshot('after_toggle');
     $I->waitForElementVisible('.hb-main-nav__menu-lv2');
     $I->click('.hb-main-nav__menu-lv2 a');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -114,6 +114,7 @@ class FlexiblePageCest {
       $I->click('.hb-main-nav__link');
     }
 
+    // This try/catch keeps the toggle consistent between environment testing.
     // Check nested menu item links
     try {
       echo ('If you see this, the nested menu link was already available to click.');
@@ -127,21 +128,9 @@ class FlexiblePageCest {
       $I->click('.hb-main-nav__toggle');
       $I->waitForElementVisible('.hb-nested-toggler');
       $I->click('.hb-nested-toggler');
-      $I->makeScreenshot('after_toggle');
       $I->waitForElementVisible('.hb-main-nav__menu-lv2');
       $I->click('.hb-main-nav__menu-lv2 a');
     }
-
-
-    // Check nested menu item links
-    // $I->makeScreenshot('before_toggler');
-    // $I->click('.hb-main-nav__toggle');
-    // $I->waitForElementVisible('.hb-nested-toggler');
-    // $I->click('.hb-nested-toggler');
-    // $I->makeScreenshot('after_toggle');
-    // $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-    // $I->click('.hb-main-nav__menu-lv2 a');
-
 
     // Check standard menu item links for logged in users
     $I->logInWithRole('contributor');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -88,7 +88,6 @@ class FlexiblePageCest {
 
    /**
    * Verify main menu links at mobile size
-   * @group z
    */
   public function testMobileMenu(FunctionalTester $I) {
     // Check standard menu item links

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -118,6 +118,7 @@ class FlexiblePageCest {
     $I->makeScreenshot('before_toggle');
     $I->click('.hb-main-nav__toggle');
     $I->click('.hb-nested-toggler');
+    $I->wait(30);
     $I->makeScreenshot('after_toggle');
     $I->waitForElementVisible('.hb-main-nav__menu-lv2');
     $I->click('.hb-main-nav__menu-lv2 a');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -117,11 +117,12 @@ class FlexiblePageCest {
     // Check nested menu item links
     $I->makeScreenshot('before_toggler');
     // $I->click('.hb-main-nav__toggle');
-    // $I->waitForElementVisible('.hb-nested-toggler');
+    $I->waitForElementVisible('.hb-nested-toggler');
     // $I->click('.hb-nested-toggler');
     // $I->makeScreenshot('after_toggle');
-    // $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-    // $I->click('.hb-main-nav__menu-lv2 a');
+    $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    $I->click('.hb-main-nav__menu-lv2 a');
+
 
     // Check standard menu item links for logged in users
     $I->logInWithRole('contributor');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -100,14 +100,14 @@ class FlexiblePageCest {
     // It will check for the visible element and continue steps for either scenario.
     try {
       $I->waitForElementVisible('.hb-main-nav__link');
-      // Continue to do this if it's present
+      // Continue to do this if it's present.
       $I->seeElement('.hb-main-nav__link');
       $I->click('.hb-main-nav__link');
-      echo 'If you see this, the menu was open and the link was clicked.';
+      echo ('If you see this, the menu was open and the link was clicked.');
 
     } catch (\Exception $e) {
       // Do this if it's not present.
-      echo 'If you see this, the menu needs toggled.';
+      echo ('If you see this, the menu needs toggled.');
       $I->click('button.hb-main-nav__toggle');
       $I->waitForElementVisible('.hb-main-nav__link');
       $I->seeElement('.hb-main-nav__link');
@@ -115,13 +115,32 @@ class FlexiblePageCest {
     }
 
     // Check nested menu item links
-    $I->makeScreenshot('before_toggler');
+    try {
+      echo ('If you see this, the nested menu link was already available to click.');
+      $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+      // Click nested menu link if it's already visible.
+      $I->click('.hb-main-nav__menu-lv2 a');
+
+    } catch (\Exception $e) {
+      // Do this if the nested menu link is not already visible.
+      echo ('If you see this, the nested menu link needs to be opened to click.');
+      $I->click('.hb-main-nav__toggle');
+      $I->waitForElementVisible('.hb-nested-toggler');
+      $I->click('.hb-nested-toggler');
+      $I->makeScreenshot('after_toggle');
+      $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+      $I->click('.hb-main-nav__menu-lv2 a');
+    }
+
+
+    // Check nested menu item links
+    // $I->makeScreenshot('before_toggler');
     // $I->click('.hb-main-nav__toggle');
-    $I->waitForElementVisible('.hb-nested-toggler');
+    // $I->waitForElementVisible('.hb-nested-toggler');
     // $I->click('.hb-nested-toggler');
     // $I->makeScreenshot('after_toggle');
-    $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-    $I->click('.hb-main-nav__menu-lv2 a');
+    // $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    // $I->click('.hb-main-nav__menu-lv2 a');
 
 
     // Check standard menu item links for logged in users


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This adds a Codeception Functional test that uses the chromedriver.
This test does an anonymous user test of the mobile menu: standard menu item links, nested toggles, nested menu links and functionality of menu links under a Contributor role as well.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. To run the Codeception tests locally you'll need to do these steps in this documentation setting up [Sparkbox Sandbox as the default site](https://github.com/SU-HSDO/suhumsci/tree/sparkbox-sprint-55/lando#configure-local-instance-to-recognize-sparkbox_sandbox-as-the-default-site).
_Codeception tests will uninstall the simpleSAML module so this module will require you to reinstall after running tests locally or rerunning `lando composer install` after you have completed PR review and testing._
2. Codeception needs to be run from the root `suhumsci` folder, it will not work from the `humsci basic` folder.
3. Add an individual test group so you are only testing this new test. Add an additional line below line 90 and add a test group name like this `@group z`.
Like this: 
![image](https://user-images.githubusercontent.com/9355698/145903040-3ca0b4ca-85c9-40d7-9adc-7a6312930002.png)
4. To run the test `lando blt codeception --group=z` (replace z with whatever you name your test group).

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
