### PR TITLE
HSD8-1363: Additional music.stanford.edu .html redirect path in .htaccess.

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -99,9 +99,10 @@ AddEncoding gzip svgz
   RewriteCond %{REQUEST_URI} "/wp-(admin|content/plugins/|includes|cron\.php|config\.php|login\.php|signup\.php)|xmlrpc.php" [OR,NC]
   RewriteCond %{THE_REQUEST} \.php[/\s?] [OR,NC]
   RewriteCond %{REQUEST_URI} \.html [NC]
-   # Allow access to SimpleSaml login and music.stanford.edu redirect path.
+   # Allow access to SimpleSaml login and music.stanford.edu redirect paths.
   RewriteCond %{REQUEST_URI} !^/simplesaml/module.php
   RewriteCond %{REQUEST_URI} !^/Academics/LessonSignups.html
+  RewriteCond %{REQUEST_URI} !^/FOM/fom.html
   RewriteRule .* - [F]
 
   # Block access to specific files/paths to all users except stanford IP's.

--- a/patches/htaccess.patch
+++ b/patches/htaccess.patch
@@ -30,7 +30,7 @@ index 4d19147c..48638114 100644
 @@ -67,6 +88,61 @@ AddEncoding gzip svgz
  <IfModule mod_rewrite.c>
    RewriteEngine on
- 
+
 +  # Block access via specific user-agents.
 +  RewriteCond %{HTTP_USER_AGENT} CQ-API-Spyder [NC]
 +  RewriteRule .* - [F,L]

--- a/patches/htaccess.patch
+++ b/patches/htaccess.patch
@@ -1,5 +1,5 @@
 diff --git a/docroot/.htaccess b/docroot/.htaccess
-index 4d19147c..df15a39f 100644
+index 4d19147c..48638114 100644
 --- a/docroot/.htaccess
 +++ b/docroot/.htaccess
 @@ -1,3 +1,24 @@
@@ -27,10 +27,10 @@ index 4d19147c..df15a39f 100644
  #
  # Apache/PHP/Drupal settings:
  #
-@@ -67,6 +88,60 @@ AddEncoding gzip svgz
+@@ -67,6 +88,61 @@ AddEncoding gzip svgz
  <IfModule mod_rewrite.c>
    RewriteEngine on
-
+ 
 +  # Block access via specific user-agents.
 +  RewriteCond %{HTTP_USER_AGENT} CQ-API-Spyder [NC]
 +  RewriteRule .* - [F,L]
@@ -42,9 +42,10 @@ index 4d19147c..df15a39f 100644
 +  RewriteCond %{REQUEST_URI} "/wp-(admin|content/plugins/|includes|cron\.php|config\.php|login\.php|signup\.php)|xmlrpc.php" [OR,NC]
 +  RewriteCond %{THE_REQUEST} \.php[/\s?] [OR,NC]
 +  RewriteCond %{REQUEST_URI} \.html [NC]
-+   # Allow access to SimpleSaml login and music.stanford.edu redirect path.
++   # Allow access to SimpleSaml login and music.stanford.edu redirect paths.
 +  RewriteCond %{REQUEST_URI} !^/simplesaml/module.php
 +  RewriteCond %{REQUEST_URI} !^/Academics/LessonSignups.html
++  RewriteCond %{REQUEST_URI} !^/FOM/fom.html
 +  RewriteRule .* - [F]
 +
 +  # Block access to specific files/paths to all users except stanford IP's.
@@ -88,7 +89,7 @@ index 4d19147c..df15a39f 100644
    # Set "protossl" to "s" if we were accessed via https://.  This is used later
    # if you enable "www." stripping or enforcement, in order to ensure that
    # you don't bounce between http and https.
-@@ -144,6 +219,8 @@ AddEncoding gzip svgz
+@@ -144,6 +220,8 @@ AddEncoding gzip svgz
    RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
    # Allow access to test-specific PHP files:
    RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?\.php


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Allowed additional music.stanford.edu .html redirect path in .htaccess.

https://stanfordits.atlassian.net/browse/HSD8-1363
Original request:
```
Afternoon, we you put in an exception to allow for an HTML link on the Music site. Could we please put in a second one?  I thought we had resolved it by changing the domain redirect, but this URL got printed on paper and delivered in people's mailboxes.
https://music.stanford.edu/FOM/fom.html
```

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
