### PR TITLE
Feat(STN-912)  Refine Collection Codeception test

### DIFF
--- a/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/acceptance/Install/Content/FlexiblePageCest.php
@@ -137,6 +137,7 @@ class FlexiblePageCest {
     $I->amOnPage('/node/add/hs_basic_page');
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Add Collection');
+    $I->canSeeNumberOfElements('.form-item-field-hs-page-components-1-subform-field-hs-collection-per-row option', 4);
     $I->selectOption('Items Per Row', 2);
     $I->canSeeOptionIsSelected('Style', '- None -');
     $I->click('Add Text Area', '.field--name-field-hs-collection-items');


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Refine the Codeception tests for Collections Component so it's a little more well rounded.

JIRA Card: https://sparkbox.atlassian.net/browse/STN-912

## Need Review By (Date)
1/7

## Urgency
medium

## Steps to Test
1. To run the Codeception tests locally you'll need to do these steps in this documentation setting up [Sparkbox Sandbox as the default site](https://github.com/SU-HSDO/suhumsci/tree/sparkbox-sprint-55/lando#configure-local-instance-to-recognize-sparkbox_sandbox-as-the-default-site).
_Codeception tests will uninstall the simpleSAML module so this module will require you to reinstall after running tests locally or rerunning `lando composer install` after you have completed PR review and testing._
2. Codeception needs to be run from the root `suhumsci` folder, it will not work from the `humsci basic` folder.
3. Add an individual test group so you are only testing this new test. Add an additional line below line 126 and add a test group name like this `@group z`.
4. To run the test `lando blt codeception --group=z` (replace z with whatever you name your test group).

## Verification of test
- [ ] Test checks for Items Per Row options available, 4.
- [ ] Test Passes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
