### PR TITLE
HSD8-1475: Pull all departments for capx importer profiles

### DIFF
--- a/config/default/field.storage.node.field_hs_person_department.yml
+++ b/config/default/field.storage.node.field_hs_person_department.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: 10
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/default/field.storage.node.field_hs_person_department.yml
+++ b/config/default/field.storage.node.field_hs_person_department.yml
@@ -13,7 +13,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 10
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -295,7 +295,7 @@ process:
         value: label/text
     -
       plugin: flatten
-  field_hs_person_department:
+  department:
     -
       plugin: sub_process
       source: department
@@ -303,6 +303,12 @@ process:
         value: department
     -
       plugin: flatten
+  field_hs_person_department:
+    -
+      plugin: null_coalesce
+      source:
+        - '@department'
+        - org_title
     -
       plugin: skip_on_empty
       method: process

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -306,15 +306,25 @@ process:
         value: department
     -
       plugin: flatten
+  orgTitle:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: org_title
+    -
+      plugin: explode
+      delimiter: '|/'
   field_hs_person_department:
     -
       plugin: null_coalesce
       source:
         - '@department'
-        - org_title
+        - '@orgTitle'
     -
       plugin: skip_on_empty
       method: process
+    -
+      plugin: multiple_values
     -
       plugin: entity_generate
       entity_type: taxonomy_term

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -108,8 +108,8 @@ source:
       selector: education
     -
       name: department
-      label: Departement
-      selector: academicOffices/0/department
+      label: 'Department'
+      selector: academicOffices
     -
       name: cv_document
       label: 'CV Document'
@@ -295,17 +295,14 @@ process:
         value: label/text
     -
       plugin: flatten
-  department:
-    -
-      plugin: skip_on_empty
-      source: department
-      method: process
   field_hs_person_department:
     -
-      plugin: null_coalesce
-      source:
-        - '@department'
-        - org_title
+      plugin: sub_process
+      source: department
+      process:
+        value: department
+    -
+      plugin: flatten
     -
       plugin: skip_on_empty
       method: process

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -297,8 +297,11 @@ process:
       plugin: flatten
   department:
     -
-      plugin: sub_process
+      plugin: skip_on_empty
+      method: process
       source: department
+    -
+      plugin: sub_process
       process:
         value: department
     -

--- a/config/default/migrate_plus.migration.hs_capx.yml
+++ b/config/default/migrate_plus.migration.hs_capx.yml
@@ -108,7 +108,7 @@ source:
       selector: education
     -
       name: department
-      label: 'Department'
+      label: Department
       selector: academicOffices
     -
       name: cv_document


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Increased the item limit from 1 to 10 on the Person department field.
- Modified the importer to pull more than 1 department.

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. I'm not sure how you want to test this, but you'll want to test an import of the `migrate_plus.migration.hs_capx` migration on a capx profile with multiple departments. I had been using the `BIOLOGY:BIO-FACULTY` workgroup and [Barbara Block](https://profiles.stanford.edu/barbara-block) as an example (she's in Oceans and Biology).

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
