### PR TITLE
Docs(STN-977):  update onboarding and Codeception docs

### DIFF
--- a/docroot/themes/humsci/humsci_basic/docs/README.md
+++ b/docroot/themes/humsci/humsci_basic/docs/README.md
@@ -31,4 +31,6 @@ These classes can be used in Drupal to further customize themes:
 * [Deploying new components without impacting legacy and existing site configuration(s)](/docroot/themes/humsci/humsci_basic/docs/config-override-deployment.md)
 
 ## Development Tasks
+
 * [Sprint Branch Prep](/docroot/themes/humsci/humsci_basic/docs/dev-prep-sprint-branch.md)
+* [Codeception Testing](/docroot/themes/humsci/humsci_basic/docs/codeception-testing.md)

--- a/docroot/themes/humsci/humsci_basic/docs/codeception-testing.md
+++ b/docroot/themes/humsci/humsci_basic/docs/codeception-testing.md
@@ -1,0 +1,32 @@
+# Codeception Testing Information
+
+To setup Codeception testing locally you will want to defer to the steps listed in the [Lando setup Readme](/lando/README.md#setup-for-local-codeception-testing). This section is intended to provide some extra information or tips for running or writing your tests locally.
+
+* [Codeception Documentation](https://codeception.com/docs/01-Introduction)
+
+## Running locally
+
+* Codeception tests live in this directory `/tests/codeception` from there they split into there respective test type directories.
+* The different types have different engines running their functionality, therefor are capable of different things
+  * Acceptance tests, these tests run with a headless Chrome browser or Chromedriver and are designed to reproduce an acceptance tester’s actions in scenarios and run them automatically.
+  * Functional tests, these tests run with Symfony BrowserKit to send requests to your app and doesn't make actual HTTP requests, these tests are intended to test functionality only and do not require a Chromedriver like Acceptance test do. These should run very fast in comparison.
+* This info is listed in the Lando setup steps, but bears repeating for understanding here.
+  * To run codeception tests run `lando blt codeception --group=install`. Or if you wish to run a single class/method add the annotation in the docblock `@group testme` and then run `lando blt codeception --group=testme`.
+
+    ```php
+    /**
+    * Private collections tests description
+    *
+    * @group testme
+    */
+    ```
+
+  * This allows you to focus on that one test you are writing or existing test your updating the steps for. It allows you to run that one group with one test vs. the entire install group that may eat up a lot of running time or cause multiple failures while waiting on your test specifically.
+
+## Debugging
+
+* The environments load some things differently, a test that passes locally may not pass on CircleCi. Example: The tests for the mobile menu have conditionals added within them because on page load the mobile menu may be open on one environment or closed on the other. The conditionals look for elements to trigger a click that may be needed for the next steps.
+* Acceptance tests that may not be passing on CircleCi but are passing locally remember that these tests run fast and sometimes the browser does not keep up or the environment loads differently.
+  * Use a `makeScreenshot`action in your test to pinpoint what the test is seeing before it fails, these can be found in the Artifacts section of the CircleCi test information. Also, locally at `/artifacts`. [Docs for makeScreenshot.](https://codeception.com/docs/modules/WebDriver#makeScreenshot)
+  * You can also grab the HTML with a `makeHtmlSnapshot`action in your test to pinpoint what the test is seeing before it fails, these can be found in the Artifacts section of the CircleCi test information. Also, locally at `/artifacts`. [Docs for makeHtmlSnapshot.](https://codeception.com/docs/modules/WebDriver#makeHtmlSnapshot)
+  * Another important tool when debugging is the `wait` or `waitForElement` actions, while `wait` allows you to give a browser pause time, `waitForElement` requires the test to stop and wait for a specific element to load before it will timeout and fail. [Docs for wait/waitForElement.](https://codeception.com/docs/modules/WebDriver#wait)

--- a/lando/README.md
+++ b/lando/README.md
@@ -5,10 +5,11 @@ If you want to use [Lando](https://lando.dev/) for local development, here are s
 _Prerequisite: Make sure you have added your SSH key in Acquia cloud, and that it's saved in your `~/.ssh folder._
 
 1. [Install Lando](https://lando.dev/download/).
+    * Apple M1/Silicon Users will need to pay special attention to the version of Lando and Docker they install for proper functionality. "If you have a new Apple Silicon based Mac then choose the arm64 DMG from Lando."
 2. Copy `lando/default.lando.yml` to `.lando.yml`.
-   a. If running acceptance tests, copy `lando/default.codeception.yml` to `tests/codeception.yml`.
 3. Take the `.loc` domains in the `.lando.yml` file and add them to your `/etc/hosts` file, as shown below:
-    ```
+
+    ```yaml
     127.0.0.1           swshumsci.suhumsci.loc
     127.0.0.1           archaeology.suhumsci.loc
     127.0.0.1           dsresearch.suhumsci.loc
@@ -27,107 +28,145 @@ _Prerequisite: Make sure you have added your SSH key in Acquia cloud, and that i
     127.0.0.1           swshumsci-sandbox.suhumsci.loc
     127.0.0.1           symsys.suhumsci.loc
     ```
+
 4. Build your containers: `lando rebuild`
     * Note: After running `lando rebuild` you should see a list a APPSERVER URLS. A `green` URL signifies the `.loc` domain has been added to your `/ect/hosts` file. If you see a `red` URL, go back to step 3 and add the `.loc` domain to your `/ect/hosts` file.
 5. Install your PHP dependencies: `lando composer install`
 6. Run `lando blt blt:init:settings` and confirm that it added a `local.settings.php` file to each of your `[my-multisite]/settings` folders (ex. `/docroot/sites/default/settings/local.settings.php`).
 7. Make sure the db settings in each of these `local.settings.php` files matches the settings in the `.lando.yml`. Note: the `database` service corresponds to the `default` multisite. The rest of the services have names that match their multisite. For example, for the default site, make sure that these values, and key-value pairs match:
-- (line 10): `$db_name = 'swshumsci';`
-- 'database' => $db_name,
-- 'username' => 'drupal',
-- 'password' => 'drupal',
-- 'host' => 'database',
-8. Run `lando blt drupal:sync --site=default --sync-files --partial` to pull down a copy of the database, files for the default multisite, and the custom views and blocks that have been built out. If you **DO NOT** want to get the custom views built out on on the database you are pulling from, you can just use: `lando blt drupal:sync --site=default --sync-files`.
-9. Run `lando info`, and browse to the url for your multisite. For the default site, you should be able to pull up http://swshumsci.suhumsci.loc/ in your browser.
-10. Depending on the local domains you've set up, you may need to add a `docroot/sites/local.sites.php` file, and use it to add your local domains to the `$sites` array. Otherwise, requests to your local multisite domains may get sent to the default site.
-11. To run codeception tests run `lando blt codeception --group=install`. Or if you wish to run a single class/method add the annotation in the docblock `@group testme` and then run `lando blt codeception --group=testme`.
 
-# Configure local instance to recognize `sparkbox_sandbox` as the default site
-- Edit `docroot/sites/default/settings/local.settings.php` database connection to be the connection located in `docroot/sites/sparkbox_sandbox/settings/local.settings.php`.
+    * (line 10): `$db_name = 'sparkbox_sandbox';`
+    * 'database' => $db_name,
+    * 'username' => 'drupal',
+    * 'password' => 'drupal',
+    * 'host' => 'database',
 
-- Create `drush/local.drush.yml`
+8. Create a new file in `/docroot/sites` called `local.sites.php`. This adds new routing based on our local environments and local `sites/` folders. Add the following code there:
 
-```
-# # This file defines drush configuration that applies to drush commands
-# # for the entire application. For site-specific settings, like URI, use
-# # ../docroot/sites/[site]/drush.yml
-drush:
-  paths:
-    # Load a drush.yml configuration file from the current working directory.
-    config:
-      - ../docroot/sites/sparkbox_sandbox/local.drush.yml
-      - docroot/sites/sparkbox_sandbox/local.drush.yml
-      # Allow local global config overrides.
-      - local.drush.yml
-      - drush/local.drush.yml
-    include:
-      - '${env.home}/.drush'
-      - /usr/share/drush/commands
+    ```php
+        <?php
+        // This is required if you have localdev domains that are different from the
+        // url structure that's already added to $sites in sites.php
+        $settings = glob(__DIR__ . '/*/settings.php');
+        foreach ($settings as $settings_file) {
+        $site_dir = str_replace(__DIR__ . '/', '', $settings_file);
+        $site_dir = str_replace('/settings.php', '', $site_dir);
+        if ($site_dir == 'default') {
+            $site_dir = 'swshumsci';
+        }
+        $sitename = str_replace('_', '-', str_replace('__', '.', $site_dir));
+        $sites["$sitename.suhumsci.loc"] = $site_dir; // Do we need to add more things to our sites array, to get requests to reach our multisites?
+        }
+    ```
 
-```
-- Edit `.lando.yml` `services > database > creds` to connect to `sparkbox_sandbox` database.
+    * **Troubleshooting note:** This file is very picky of typos and spacing, if you have issues syncing, ensure this file does not have extra spaces or mistyped information.
 
-```
-Example:
-services:
-  appserver:
-    ssl: true
-  database: # Override the database that comes in the drupal8
-    creds:  # recipe and use it for the /sites/default site.
-      user: drupal
-      password: drupal
-      database: sparkbox_sandbox
-```
+9. Run `lando blt drupal:sync --site=sparkbox_sandbox` to pull down a copy of the database, files for the default multisite, and the custom views and blocks that have been built out.
+10. Run `lando info`, and browse to the url for your multisite. For the default site, you should be able to pull up http://sparkbox-sandbox.suhumsci.loc// in your browser.
+11. Depending on the local domains you've set up, you may need to add a `docroot/sites/local.sites.php` file, and use it to add your local domains to the `$sites` array. Otherwise, requests to your local multisite domains may get sent to the default site.
 
-# Switching between local sites
+## Switching between local sites
+
 1. In your `.lando.yml` file, uncomment the service for the site you want to run locally.
 2. Run `lando rebuild` (this needs to be run anytime you make changes to `.lando.yml`).
 3. Confirm that the password, database, and hostname values in `sites/[my-multisite]/settings/local.settings.php` correctly match the values in your `.lando.yml` file.
-4. Create a new file in `/docroot/sites` called `local.sites.php`. This adds new routing based on our local environments and local `sites/` folders. Add the following code there:
-```
-    <?php
-    // This is required if you have localdev domains that are different from the
-    // url structure that's already added to $sites in sites.php
-    $settings = glob(__DIR__ . '/*/settings.php');
-    foreach ($settings as $settings_file) {
-    $site_dir = str_replace(__DIR__ . '/', '', $settings_file);
-    $site_dir = str_replace('/settings.php', '', $site_dir);
-    if ($site_dir == 'default') {
-        $site_dir = 'swshumsci';
-    }
-    $sitename = str_replace('_', '-', str_replace('__', '.', $site_dir));
-    $sites["$sitename.suhumsci.loc"] = $site_dir; // Do we need to add more things to our sites array, to get requests to reach our multisites?
-    }
-```
-5. Sync the database and files with a copy from production: `lando blt drupal:sync --site=[my-multisite] --sync-files`.
+4. Ensure you have created your `local.sites.php` file in the `/docroot/sites` folder as indicated in the Lando steps above.
+5. Sync the database and files with a copy from production: `lando blt drupal:sync --site=[my-multisite]`.
 6. From now on, when you run a cache clear or try to get an admin link, you'll need to specify which Drupal site you are performing the action, for instance, for the default site: `lando drush @default.local cr` and for the economics site: `lando drush @economics.local uli`.
 
 Troubleshooting Note for local sites: If multisite setup is causing you issues, try setting up the default setup first and then attempt a multisite configuration.
 
+## Setup for local Codeception testing
+
+1. Copy codeception yml for setup.
+Copy `lando/default.codeception.yml` to `tests/codeception.yml`.
+2. Add local Drush configuration for testing
+    * Edit `docroot/sites/default/settings/local.settings.php` database connection to be the connection located in `docroot/sites/sparkbox_sandbox/settings/local.settings.php`.
+
+    * Create `drush/local.drush.yml`
+
+    ```yaml
+    # # This file defines drush configuration that applies to drush commands
+    # # for the entire application. For site-specific settings, like URI, use
+    # # ../docroot/sites/[site]/drush.yml
+    drush:
+      paths:
+        # Load a drush.yml configuration file from the current working directory.
+        config:
+          - ../docroot/sites/sparkbox_sandbox/local.drush.yml
+          - docroot/sites/sparkbox_sandbox/local.drush.yml
+          # Allow local global config overrides.
+          - local.drush.yml
+          - drush/local.drush.yml
+        include:
+          - '${env.home}/.drush'
+          - /usr/share/drush/commands
+    ```
+
+3. Ensure your `.lando.yml` file default database is setup with `sparkbox_sandbox` as your default db.
+
+    ```yaml
+    Example:
+    services:
+      appserver:
+        ssl: true
+      database: # Override the database that comes in the drupal8
+        creds:  # recipe and use it for the /sites/default site.
+          user: drupal
+          password: drupal
+          database: sparkbox_sandbox
+    ```
+
+### To run Codeception tests locally
+
+To run codeception tests run `lando blt codeception --group=install`. Or if you wish to run a single class/method add the annotation in the docblock `@group testme` and then run `lando blt codeception --group=testme`.
+
 ## Syncing from Staging
+
 In order to sync from a staging or dev site, you will have to do the following:
 
 1. In `suhumsci/docroot/sites/sparkbox_sandbox/blt.yml` or whichever relevant site you are working with, change line 10 for remote to: `remote: sparkbox_sandbox.stage` or `remote: sparkbox_sandbox.dev`.
-2.  Sync the database as you normally would: `lando blt drupal:sync --site=[my-multisite] --sync-files`.
+2. Sync the database as you normally would: `lando blt drupal:sync --site=[my-multisite]`.
+
+## Configuration for local SimpleSAML authentication
+
+To configure the SimpleSAML module so you stop seeing the configuration errors in Drupal from that module and also to allow you to login from the /user login page with your Stanford account. (These commands should be run from the root directory.)
+
+1. Run `lando blt sws:keys`
+2. Run `lando blt sbsc`
+3. Go to the the `/simplesamlphp/config` folder and edit the local.config.php file.
+4. Make sure lines 10,11,12 match the information from your `lando.yml` file for the site you are working on.
+    * Example: If you are working on `sparkbox_sandbox` you will want to add `sparkbox_sandbox` in for the host and the dbname on line 10 and update the username and password below to drupal.
+5. After you’ve gotten that file up to date, you need to run lando blt sbsc once more and then clear your site cache with `lando drush @[site_name] cr` and the error should be gone upon reloading.
+
+**Notes:**
+
+* There is still some slight bugs to work out with SimplsSAML’s login but it will work for login, but after login may throw errors on the login page, this can be resolved by clearing the browser cookies for that site.
+
+* The command for `lando drush uli` should still function with or without SimpleSAML configured to login to the local site, if this is redirecting or not functioning correctly you should ensure the module is enabled or resync your configuration on your local site.
 
 ## Common commands
-- `lando drush uli` - Get a link for logging in as an admin user
-- `docker ps` - Check that your docker containers are running
-- `lando info` - Check your lando config
-- `lando mysql -h swshumsci_sandbox` - Jump into a mysql CLI for a given multisite
-- `lando drush cr` - clear cache
-- `lando drush config-export` - export your local database settings
-- `lando drush config-import` - import new database settings to your local.
+
+* `lando drush uli` - Get a link for logging in as an admin user
+* `docker ps` - Check that your docker containers are running
+* `lando info` - Check your lando config
+* `lando mysql -h sparkbox_sandbox` - Jump into a mysql CLI for a given multisite
+* `lando drush cr` - clear cache
+* `lando drush config-export` - export your local database settings
+* `lando drush config-import` - import new database settings to your local.
 
 Utilizing these commands with specific sites in your multisite setup looks like this: `lando drush @[]my-multisite] cr`.
 
 ## Troubleshooting
+
 ### Importing Configuration
-- If you run into issues importing new config files try running the command with the partial flag: `lando drush config-import --partial`.
-- If the partial flag doesn't work, you may be missing a dependency. Re-sync your whole database, then run `lando composer install`.
-- If you find yourself in a position where starting fresh is your best plan of action, `lando destroy` will completely clear your running lando instances for a clean start.
-- If running `lando composer install` results in a timeout while installing a dependency, the default composer timeout for lando can be increased by running `lando composer --global config process-timeout 2000`.
+
+* If you run into issues importing new config files try running the command with the partial flag: `lando drush config-import --partial`.
+* If the partial flag doesn't work, you may be missing a dependency. Re-sync your whole database, then run `lando composer install`.
+* If you find yourself in a position where starting fresh is your best plan of action, `lando destroy` will completely clear your running lando instances for a clean start.
+* If running `lando composer install` results in a timeout while installing a dependency, the default composer timeout for lando can be increased by running `lando composer --global config process-timeout 2000`.
 
 ## Other useful links
-- [Lando Drupal 8 docs](https://docs.lando.dev/config/drupal8.html)
-- [Drush configuration and aliases](../drush/README.md)
+
+* [Lando Drupal 8 docs](https://docs.lando.dev/config/drupal8.html)
+* [Drush configuration and aliases](../drush/README.md)

--- a/lando/default.lando.yml
+++ b/lando/default.lando.yml
@@ -32,7 +32,7 @@ services:
     creds:  # recipe and use it for the /sites/default site.
       user: drupal
       password: drupal
-      database: swshumsci
+      database: sparkbox_sandbox
   chromedriver:
     type: compose
     services:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Update the Onboarding documentation so it focuses on setting up Sparkbox Sandbox as your first local site to create a more cohesive system for steps.

Add some notes and documentation for Codeception.

I also added steps to configure SimpleSAML Authentication locally as that had never been added to our docs.

## Need Review By (Date)
asap

## Urgency
low

## Steps to Test
1. Read through docs, compare to old docs and your current setup.
2. I also fixed a bunch of Markdown linting errors on the files I touched, if things don't look right let me know.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
