### PR TITLE
Use github actions to stage content

### DIFF
--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -11,4 +11,6 @@ jobs:
       - name: Copy databases
         env:
           SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}
+          ACQUIA_KEY: ${{ secrets.ACQUIA_KEY }}
+          ACQUIA_SECRET: ${{ secrets.ACQUIA_SECRET }}
         run: vendor/bin/blt stage --no-interaction

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -1,0 +1,11 @@
+name: Content Staging
+on: [push]
+jobs:
+  Copy-Prod-Database-Down:
+    runs-on: cimg/php:7.4
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: composer install --optimize-autoloader
+      - run: vendor/bin/blt blt:telemetry:disable --no-interaction
+      - run: vendor/bin/blt stage --no-interaction

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -2,7 +2,7 @@ name: Content Staging
 on: [push]
 jobs:
   Copy-Prod-Database-Down:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -4,11 +4,11 @@ jobs:
   Copy-Prod-Database-Down:
     runs-on: ubuntu-latest
     steps:
-      - name: Get Variables
-        env:
-          SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: composer update --optimize-autoloader
       - run: vendor/bin/blt blt:telemetry:disable --no-interaction
-      - run: vendor/bin/blt stage --no-interaction
+      - name: Copy databases
+        env:
+          SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}
+        run: vendor/bin/blt stage --no-interaction

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -1,5 +1,7 @@
 name: Content Staging
-on: [push]
+on:
+  schedule:
+    - cron: '*/5 * * * *'
 jobs:
   Copy-Prod-Database-Down:
     runs-on: ubuntu-latest

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -2,7 +2,7 @@ name: Content Staging
 on: [push]
 jobs:
   Copy-Prod-Database-Down:
-    runs-on: cimg/php:7.4
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -2,10 +2,10 @@ name: Content Staging
 on: [push]
 jobs:
   Copy-Prod-Database-Down:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - run: composer install --optimize-autoloader
+      - run: composer update --optimize-autoloader
       - run: vendor/bin/blt blt:telemetry:disable --no-interaction
       - run: vendor/bin/blt stage --no-interaction

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -4,6 +4,9 @@ jobs:
   Copy-Prod-Database-Down:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Variables
+        env:
+          SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: composer update --optimize-autoloader

--- a/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
@@ -147,9 +147,6 @@ class HsAcquiaApiCommands extends BltTasks {
     'env' => 'test',
     'no-notify' => FALSE,
   ]) {
-
-    $this->say('ran');
-    return;
     $task_started = time() - (60 * 60 * 24);
     $this->connectAcquiaApi();
 

--- a/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
@@ -148,6 +148,9 @@ class HsAcquiaApiCommands extends BltTasks {
     'no-notify' => false,
   ]) {
 
+    if(getenv('SLACK_NOTIFICATION_URL')){
+      $this->say('SLACK_NOTIFICATION_URL exists');
+    }
     $this->say('This command was called');
     return;
     $task_started = time() - (60 * 60 * 24);

--- a/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
@@ -145,14 +145,8 @@ class HsAcquiaApiCommands extends BltTasks {
     'exclude' => NULL,
     'resume' => FALSE,
     'env' => 'test',
-    'no-notify' => false,
+    'no-notify' => FALSE,
   ]) {
-
-    if(getenv('SLACK_NOTIFICATION_URL')){
-      $this->say('SLACK_NOTIFICATION_URL exists');
-    }
-    $this->say('This command was called');
-    return;
     $task_started = time() - (60 * 60 * 24);
     $this->connectAcquiaApi();
 

--- a/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
@@ -147,6 +147,9 @@ class HsAcquiaApiCommands extends BltTasks {
     'env' => 'test',
     'no-notify' => FALSE,
   ]) {
+
+    $this->say('ran');
+    return;
     $task_started = time() - (60 * 60 * 24);
     $this->connectAcquiaApi();
 

--- a/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsAcquiaApiCommands.php
@@ -147,6 +147,9 @@ class HsAcquiaApiCommands extends BltTasks {
     'env' => 'test',
     'no-notify' => false,
   ]) {
+
+    $this->say('This command was called');
+    return;
     $task_started = time() - (60 * 60 * 24);
     $this->connectAcquiaApi();
 


### PR DESCRIPTION
- feat: use we_megamenu process hook to add private page icon before private pages, style lock icon in megamenu
- add newline to eof
- fix: resize lock icon and fix padding
- STN-974: Move Mega Menu SCSS (#1087)
- fix(STN-994): scss for private page icon (#1097)
- fix: keep expand/collapse button in place when clicked (#1095)
- Chore: Sparkbox Cleanup (#1098)
- STN-982: Mega Menu On-Click Modification (#1093)
- chore: compiled CSS
- fix(sparkbox-sprint-62): corrected linting errors
- 9.3.15
- Updated dependencies Apr 27 2022
- fix(sparkbox-sprint-62): change mega menu library from preprocess html to preprocess block
- fix: update block preprocess hook for megamenu in traditional and colorful themes
- feat(STN-992): last item endcaps and bottom border utility class (#1100)
- fix(STN-995): removed bottom margin from level 3 items that have children (#1101)
- fix: rebase error
- chore: compiled CSS
- fix: hover issue
- Updated dependencies
- Removed sparkbox workgroup mapping
- Gitpod setup
- Updated dependencies May 4 2022
- HSD8-1287 Slack notification for the blt stage command
- test github actions

# READY FOR REVIEW

## Summary
_[briefly summarize the changes here]_

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Sparkbox PR Checklist](../docs/SparkboxPRChecklist.md)
