### PR TITLE
SHS-134: Add Links to Codeception Docs

### DIFF
--- a/docs/Codeception.md
+++ b/docs/Codeception.md
@@ -4,21 +4,21 @@ The following Codeception tests are currently run during a CI build. Unless othe
 
 ## Acceptance
 
-* [Course] (../tests/codeception/acceptance/Install/Content/CourseCest.php)
-* Flexible Page
-  * Postcard
-  * Accordion
-  * Back to top block
-  * Text area
-  * Collections (2 items per row - Text Area and Postcard)
-* Private Page Field Test
+* [Course](../tests/codeception/acceptance/Install/Content/CourseCest.php)
+* [Flexible Page](../tests/codeception/acceptance/Install/Content/CourseCest.php)
+  * [Postcard](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L29)
+  * [Accordion](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L54)
+  * [Back to top block](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L71)
+  * [Text area](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L92)
+  * [Collections (2 items per row - Text Area and Postcard)](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L128)
+* [Private Page Field Test](../tests/codeception/acceptance/Install/Content/PrivatePageContentCest.php)
   * With Site Manager role, test following field visibility:
     * Private Text Area
     * Private Collection
     * Spotlight - Slider
     * Accordion
     * Postcard
-* Private Page Permissions
+* [Private Page Permissions](../tests/codeception/acceptance/Install/Content/PrivatePagePermissionCest.php)
   * Test access to private page for role:
     * Site Manager
     * Developer
@@ -31,61 +31,62 @@ The following Codeception tests are currently run during a CI build. Unless othe
     * Stanford Student
     * Authenticated user
     * Annoymous user
