### PR TITLE
SHS-30 - Fixes home page crash on cache clear

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -214,3 +214,4 @@ function humsci_basic_preprocess_pattern_vertical_link_card(&$variables) {
     $variables['title'] = ['#markup' => trim(strip_tags(render($variables['title'])))];
   }
 }
+

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -168,7 +168,6 @@ function _humsci_basic_check_link_access(array &$link_items) {
       $parameters = $url->getRouteParameters();
       $nid = $parameters['node'];
       $node = Node::load($nid);
-      $type = $node->bundle();
 
       if (!isset($link_item['attributes'])) {
         $link_item['attributes'] = new Attribute();
@@ -179,6 +178,7 @@ function _humsci_basic_check_link_access(array &$link_items) {
           $link_item['attributes']->setAttribute('data-unpublished-node', 'true');
         }
 
+        $type = $node->bundle();
         if ($type == 'hs_private_page') {
           $link_item['attributes']->addClass('hb-private-page-link');
         }

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -214,4 +214,3 @@ function humsci_basic_preprocess_pattern_vertical_link_card(&$variables) {
     $variables['title'] = ['#markup' => trim(strip_tags(render($variables['title'])))];
   }
 }
-


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fixes home page crash when cache is cleared.

## Need Review By (Date)
- None

## Urgency
- Medium

## Steps to Test
1. Clear the cache
2. Load the home page - it should no longer crash.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
