### PR TITLE
Stn 986  mega menu dark masthead

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vendor.we-megamenu.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vendor.we-megamenu.scss
@@ -39,10 +39,6 @@
         display: block;
         border: 0;
         transition: transform 150ms ease-in-out;
-
-        .hb-dark-pattern & {
-          @include hb-global-color('color','white');
-        }
       }
 
       // remove default mega menu caret
@@ -66,6 +62,10 @@
       > .we-mega-menu-li,
       > .we-megamenu-nolink {
 
+        .hb-dark-pattern & {
+          @include hb-global-color('color','white');
+        }
+
         // bottom border on hover via background
         &:hover,
         &:focus {
@@ -74,6 +74,10 @@
           background-size: 100% 0.55rem;
           background-repeat: no-repeat;
           background-position: bottom;
+
+          .hb-dark-pattern & {
+            @include hb-global-color('color','white');
+          }
         }
       }
 
@@ -190,6 +194,19 @@
     border-left: 0;
     border-right: 0;
     overflow: hidden;
+    @include hb-global-color('color', 'black');
+
+    .hb-dark-pattern & {
+      @include hb-global-color('color','black');
+    }
+
+    a:not([class]) {
+      @include hb-pairing-color('color', 'tertiary');
+
+      .hb-dark-pattern & {
+        @include hb-pairing-color('color', 'tertiary');
+      }
+    }
 
     // remove default mega menu height
     > .we-mega-menu-submenu-inner {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Overrides specific to dark masthead variant to ensure that the mega menu text is legible and consistent with standard menu styling on the dark masthead.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Run npm test
2. Install and activate the mega menu module as specified in STN-941, PR #1074 
3. Go to Appearance and then select "Settings" by your default theme.
4. Scroll down to "Local Masthead Settings" and select "Dark Masthead"
5. View the mega menu and check the color of the text in all 3 levels of nav items
6. Check on both Traditional and Colorful themes

- [x] Confirm all level 1 links are white
- [x] Confirm all level 1 links are white on hover
- [x] Confirm that all text within the dropdown submenu is either black or #8c1515 (should be consistent with how they appear when a normal masthead is activated)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