-* Permissions Testing - verify the following role permssions in config match permissions in database
-  * Anonymous
-  * Authenticated user
-  * Contributor
-  * Site Manager
-* Install State
-  * Default Content (Home page)
+* [Permissions Testing - verify the following role permissions in config match permissions in database](../tests/codeception/acceptance/Install/Roles)
+  * [Anonymous](../tests/codeception/acceptance/Install/Roles/AnonymousCest.php)
+  * [Authenticated user](../tests/codeception/acceptance/Install/Roles/AuthenticatedCest.php)
+  * [Contributor](../tests/codeception/acceptance/Install/Roles/ContributorCest.php)
+  * [Site Manager](../tests/codeception/acceptance/Install/Roles/SiteManagerCest.php)
+* [Install State](../tests/codeception/acceptance/Install/InstallStateCest.php)
+  * [Default Content (Home page)](../tests/codeception/acceptance/Install/InstallStateCest.php#L29)
     * Text input
     * Search button
     * Specific content
-  * Visible Admin Items
+  * [Visible Admin Items](../tests/codeception/acceptance/Install/InstallStateCest.php#L44)
     * Admin menu items
     * Specific people in user list
   * Specific number of shortcuts for specific roles
-    * Contributor
-    * Site Manager
-  * Unpublished Menu Items
+    * [Contributor](../tests/codeception/acceptance/Install/InstallStateCest.php#L62)
+    * [Site Manager](../tests/codeception/acceptance/Install/InstallStateCest.php#L73)
+    * [Developer](../tests/codeception/acceptance/Install/InstallStateCest.php#L84)
+  * [Unpublished Menu Items](../tests/codeception/acceptance/Install/InstallStateCest.php#L93)
     * Site Managers should be able to place a page under an unpublished page in the menu
     * Tests adding menu items and verifying they exist after save
-  * Fast 404
+  * [Fast 404](../tests/codeception/acceptance/Install/InstallStateCest.php#L127)
     * Create a node and redirect to the node
     * Test visiting the redirect and verify redirect works to the node
-* Paragraphs
+* [Paragraphs](../tests/codeception/acceptance/Paragraphs/ParagraphsCest.php)
   * Tests specific paragraphs included/excluded from collections on:
     * Private Page
     * Rows
     * Public Collections
     * Flexible Page
-* Menu Items
-  * Validity of menu links in header
-  * Pathauto automatic aliasing of paths
+* [Menu Items](../tests/codeception/acceptance/MenuItemsCest.php)
+  * [Validity of menu links in header](../tests/codeception/acceptance/MenuItemsCest.php#L48)
+  * [Pathauto automatic aliasing of paths](../tests/codeception/acceptance/MenuItemsCest.php#L64)
 
 ## Functional
 
-* Flexible Page
-  * Hero
-  * Photo Album
-  * Mobile Menu button and toggles
-  * Spotlight Slider (with 2 slides)
-  * Vertical Timeline
-* Video Embed
+* [Flexible Page](../tests/codeception/functional/Install/Content/FlexiblePageCest.php)
+  * [Hero](../tests/codeception/functional/Install/Content/FlexiblePageCest.php#L36)
+  * [Photo Album](../tests/codeception/functional/Install/Content/FlexiblePageCest.php#L74)
+  * [Mobile Menu button and toggles](../tests/codeception/functional/Install/Content/FlexiblePageCest.php#L117)
+  * [Spotlight Slider (with 2 slides)](../tests/codeception/functional/Install/Content/FlexiblePageCest.php#L173)
+  * [Vertical Timeline](../tests/codeception/functional/Install/Content/FlexiblePageCest.php#L242)
+* [Video Embed](../tests/codeception/functional/Install/Content/VideoEmbedCest.php)
   * Title
   * Text field
   * Media (YouTube video via URL)
   * Caption
-* Media
-  * Document (txt file)
-  * Cannot upload PHP files
-  * Images
-  * Video (YouTube via URL)
-* MegaMenu
+* [Media](../tests/codeception/functional/MediaCest.php)
+  * [Document (txt file)](../tests/codeception/functional/MediaCest.php#L14)
+  * [Cannot upload PHP files](../tests/codeception/functional/MediaCest.php#L30)
+  * [Images](../tests/codeception/functional/MediaCest.php#L41)
+  * [Video (YouTube via URL)](../tests/codeception/functional/MediaCest.php#L59)
+* [MegaMenu](../tests/codeception/functional/MegaMenuCest.php)
   * Enable MegaMenu
   * Add top level and second level item
   * Toggles menu items
   * Mobile menu button and toggles
 
 ## Disabled Acceptance Tests
-  * Flexible Page - Row with Text Area
+  * [Flexible Page - Row with Text Area](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L109)

--- a/docs/Codeception.md
+++ b/docs/Codeception.md
@@ -4,7 +4,7 @@ The following Codeception tests are currently run during a CI build. Unless othe
 
 ## Acceptance
 
-* Course
+* [Course] (tests/codeception/acceptance/Install/Content/CourseCest.php)
 * Flexible Page
   * Postcard
   * Accordion

--- a/docs/Codeception.md
+++ b/docs/Codeception.md
@@ -4,7 +4,7 @@ The following Codeception tests are currently run during a CI build. Unless othe
 
 ## Acceptance
 
-* [Course] (tests/codeception/acceptance/Install/Content/CourseCest.php)
+* [Course] (../tests/codeception/acceptance/Install/Content/CourseCest.php)
 * Flexible Page
   * Postcard
   * Accordion

--- a/docs/Codeception.md
+++ b/docs/Codeception.md
@@ -5,7 +5,7 @@ The following Codeception tests are currently run during a CI build. Unless othe
 ## Acceptance
 
 * [Course](../tests/codeception/acceptance/Install/Content/CourseCest.php)
-* [Flexible Page](../tests/codeception/acceptance/Install/Content/CourseCest.php)
+* [Flexible Page](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php)
   * [Postcard](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L29)
   * [Accordion](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L54)
   * [Back to top block](../tests/codeception/acceptance/Install/Content/FlexiblePageCest.php#L71)


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds links to the tests (and line numbers of specific tests) from the Codeception documentation for easier reference to what each test is actually doing.

## Urgency
low

## Steps to Test
1. Review [Codeception documentation](https://github.com/SU-HSDO/suhumsci/blob/SHS-134--codeception-doc-links/docs/Codeception.md) and verify that the links to the tests are correct.
