### PR TITLE
HSD8-000: Adjust htaccess path and user-agent blocks

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -94,8 +94,10 @@ AddEncoding gzip svgz
   RewriteCond %{REQUEST_URI} ^/vendor [OR,NC]
   RewriteCond %{REQUEST_URI} "/wp-(admin|content/plugins/|includes|cron\.php|config\.php|login\.php|signup\.php)|xmlrpc.php" [OR,NC]
   RewriteCond %{THE_REQUEST} \.php[/\s?] [OR,NC]
-  RewriteCond %{THE_REQUEST} \.html[/\s?] [NC]
+  RewriteCond %{REQUEST_URI} \.html [NC]
+   # Allow access to SimpleSaml login and music.stanford.edu redirect path.
   RewriteCond %{REQUEST_URI} !^/simplesaml/module.php
+  RewriteCond %{REQUEST_URI} !^/Academics/LessonSignups.html
   RewriteRule .* - [F]
 
   # Block access to specific files/paths to all users except stanford IP's.

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -88,6 +88,10 @@ AddEncoding gzip svgz
 <IfModule mod_rewrite.c>
   RewriteEngine on
 
+  # Block access via specific user-agents.
+  RewriteCond %{HTTP_USER_AGENT} CQ-API-Spyder [NC]
+  RewriteRule .* - [F,L]
+
   # Block access to php & html files. Node_modules and the vendor
   # directory should never be available. Also block any WordPress urls.
   RewriteCond %{REQUEST_URI} node_modules [OR,NC]


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Allowed an exception to the `.html` path block for a specific redirect for music.stanford.edu
- Added a user-agent block for `CQ-API-Spyder`

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
