### PR TITLE
SHS-123: Codeception: Create aria attributes test for timeline items

### DIFF
--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -234,4 +234,58 @@ class FlexiblePageCest {
     $I->canSeeNumberOfElements('picture img', 1);
   }
 
+  /**
+   * I can find appropriate aria attributes on a timeline item.
+   */
+  public function testTimelineItemAriaLabel(FunctionalTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage('node/add/hs_basic_page');
+    $I->fillField('Title', $this->faker->words(3, TRUE));
+    $I->click('List additional actions', '[data-drupal-selector="edit-field-hs-page-components-add-more-operations"]');
+    $I->click('field_hs_page_components_hs_timeline_add_more');
+    $I->waitForText('Vertical Timeline');
+    $I->checkOption('Collapse by default');
+    $I->fillField('field_hs_page_components[1][subform][field_hs_timeline][0][subform][field_hs_timeline_item_summary][0][value]', 'Timeline Item #1 Title');
+    $I->click('.cke_button__source.cke_button_off');
+    $I->fillField('.cke_source', '<p>Timeline item #1 description.</p>');
+    $I->click('Add Timeline Item');
+    $I->wait(1);
+    $I->fillField('field_hs_page_components[1][subform][field_hs_timeline][1][subform][field_hs_timeline_item_summary][0][value]', 'Timeline Item #2 Title');
+    $I->click('Save');
+    $I->canSee('Timeline Item #1 Title');
+    $I->canSee('Timeline Item #2 Title');
+
+    // Check aria attributes for first item.
+    $this->firstItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-pressed');
+    if (filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-pressed is true in the first item');
+    }
+    $this->firstItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-expanded');
+    if (filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-expanded is true in the first item');
+    }
+
+    // Check aria attributes for second item.
+    $this->secondItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][last()]', 'aria-pressed');
+    if (filter_var($this->secondItemAriaPressed, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-pressed is true in the second item');
+    }
+    $this->secondItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][last()]', 'aria-expanded');
+    if (filter_var($this->secondItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-expanded is true in the second item');
+    }
+
+    // Open first summary.
+    $I->click('//*[@class="hb-timeline-item__summary"][1]');
+    $this->firstItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-pressed');
+    if (!filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-pressed is false in the first item');
+    }
+    $this->firstItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-expanded');
+    if (!filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
+      $I->fail('aria-expanded is false in the first item');
+    }
+    $I->canSee('Timeline item #1 description.');
+  }
+
 }

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -237,7 +237,7 @@ class FlexiblePageCest {
   /**
    * I can find appropriate aria attributes on a timeline item.
    */
-  public function testTimelineItemAriaLabel(FunctionalTester $I) {
+  public function testVerticalTimeline(FunctionalTester $I) {
     $I->logInWithRole('administrator');
     $I->amOnPage('node/add/hs_basic_page');
     $I->fillField('Title', $this->faker->words(3, TRUE));
@@ -256,35 +256,23 @@ class FlexiblePageCest {
     $I->canSee('Timeline Item #2 Title');
 
     // Check aria attributes for first item.
-    $this->firstItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-pressed');
-    if (filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-pressed is true in the first item');
-    }
-    $this->firstItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-expanded');
-    if (filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-expanded is true in the first item');
-    }
+    $this->firstItemAriaPressed = $I->grabAttributeFrom('.hb-timeline-item__summary:first-child', 'aria-pressed');
+    $I->assertFalse(filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL), 'Aria-pressed should be false in the first item.');
+    $this->firstItemAriaExpanded = $I->grabAttributeFrom('.hb-timeline-item__summary:first-child', 'aria-expanded');
+    $I->assertFalse(filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL), 'arria-expanded should be false in the first item');
 
     // Check aria attributes for second item.
-    $this->secondItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][last()]', 'aria-pressed');
-    if (filter_var($this->secondItemAriaPressed, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-pressed is true in the second item');
-    }
-    $this->secondItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][last()]', 'aria-expanded');
-    if (filter_var($this->secondItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-expanded is true in the second item');
-    }
+    $this->secondItemAriaPressed = $I->grabAttributeFrom('.hb-timeline-item__summary:last-child', 'aria-pressed');
+    $I->assertFalse(filter_var($this->secondItemAriaPressed, FILTER_VALIDATE_BOOL), 'Aria-pressed should be false in the second item.');
+    $this->secondItemAriaExpanded = $I->grabAttributeFrom('.hb-timeline-item__summary:last-child', 'aria-expanded');
+    $I->assertFalse(filter_var($this->secondItemAriaExpanded, FILTER_VALIDATE_BOOL), 'Aria-expanded should be false in the second item.');
 
     // Open first summary.
-    $I->click('//*[@class="hb-timeline-item__summary"][1]');
-    $this->firstItemAriaPressed = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-pressed');
-    if (!filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-pressed is false in the first item');
-    }
-    $this->firstItemAriaExpanded = $I->grabAttributeFrom('//*[@class="hb-timeline-item__summary"][1]', 'aria-expanded');
-    if (!filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL)) {
-      $I->fail('aria-expanded is false in the first item');
-    }
+    $I->click('.hb-timeline-item__summary:first-child');
+    $this->firstItemAriaPressed = $I->grabAttributeFrom('.hb-timeline-item__summary:first-child', 'aria-pressed');
+    $I->assertTrue(filter_var($this->firstItemAriaPressed, FILTER_VALIDATE_BOOL), 'Aria-pressed should be true in the first item.');
+    $this->firstItemAriaExpanded = $I->grabAttributeFrom('.hb-timeline-item__summary:first-child', 'aria-expanded');
+    $I->assertTrue(filter_var($this->firstItemAriaExpanded, FILTER_VALIDATE_BOOL), 'Aria-expanded should be true in the first item.');
     $I->canSee('Timeline item #1 description.');
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Add a Codeception test for the Vertical Timeline component that will check the status of aria attributes on a timeline item summary.

## Urgency
_medium_

## Steps to Test
1. Run codeception tests either via CI or locally
2. Verify that the testVideoEmbed test passes.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
