### PR TITLE
Fix: spotlight bg hook added and remove region disable field

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
@@ -16,7 +16,6 @@ dependencies:
     - field_formatter_class
     - hs_field_helpers
     - link
-    - options
     - smart_trim
     - stanford_media
 third_party_settings:
@@ -41,20 +40,11 @@ third_party_settings:
         - field_hs_spotlight_title
         - field_hs_spotlight_body
         - field_hs_spotlight_link
-      background:
-        - field_hs_spotlight_bg
 id: paragraph.hs_spotlight.default
 targetEntityType: paragraph
 bundle: hs_spotlight
 mode: default
 content:
-  field_hs_spotlight_bg:
-    type: list_key
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: background
   field_hs_spotlight_body:
     type: smart_trim
     label: hidden
@@ -122,6 +112,7 @@ content:
     weight: 1
     region: overlay_text
 hidden:
+  field_hs_spotlight_bg: true
   field_hs_spotlight_height: true
   field_hs_spotlight_image_align: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
@@ -18,7 +18,6 @@ dependencies:
     - hs_field_helpers
     - layout_builder
     - link
-    - options
     - smart_trim
     - stanford_media
 third_party_settings:
@@ -43,8 +42,6 @@ third_party_settings:
         - field_hs_spotlight_title
         - field_hs_spotlight_body
         - field_hs_spotlight_link
-      background:
-        - field_hs_spotlight_bg
   layout_builder:
     enabled: false
     allow_custom: false
@@ -53,13 +50,6 @@ targetEntityType: paragraph
 bundle: hs_spotlight
 mode: preview
 content:
-  field_hs_spotlight_bg:
-    type: list_key
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: background
   field_hs_spotlight_body:
     type: smart_trim
     label: hidden
@@ -127,6 +117,7 @@ content:
     weight: 1
     region: overlay_text
 hidden:
+  field_hs_spotlight_bg: true
   field_hs_spotlight_height: true
   field_hs_spotlight_image_align: true
   search_api_excerpt: true

--- a/docroot/modules/humsci/hs_layouts/hs_layouts.module
+++ b/docroot/modules/humsci/hs_layouts/hs_layouts.module
@@ -5,6 +5,8 @@
  * hs_layouts.module
  */
 
+use Drupal\Component\Utility\Html;
+
 /**
  * Implements hook_plugin_filter_TYPE__CONSUMER_alter().
  */
@@ -39,5 +41,17 @@ function hs_layouts_preprocess_container(&$variables) {
   if (!empty($variables['element']['layout-section'])) {
     // Add styles to the layout builder admin configuration.
     $variables['#attached']['library'][] = 'hs_layouts/layout_builder_admin';
+  }
+}
+
+/**
+ * Implements hook_preprocess_preprocess_pattern_spotlight().
+ */
+function hs_layouts_preprocess_pattern_spotlight(&$variables) {
+  $paragraph = $variables['context']->getProperty('entity');
+  if ($paragraph->hasField('field_hs_spotlight_bg') && !$paragraph->field_hs_spotlight_bg->isEmpty()) {
+    $bgValue = $paragraph->field_hs_spotlight_bg->first()->getValue()['value'];
+
+    $variables['spotlight_bg_class'] = Html::cleanCssIdentifier($bgValue);
   }
 }

--- a/docroot/modules/humsci/hs_layouts/hs_layouts.module
+++ b/docroot/modules/humsci/hs_layouts/hs_layouts.module
@@ -49,9 +49,8 @@ function hs_layouts_preprocess_container(&$variables) {
  */
 function hs_layouts_preprocess_pattern_spotlight(&$variables) {
   $paragraph = $variables['context']->getProperty('entity');
-  if ($paragraph->hasField('field_hs_spotlight_bg') && !$paragraph->field_hs_spotlight_bg->isEmpty()) {
-    $bgValue = $paragraph->field_hs_spotlight_bg->first()->getValue()['value'];
-
-    $variables['spotlight_bg_class'] = Html::cleanCssIdentifier($bgValue);
+  if ($paragraph->hasField('field_hs_spotlight_bg') && $paragraph->get('field_hs_spotlight_bg')->count()) {
+    $bgValue = $paragraph->get('field_hs_spotlight_bg')->getString();
+    $variables['attributes']->addClass(Html::cleanCssIdentifier($bgValue));
   }
 }

--- a/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.html.twig
@@ -1,15 +1,12 @@
-{%- set attributes = attributes.addClass('hb-spotlight', bg_class) -%}
+{%- set attributes = attributes.addClass('hb-spotlight', spotlight_bg_class) -%}
 
 {% if variant %}
   {% set variant_class = "hb-spotlight--image-#{variant}" %}
   {% set attributes = attributes.addClass(variant_class) %}
 {% endif %}
 
-{% set bg_class = background.field_hs_spotlight_bg['0']['#markup']|clean_class %}
-
-
 {% spaceless %}
-  <div{{ attributes.addClass(bg_class) }}>
+  <div{{ attributes}}>
     <div class="hb-spotlight__wrapper">
       {% if image %}
         <div class="hb-spotlight__image-wrapper">

--- a/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.html.twig
@@ -1,4 +1,4 @@
-{%- set attributes = attributes.addClass('hb-spotlight', spotlight_bg_class) -%}
+{%- set attributes = attributes.addClass('hb-spotlight') -%}
 
 {% if variant %}
   {% set variant_class = "hb-spotlight--image-#{variant}" %}

--- a/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.ui_patterns.yml
+++ b/docroot/modules/humsci/hs_layouts/patterns/spotlight/spotlight.ui_patterns.yml
@@ -21,10 +21,6 @@ spotlight:
       label: "Overlay Text"
       type: mixed
       preview: "<h2>Etiam sollicitudin</h2><p>ipsum eu pulvinar rutrum, tellus ipsum laoreet sapien, quis venenatis ante odio sit amet eros. Lorem ipsum dolor sit amet</p><a class=\"decanter-button\">augue augue mollis justo.</a>"
-    background:
-      label: "Background"
-      preview: "Background"
-      type: mixed
   libraries:
     - spotlight:
         css:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This work changes the Spotlight background class field application from Twig variable to a hook inside the module.
No functionality should change swapping between these methods.

However, the "Background" region inside the Paragraph should know be removed and the background field should now be set to disabled if you look at the Manage Display tab for the Spotlight Paragraph.  Checking both Preview and Default display modes for Tall and Short, they should both be the same.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. npm run test
2. Import the new configuration `lando drush @sparkbox_sandbox.local config:import --partial`
3. Clear cache `lando drush @sparkbox_sandbox.local cr`
4. View a page with different accordion types setup and different colors.
5. Check default option has not changed
6. Verify it works on both Traditional and Colorful.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
