### PR TITLE
Security fix for composer >= 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -283,7 +283,16 @@
     "config": {
         "sort-packages": true,
         "discard-changes": true,
-        "allow-plugins": true
+        "allow-plugins": {
+            "composer/installers": true,
+            "simplesamlphp/composer-module-installer": true,
+            "davidbarratt/custom-installer": true,
+            "drupal/console-extend-plugin": true,
+            "acquia/blt": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "drupal/core-project-message": true
+        }
     },
     "scripts": {
         "post-drupal-scaffold-cmd": [


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
See https://getcomposer.org/allow-plugins
as of last night, allow-plugins is required to have a list of plugins that are accepted each with a true false value. Simply making this value "true" is no longer supported and cause composer install to fail with the following error
![image](https://user-images.githubusercontent.com/526491/176905045-38295e53-fba5-4ec5-ab12-9785126c8b4c.png)


## Need Review By (Date)
ASAP

## Urgency
HIGH

## Steps to Test
1. run composer install
2. Validate that it finishes successfully.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
