### PR TITLE
HSD8-1480: Re-enabled the hero gradient slider on the hs_collection items.

### DIFF
--- a/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
+++ b/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
@@ -9,7 +9,6 @@ dependencies:
     - paragraphs.paragraphs_type.hs_clr_bnd
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
-    - paragraphs.paragraphs_type.hs_gradient_hero_slider
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area
     - paragraphs.paragraphs_type.hs_row
@@ -33,8 +32,6 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      hs_gradient_hero_slider: hs_gradient_hero_slider
-      hs_carousel: hs_carousel
       hs_collection: hs_collection
       hs_priv_text_area: hs_priv_text_area
       hs_row: hs_row
@@ -46,6 +43,7 @@ settings:
       stanford_gallery: stanford_gallery
       hs_priv_collection: hs_priv_collection
       hs_sptlght_slder: hs_sptlght_slder
+      hs_carousel: hs_carousel
     negate: 1
     target_bundles_drag_drop:
       hs_accordion:
@@ -71,7 +69,7 @@ settings:
         enabled: true
       hs_gradient_hero_slider:
         weight: -40
-        enabled: true
+        enabled: false
       hs_hero_image:
         weight: -37
         enabled: false


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Re-enabled the Hero Gradient Slider as an option for reference in the `hs_collection` paragraph items field.
- The config change says `enabled: false` but that's because the field setting is for exclusion, not inclusion; `enabled: false` means it's _not_ excluded (so enabled).
https://stanfordits.atlassian.net/browse/HSD8-1480

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
