### PR TITLE
Stn 980  update sidebar nav

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_secondary-nav.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_secondary-nav.scss
@@ -193,11 +193,11 @@
     // when a nolink item behaves as a toggle button, add button toggle icon
     &.hb-secondary-toggler {
       position: relative;
+      cursor: pointer;
 
       &::after {
         @include hb-menu-icon-wrapper(48px, 48px);
         @include hb-menu-plus-icon;
-        cursor: pointer;
         position: absolute;
         top: hb-calculate-rems(3px);
         right: 0;

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_secondary-nav.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_secondary-nav.scss
@@ -189,6 +189,32 @@
         }
       }
     }
+
+    // when a nolink item behaves as a toggle button, add button toggle icon
+    &.hb-secondary-toggler {
+      position: relative;
+
+      &::after {
+        @include hb-menu-icon-wrapper(48px, 48px);
+        @include hb-menu-plus-icon;
+        cursor: pointer;
+        position: absolute;
+        top: hb-calculate-rems(3px);
+        right: 0;
+
+        // If there is no JS then the navigation is automatically expanded and
+        // toggle buttons are unnecessary.
+        .no-js & {
+          display: none;
+        }
+      }
+
+      &[aria-expanded="true"] {
+        &::after {
+          @include hb-menu-minus-icon;
+        }
+      }
+    }
   }
 
   &__button {

--- a/docroot/themes/humsci/humsci_basic/templates/menus/macros/secondary-nav-menu.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/menus/macros/secondary-nav-menu.twig
@@ -7,7 +7,7 @@
   {% import _self as menus %}
   <ul class="hb-secondary-nav__menu {{ class_prefix }}__menu hb-secondary-nav__menu-lv{{ menu_level }} {{ class_prefix }}__menu-lv{{ menu_level }}">
   {% for item in items %}
-    {# Link Attribtues #}
+    {# Link Attributes #}
     {% set link_attributes = item.attributes %}
     {% set link_attributes = link_attributes.addClass(class_prefix ~ "__link") %}
     {% set link_attributes = link_attributes.addClass("hb-secondary-nav__link") %}
@@ -27,16 +27,39 @@
     {% endif %}
 
     <li{{ list_attributes }}>
-      {{ link(item.title, item.url, link_attributes) }}
-
-      {% if item.below %}
+      {# This check whether or not there is a URL #}
+      {% if item.url.toString() is empty %}
+        {#
+          If there is no URL (<nolink>) then we need the toggler classes to be
+          on the anchor tag. We also don't need the button because the anchor tag
+          acts as the button to toggle the nested navigation.
+        #}
+        {% set link_attributes = link_attributes.addClass('hb-secondary-toggler') %}
         {% set randomInt = random(0, 100) %}
-        <button class="{{ class_prefix }}__button hb-secondary-toggler" id="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}" aria-expanded="true">
-          Toggle {{ item.title }}
-        </button>
-        <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}">
-          {{ menus.secondary_nav_menu(item.below, menu_level + 1, class_prefix, item) }}
-        </div>
+        <a{{ link_attributes }} id="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}" aria-expanded="true" role="button">{{ item.title }}</a>
+
+        {% if item.below %}
+          <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}">
+            {{ menus.secondary_nav_menu(item.below, menu_level + 1, class_prefix, item) }}
+          </div>
+        {% endif %}
+
+      {% else %}
+        {#
+          If there is a URL then we use a separate button element to toggle the
+          nested navigation and the anchor tag will just act as a link.
+        #}
+        {{ link(item.title, item.url, link_attributes) }}
+
+        {% if item.below %}
+          {% set randomInt = random(0, 100) %}
+          <button class="{{ class_prefix }}__button hb-secondary-toggler" id="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}" aria-expanded="true">
+            Toggle {{ item.title }}
+          </button>
+          <div class="{{ class_prefix }}__menu-container" aria-labelledby="{{ item.title|replace({' ': ''}) }}{{ menu_level }}{{ randomInt }}">
+            {{ menus.secondary_nav_menu(item.below, menu_level + 1, class_prefix, item) }}
+          </div>
+        {% endif %}
       {% endif %}
     </li>
   {% endfor %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Sidebar nolink items should now serve as the toggler for their submenus rather than having a separate button toggler. Linked items have a separate button toggler instead so that the link can be selected. This has the desired result of expanding the click area for nolink toggles. This mimics the behavior of nolink items in the main nav on mobile. 

## Need Review By (Date)
4/3

## Urgency
medium

## Steps to Test
1. Run npm test
2. Edit the main menu in Structure > Menus > Main Navigation
3. Select **+Add link** to add a new Level 1 nav item with a Link of _/node/41566_ (Test Page)
4.  Add a second nav link to serve as Level 2 with Link URL set as `<nolink>`
5. Use the drag (four arrows crossed) icon to drag the newly created Level 2 `<nolink>` item under the newly created Level 1 item
6. Use the same process to add atleast one Level 3 nav item under the newly created `<nolink>` nav item. Give the Level 3 items link urls such as `<front>` or _/node/41566_
7. View the node of the Level 1 nav item. In the left sidebar, select the Level 2 item text area to open and close the submenu.

- [x] Confirm that the Level 2 nolink item successfully toggles the Level 3 submenu when either the text area or the +/- toggle icon are clicked.
- [x] Observe sidebar menus on existing pages to make sure Level 2 items which are links retain a separate +/- toggle button so that their link URLs can still be accessed on click

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
