### PR TITLE
feat(STN-992): last item endcaps and bottom border utility class

### DIFF
--- a/docroot/themes/humsci/humsci_basic/docs/utility-classes.md
+++ b/docroot/themes/humsci/humsci_basic/docs/utility-classes.md
@@ -185,6 +185,7 @@ _Note:_ Classes must be added to the field only. Any classes added to the field 
 | hb-main-body-detail-image | Used specifically on node detail pages to float an image. | - |
 | hb-carousel-reset-height | Override inline styles to reset the default height of the text box within a carousel. | - |
 | hb-timeline-checklist | Change vertical timeline circle icons to squares. | - |
+| hb-timeline-border | Add a bottom border to each vertical timeline. | - |
 
 ### Misc
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.timeline-item.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.timeline-item.scss
@@ -18,6 +18,33 @@
     height: 0; // remove the vertical pipe that connects timeline items from the last item
   }
 
+  &:last-of-type {
+    // when last item is open, show vertical pipe that connects timeline items
+    .hb-timeline-item[open] {
+      &::before {
+        content: '';
+        position: absolute;
+        height: calc(100% - 20px);
+        width: 4px;
+        @include hb-pairing-color('background-color', 'primary');
+        left: 1rem;
+        bottom: hb-calculate-rems(-2px);
+      }
+
+      // last item has small filled circle or square endcap when open
+      &::after {
+        @include hb-pairing-color('background-color', 'primary');
+        content: '';
+        position: absolute;
+        height: 12px;
+        width: 12px;
+        left: 6px;
+        bottom: -6px;
+        border-radius: 50%;
+      }
+    }
+  }
+
   .field-hs-row-components[class*="counted-items-"] &,
   .field-hs-collection-items[class*="item-per-row--"] & {
     margin-bottom: 0 !important;

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
@@ -131,4 +131,24 @@
       }
     }
   }
+
+  // endcap of last item is small square
+  .ptype-hs-timeline-item:last-of-type,
+  .views-view-pattern .hb-timeline-item:last-of-type {
+    .hb-timeline-item[open] {
+      &::after {
+        border-radius: initial;
+      }
+    }
+  }
+}
+
+// Vertical timeline bottom border on last item in each timeline
+// Apply in layout builder block configuration
+.hb-timeline-border {
+  .ptype-hs-timeline-item:last-of-type,
+  .views-view-pattern .hb-timeline-item:last-of-type {
+    padding-bottom: hb-calculate-rems(28px);
+    border-bottom: 1px solid #000;
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
When the last timeline item in a vertical timeline group is opened, it will now have an end cap corresponding to the appearance of the heading icons (circle or square). Default will be a small circle, and where hb-timeline-checklist utility class is applied in layout builder, it will be a small square. This will not effect timeline items which have no description content, as those items cannot be opened and closed. In addition, a new utility class hb-timeline-border is added which can be implemented in layout builder to cause timeline groups to have a bottom border.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Pull and NPM Start
2. Add a vertical timeline to a page which included description content in the final timeline item
3. Open and close the last timeline item to check for the endpoint
4. On the same page, access LAYOUT
5. hover over the block area within layout builder which wraps the vertical timeline and select "configure"
6. in Field Formatter Class, add the utility classes **hb-timeline-checklist** and **hb-timeline-border**

- [x] Confirm that the last timeline item in a vertical timeline group has a left border with a small circle endcap while open
- [x] Confirm the left border and end cap disappear when the item is closed
- [x] Confirm that adding hb-timeline-checklist in layout builder caused the endcap to become a small square instead of a circle
- [x] Confirm that adding hb-timeline-border in layout builder caused a thin black border to appear after the last timeline item in each vertical timeline group
- [x] Remove the descriptive text content from the last timeline item and confirm it is unaffected (has no left border, no endcap, cannot be opened and closed)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
