### PR TITLE
fix(STN-995): removed bottom margin from level 3 items that have chil…

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vendor.we-megamenu.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vendor.we-megamenu.scss
@@ -315,6 +315,11 @@
               @include hb-global-color('color', 'black');
             }
           }
+
+          // level 3 items with dropdowns same margin as without dropdowns
+          &.dropdown-menu {
+            margin-bottom: 0;
+          }
         }
 
         // level 4 hidden


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Eliminates extra space under level 3 nav items in the mega menu which was added due to those items having invisible level 4 children. _Pardon the branch name misspelling._ 

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Pull and npm start
2. Enable the mega menu add add it to the main navigation region of the site
3. Edit the site's menu to add a level 4 nav item
4. Add level 3 items that follow the new level 4 item (you want to see level 3 items with a level 4 child, followed by more level 3 items)
5. View the mega menu's submenu dropdown to confirm consistent spacing

- [x] Confirm that level 3 items which have an invisible level 4 item under them do not have any additional bottom margin

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
