### PR TITLE
HSD8 1292

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -41,7 +41,7 @@ function su_humsci_profile_pathauto_pattern_alter(PathautoPatternInterface $patt
   $parent = explode(':', $node->menu['menu_parent']);
 
   // Make sure the parent menu item is a link content entity. The common form
-  // of the parent is `[menu_name]:[type]:[uuid]`
+  // of the parent is `[menu_name]:[type]:[uuid]`.
   if (
     count($parent) >= 3 &&
     $parent[0] == 'main' &&

--- a/tests/codeception/acceptance/MenuItemsCest.php
+++ b/tests/codeception/acceptance/MenuItemsCest.php
@@ -62,7 +62,7 @@ class MenuItemsCest {
     $url = parse_url($this->faker->url);
     $manual_url = $url['path'];
 
-    $I->logInWithRole('site_manager');
+    $I->logInWithRole('administrator');
     $auto_alias = $I->createEntity([
       'title' => $this->faker->words(3, TRUE),
       'type' => 'hs_basic_page',

--- a/tests/codeception/acceptance/MenuItemsCest.php
+++ b/tests/codeception/acceptance/MenuItemsCest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Url;
+use Faker\Factory;
 
 /**
  * Class MenuItemsCest.
@@ -8,6 +9,36 @@ use Drupal\Core\Url;
  * @group existingSite
  */
 class MenuItemsCest {
+
+  /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test generated links.
+   *
+   * @var \Drupal\menu_link_content\MenuLinkContentInterface[]
+   */
+  protected $menuLinks = [];
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
+   * Cleanup menu links after the test.
+   */
+  public function _after(AcceptanceTester $I) {
+    foreach ($this->menuLinks as $link) {
+      $link->delete();
+    }
+  }
 
   /**
    * Every main menu item should not error.
@@ -19,6 +50,70 @@ class MenuItemsCest {
       $I->amOnPage($path);
       $I->canSeeResponseCodeIsBetween(200, 404);
     }
+  }
+
+  /**
+   * Path auto settings should work correctly.
+   *
+   * @group pathauto
+   */
+  public function testPathAuto(AcceptanceTester $I) {
+    $url = parse_url($this->faker->url);
+    $manual_url = $url['path'];
+
+    $I->logInWithRole('site_manager');
+    $auto_alias = $I->createEntity([
+      'title' => $this->faker->words(3, TRUE),
+      'type' => 'hs_basic_page',
+    ]);
+    $I->amOnPage($auto_alias->toUrl('edit-form')->toString());
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', $auto_alias->label());
+    $I->click('Save');
+    $I->canSee($auto_alias->label(), 'h1');
+
+    $manual_alias = $I->createEntity([
+      'title' => $this->faker->words(3, TRUE),
+      'type' => 'hs_basic_page',
+    ]);
+    $I->amOnPage($manual_alias->toUrl('edit-form')->toString());
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', $manual_alias->label());
+    $I->uncheckOption('Generate automatic URL alias');
+    $I->fillField('URL alias', $manual_url);
+    $I->click('Save');
+
+    $nolink = $I->createEntity([
+      'title' => 'Foo Bar',
+      'link' => 'route:<nolink>',
+      'weight' => 0,
+      'menu_name' => 'main',
+    ], 'menu_link_content');
+    $this->menuLinks[] = $nolink;
+
+    $node = $I->createEntity([
+      'title' => $this->faker->words(3, TRUE),
+      'type' => 'hs_basic_page',
+    ]);
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', $node->label());
+    $I->selectOption('Parent link', '-- ' . $auto_alias->label());
+    $I->click('Change parent (update list of weights)');
+    $I->click('Save');
+    $I->canSeeInCurrentUrl($auto_alias->toUrl()->toString() . '/');
+
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->selectOption('Parent link', '-- ' . $manual_alias->label());
+    $I->click('Change parent (update list of weights)');
+    $I->click('Save');
+    $I->canSeeInCurrentUrl($manual_alias->toUrl()->toString() . '/');
+
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->selectOption('Parent link', '-- ' . $nolink->label());
+    $I->click('Change parent (update list of weights)');
+    $I->click('Save');
+    $I->canSeeInCurrentUrl('/foo-bar/');
   }
 
   /**

--- a/tests/codeception/acceptance/MenuItemsCest.php
+++ b/tests/codeception/acceptance/MenuItemsCest.php
@@ -56,6 +56,7 @@ class MenuItemsCest {
    * Path auto settings should work correctly.
    *
    * @group pathauto
+   * @group install
    */
   public function testPathAuto(AcceptanceTester $I) {
     $url = parse_url($this->faker->url);


### PR DESCRIPTION
- fix: adjust styles to fix display issues with twit and issuu embeds
- shs-5: run build command
- shs-2: fix alignment of media asset edit button in wysiwyg
- fix(theme-fix): fixes home page crash on cache clear
- shs-10: gradient hero fix animated text bug
- test
- Revert "test"
- fix: fix template comment
- shs-6: update breakout box background color
- shs-5: fix compiled css to match latest develop
- 9.3.17
- shs-6: update compiled css
- shs-10: update compiled css to latest
- shs-2: update compiled css to latest
- shs-5: update compiled css to latest
- HSD8-1231 Added field for bookmark localist feed urls.
- HSD8-1234 Invalidate urls if a redirect is created
- HSD8-1292 Adjust path auto pattern for no link menu items

# READY FOR REVIEW

## Summary
_[briefly summarize the changes here]_

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
