### PR TITLE
SHS-121: (bug) Sidebar Menu not expanding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -205,6 +205,7 @@
         "drupal/menu_link_attributes": "^1.2",
         "drupal/menu_link_weight": "^1.0@beta",
         "drupal/menu_position": "^1.0@beta",
+        "drupal/menu_trail_by_path": "^2.0",
         "drupal/metatag": "^1.14",
         "drupal/migrate_source_csv": "^3.4",
         "drupal/mysql56": "^1.1",
@@ -340,6 +341,9 @@
             "drupal/menu_position": {
                 "https://www.drupal.org/project/menu_position/issues/3110502": "https://www.drupal.org/files/issues/2020-07-29/drupal-menu_position-WSOD-when-menu-parent-no-longer-exists-3110502-26.patch",
                 "Clean menu tree": "patches/contrib/menu_postion_rule-edit_route.patch"
+            },
+            "drupal/menu_trail_by_path": {
+                "https://www.drupal.org/project/menu_trail_by_path/issues/2914746": "https://www.drupal.org/files/issues/2022-04-06/2914746-27.patch"
             },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2895561": "https://www.drupal.org/files/issues/2021-05-06/paragraphs-2895561-32.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4034a7891e6c2c91f0b68e0efb670521",
+    "content-hash": "1cb6cab18a7518ca9d336ef82a87e327",
     "packages": [
         {
             "name": "acquia/blt",
@@ -8787,6 +8787,66 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/menu_position",
                 "issues": "https://www.drupal.org/project/issues/menu_position"
+            }
+        },
+        {
+            "name": "drupal/menu_trail_by_path",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/menu_trail_by_path.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/menu_trail_by_path-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "4974b181df7112e2b09e3bddf10b9e704db15375"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9.0 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1667652245",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "davy-r",
+                    "homepage": "https://www.drupal.org/user/3278771"
+                },
+                {
+                    "name": "mbovan",
+                    "homepage": "https://www.drupal.org/user/3149657"
+                },
+                {
+                    "name": "redndahead",
+                    "homepage": "https://www.drupal.org/user/160320"
+                },
+                {
+                    "name": "SeriousMatters",
+                    "homepage": "https://www.drupal.org/user/290439"
+                }
+            ],
+            "description": "Expand menus and set active-trail according to the current path.",
+            "homepage": "https://www.drupal.org/project/menu_trail_by_path",
+            "support": {
+                "source": "https://git.drupalcode.org/project/menu_trail_by_path"
             }
         },
         {
@@ -27708,5 +27768,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -161,6 +161,7 @@ module:
   menu_link_attributes: 0
   menu_link_content: 0
   menu_position: 0
+  menu_trail_by_path: 0
   menu_ui: 0
   metatag: 0
   metatag_favicons: 0


### PR DESCRIPTION
## Summary
- Installs the Menu Trail by Path module
- Addresses a long standing bug where using rabbit_hole redirects can cause the menu items `active_trail` indicator to be lost. Thus breaking the active state of the sidebar for users.

## Need Review By (Date)
TBD

## Urgency
low

## Steps to Test
1. We have had a hard time reproducing this locally. Even following the same reported steps seems to result in the sidebar `active_trail` being set properly. We waited until a production instance of the bug is present and rebuilt our locals with the example site. As of now, this link shows the bug: https://sgs.stanford.edu/global-internships/apply/application 
2. Rebuild your local instance of the above site using the `develop` branch. Verify the bug is reproducible on your local machine.
3. Checkout this branch and rebuild the above site
4. Verify the `menu_trail_by_path` module is enabled with default config during the rebuild process.
5. Go to the page above and verify the sidebar has the `active_trail` value set with `apply` menu item highlights/open and the `application` set to active.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
