### PR TITLE
Lift htaccess block of .html paths.

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -93,8 +93,9 @@ AddEncoding gzip svgz
   RewriteCond %{REQUEST_URI} node_modules [OR,NC]
   RewriteCond %{REQUEST_URI} ^/vendor [OR,NC]
   RewriteCond %{REQUEST_URI} "/wp-(admin|content/plugins/|includes|cron\.php|config\.php|login\.php|signup\.php)|xmlrpc.php" [OR,NC]
-  RewriteCond %{THE_REQUEST} \.php[/\s?] [OR,NC]
-  RewriteCond %{THE_REQUEST} \.html[/\s?] [NC]
+  # RewriteCond %{THE_REQUEST} \.php[/\s?] [OR,NC]
+  # RewriteCond %{THE_REQUEST} \.html[/\s?] [NC]
+  RewriteCond %{THE_REQUEST} \.php[/\s?] [NC]
   RewriteCond %{REQUEST_URI} !^/simplesaml/module.php
   RewriteRule .* - [F]
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- The music site has two very important URL redirects they need in place from URL paths with `.html` exensions, but `.html` paths are blocked through the `.htaccess` file. This removes the blocking of `.html` paths.
- Original PR with the `.html` block appears to be for reducing bot traffic: https://github.com/SU-HSDO/suhumsci/commit/9e27e9bd7d12aa533a430d2e8b61918b1d389fe6

## Need Review By (Date)
ASAP

## Urgency
Med/High

## Steps to Test
1. Create a URL redirect from an `.html` file path to anyhwere else on the site (eg., from `test/test.html`) and ensure it works.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
