### PR TITLE
HSD8-1405-1406-1407: Mapped 3 site aliases to correct 2022 paths.

### DIFF
--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -95,6 +95,9 @@ $sites['heidi-williams.humsci.stanford.edu'] = 'heidi_williams2022__humsci';
 $sites['gavin-wright.humsci.stanford.edu'] = 'gavin_wright2022__humsci';
 $sites['humanitiescore.stanford.edu'] = 'humanitiescore2022';
 $sites['facultyaffairs-humsci.stanford.edu'] = 'facultyaffairs_humsci2021';
+$sites['lowe.stanford.edu'] = 'lowe2022';
+$sites['shenlab.stanford.edu'] = 'shenlab2022';
+$sites['duboislab.stanford.edu'] = 'duboislab2022';
 
 
 if (file_exists(__DIR__ . '/local.sites.php')) {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Mapped aliases for 3 launches using the workaround:

- [HSD8-1405](https://stanfordits.atlassian.net/browse/HSD8-1405): Launch request lowe2022-prod 11/17
- [HSD8-1406](https://stanfordits.atlassian.net/browse/HSD8-1406): Launch request shenlab2022-prod 11/17
- [HSD8-1407](https://stanfordits.atlassian.net/browse/HSD8-1407): Launch request duboislab2022-prod 11/17

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)

