### PR TITLE
SHS-4982: Remove webp conversion from image styles

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -252,7 +252,6 @@ module:
   views_ui: 0
   webform: 0
   webform_ui: 0
-  webp: 0
   ds: 1
   extlink: 1
   menu_admin_per_menu: 1

--- a/config/default/image.style.hero_banner.yml
+++ b/config/default/image.style.hero_banner.yml
@@ -15,9 +15,3 @@ effects:
       width: 1600
       height: null
       upscale: false
-  fa107383-fe81-43e7-93bc-87e90232b434:
-    uuid: fa107383-fe81-43e7-93bc-87e90232b434
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_large.yml
+++ b/config/default/image.style.hero_large.yml
@@ -17,9 +17,3 @@ effects:
       width: 2000
       height: 500
       crop_type: focal_point
-  57fcc073-f6e3-4052-910a-fd34bdfc4453:
-    uuid: 57fcc073-f6e3-4052-910a-fd34bdfc4453
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_medium.yml
+++ b/config/default/image.style.hero_medium.yml
@@ -17,9 +17,3 @@ effects:
       width: 1300
       height: 400
       crop_type: focal_point
-  9d65c27c-1562-46e0-b873-f4dc63061624:
-    uuid: 9d65c27c-1562-46e0-b873-f4dc63061624
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_no_text_1200px_.yml
+++ b/config/default/image.style.hero_no_text_1200px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1200
       height: 300
       crop_type: focal_point
-  09deafd4-d3bf-4b9b-bd88-67cc03346433:
-    uuid: 09deafd4-d3bf-4b9b-bd88-67cc03346433
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_no_text_497px_sml.yml
+++ b/config/default/image.style.hero_no_text_497px_sml.yml
@@ -15,9 +15,3 @@ effects:
       width: 497
       height: 142
       crop_type: focal_point
-  0f23651a-d1ae-4b56-b92a-a30ea18581af:
-    uuid: 0f23651a-d1ae-4b56-b92a-a30ea18581af
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_no_text_657px_.yml
+++ b/config/default/image.style.hero_no_text_657px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 882
       height: 221
       crop_type: focal_point
-  5f51c51d-54e6-4d96-832d-fc23a9655286:
-    uuid: 5f51c51d-54e6-4d96-832d-fc23a9655286
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_no_text_657px_sml.yml
+++ b/config/default/image.style.hero_no_text_657px_sml.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 212
       crop_type: focal_point
-  1b50795a-6346-42dc-aff5-2f266142fad5:
-    uuid: 1b50795a-6346-42dc-aff5-2f266142fad5
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_no_text_881px_.yml
+++ b/config/default/image.style.hero_no_text_881px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1088
       height: 272
       crop_type: focal_point
-  fc25bacd-0213-415c-9b9c-b53506c9805b:
-    uuid: fc25bacd-0213-415c-9b9c-b53506c9805b
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_small.yml
+++ b/config/default/image.style.hero_small.yml
@@ -17,9 +17,3 @@ effects:
       width: 700
       height: 200
       crop_type: focal_point
-  2b51fb97-8f17-4915-8bd8-60c597ad3d85:
-    uuid: 2b51fb97-8f17-4915-8bd8-60c597ad3d85
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_with_text_1088px_.yml
+++ b/config/default/image.style.hero_with_text_1088px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1088
       height: 490
       crop_type: focal_point
-  a3fc3265-62ea-40f6-843b-dda35f716c5f:
-    uuid: a3fc3265-62ea-40f6-843b-dda35f716c5f
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_with_text_497px_.yml
+++ b/config/default/image.style.hero_with_text_497px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 497
       height: 390
       crop_type: focal_point
-  1ac41dad-0f2c-4ebc-8640-428a3f004842:
-    uuid: 1ac41dad-0f2c-4ebc-8640-428a3f004842
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_with_text_657px_.yml
+++ b/config/default/image.style.hero_with_text_657px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 390
       crop_type: focal_point
-  e71d79c8-01db-4fe8-a781-f0c52dc2fe82:
-    uuid: e71d79c8-01db-4fe8-a781-f0c52dc2fe82
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_with_text_881px_.yml
+++ b/config/default/image.style.hero_with_text_881px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 881
       height: 490
       crop_type: focal_point
-  d74a4179-672d-44bd-a2bf-b59bfda7b126:
-    uuid: d74a4179-672d-44bd-a2bf-b59bfda7b126
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hero_with_text_large.yml
+++ b/config/default/image.style.hero_with_text_large.yml
@@ -15,9 +15,3 @@ effects:
       width: 1200
       height: 490
       crop_type: focal_point
-  342787a2-5edc-4c38-93c1-b7e048f69039:
-    uuid: 342787a2-5edc-4c38-93c1-b7e048f69039
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_across_events_262px_.yml
+++ b/config/default/image.style.hp_3_across_events_262px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 262
       height: 182
       crop_type: focal_point
-  16e1b59d-f497-45a5-a247-98594de7f894:
-    uuid: 16e1b59d-f497-45a5-a247-98594de7f894
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_across_events_320px_.yml
+++ b/config/default/image.style.hp_3_across_events_320px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 320
       height: 222
       crop_type: focal_point
-  2917f88b-8676-4fea-a1ec-c22dcc5531c5:
-    uuid: 2917f88b-8676-4fea-a1ec-c22dcc5531c5
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_across_events_331px_.yml
+++ b/config/default/image.style.hp_3_across_events_331px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 331
       height: 230
       crop_type: focal_point
-  2f633c49-ae8c-44fc-a1aa-83ff534253d0:
-    uuid: 2f633c49-ae8c-44fc-a1aa-83ff534253d0
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_across_events_360px_.yml
+++ b/config/default/image.style.hp_3_across_events_360px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 368
       height: 256
       crop_type: focal_point
-  e767d7ec-a6f5-44e4-8045-7679131fbc4c:
-    uuid: e767d7ec-a6f5-44e4-8045-7679131fbc4c
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_across_events_496px_.yml
+++ b/config/default/image.style.hp_3_across_events_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 344
       crop_type: focal_point
-  ff5889d4-4600-40be-a382-533a25a9b699:
-    uuid: ff5889d4-4600-40be-a382-533a25a9b699
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_down_events_356px_.yml
+++ b/config/default/image.style.hp_3_down_events_356px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 356
       height: 247
       crop_type: focal_point
-  f6058ded-5ec8-4412-922e-3f5c95e9bd86:
-    uuid: f6058ded-5ec8-4412-922e-3f5c95e9bd86
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_down_events_442px_.yml
+++ b/config/default/image.style.hp_3_down_events_442px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 442
       height: 307
       crop_type: focal_point
-  2b890183-494a-4ee6-bb33-4a78ef522f16:
-    uuid: 2b890183-494a-4ee6-bb33-4a78ef522f16
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_down_events_488px_.yml
+++ b/config/default/image.style.hp_3_down_events_488px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 488
       height: 339
       crop_type: focal_point
-  107a75e7-ebff-4f57-83e9-6d0b3b0820b8:
-    uuid: 107a75e7-ebff-4f57-83e9-6d0b3b0820b8
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_down_events_492px_.yml
+++ b/config/default/image.style.hp_3_down_events_492px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 345
       crop_type: focal_point
-  16902606-b305-4184-af59-428ba4926410:
-    uuid: 16902606-b305-4184-af59-428ba4926410
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_3_down_events_688px_.yml
+++ b/config/default/image.style.hp_3_down_events_688px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 478
       crop_type: focal_point
-  47242e20-001f-4e07-903e-56868cfda759:
-    uuid: 47242e20-001f-4e07-903e-56868cfda759
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_4_across_236px_.yml
+++ b/config/default/image.style.hp_4_across_236px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 236
       height: 164
       crop_type: focal_point
-  59cee418-c1a7-4ad2-b2b1-d122ae8dcc14:
-    uuid: 59cee418-c1a7-4ad2-b2b1-d122ae8dcc14
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_4_across_264px_.yml
+++ b/config/default/image.style.hp_4_across_264px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 264
       height: 183
       crop_type: focal_point
-  ba1bfdb3-9902-4448-9f77-b803b503eb9b:
-    uuid: ba1bfdb3-9902-4448-9f77-b803b503eb9b
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_4_across_320px_.yml
+++ b/config/default/image.style.hp_4_across_320px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 320
       height: 222
       crop_type: focal_point
-  ef1f809d-81bb-4a61-a5af-31ec4314cfb4:
-    uuid: ef1f809d-81bb-4a61-a5af-31ec4314cfb4
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hp_4_across_496px_.yml
+++ b/config/default/image.style.hp_4_across_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 344
       crop_type: focal_point
-  e318cf93-3a52-44b4-883a-37c8edc4b22e:
-    uuid: e318cf93-3a52-44b4-883a-37c8edc4b22e
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_large_rectangle_720x500.yml
+++ b/config/default/image.style.hs_large_rectangle_720x500.yml
@@ -15,9 +15,3 @@ effects:
       width: 600
       height: 415
       crop_type: focal_point
-  ed4826b0-cf0e-4946-aca4-596dd2265ed9:
-    uuid: ed4826b0-cf0e-4946-aca4-596dd2265ed9
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_large_scaled_480px.yml
+++ b/config/default/image.style.hs_large_scaled_480px.yml
@@ -13,9 +13,3 @@ effects:
       width: 480
       height: null
       upscale: true
-  e4d80263-d039-42d3-a303-da42c2158abb:
-    uuid: e4d80263-d039-42d3-a303-da42c2158abb
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_large_square_480x480.yml
+++ b/config/default/image.style.hs_large_square_480x480.yml
@@ -15,9 +15,3 @@ effects:
       width: 480
       height: 480
       crop_type: focal_point
-  3fccc108-9750-413a-b170-11e5783dd9a9:
-    uuid: 3fccc108-9750-413a-b170-11e5783dd9a9
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_medium_rectangle_360x250.yml
+++ b/config/default/image.style.hs_medium_rectangle_360x250.yml
@@ -15,9 +15,3 @@ effects:
       width: 360
       height: 250
       crop_type: focal_point
-  4eb5c9c1-04da-4f4c-b344-060edc23cb22:
-    uuid: 4eb5c9c1-04da-4f4c-b344-060edc23cb22
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_medium_scaled_360px.yml
+++ b/config/default/image.style.hs_medium_scaled_360px.yml
@@ -13,9 +13,3 @@ effects:
       width: 360
       height: null
       upscale: true
-  78e7b830-3aa0-4c54-8677-b5a1a6ccdfbc:
-    uuid: 78e7b830-3aa0-4c54-8677-b5a1a6ccdfbc
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_medium_square_360x360.yml
+++ b/config/default/image.style.hs_medium_square_360x360.yml
@@ -15,9 +15,3 @@ effects:
       width: 360
       height: 360
       crop_type: focal_point
-  f95e6198-dea8-409c-af8d-6ab9781f6a42:
-    uuid: f95e6198-dea8-409c-af8d-6ab9781f6a42
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_slideshow_large_2000x1500.yml
+++ b/config/default/image.style.hs_slideshow_large_2000x1500.yml
@@ -15,9 +15,3 @@ effects:
       width: 2000
       height: 1500
       crop_type: focal_point
-  e587ba64-bc26-4069-81e0-2abef97327bb:
-    uuid: e587ba64-bc26-4069-81e0-2abef97327bb
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_slideshow_medium_1500x1125.yml
+++ b/config/default/image.style.hs_slideshow_medium_1500x1125.yml
@@ -15,9 +15,3 @@ effects:
       width: 1500
       height: 1125
       crop_type: focal_point
-  3aebc0a2-7feb-40a2-9959-f3aaea65422d:
-    uuid: 3aebc0a2-7feb-40a2-9959-f3aaea65422d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_slideshow_small_1000x750.yml
+++ b/config/default/image.style.hs_slideshow_small_1000x750.yml
@@ -15,9 +15,3 @@ effects:
       width: 1000
       height: 750
       crop_type: focal_point
-  4db5008d-d1c3-4b45-a683-6b74b6b37a36:
-    uuid: 4db5008d-d1c3-4b45-a683-6b74b6b37a36
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_slideshow_xsmall_800x600.yml
+++ b/config/default/image.style.hs_slideshow_xsmall_800x600.yml
@@ -15,9 +15,3 @@ effects:
       width: 800
       height: 600
       crop_type: focal_point
-  faa2c633-58a6-419b-9876-9b6fa35af5f9:
-    uuid: faa2c633-58a6-419b-9876-9b6fa35af5f9
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_small_scaled_200px.yml
+++ b/config/default/image.style.hs_small_scaled_200px.yml
@@ -13,9 +13,3 @@ effects:
       width: 200
       height: null
       upscale: true
-  784ec80f-42aa-4dff-879e-6094156b9e41:
-    uuid: 784ec80f-42aa-4dff-879e-6094156b9e41
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_small_square_200x200.yml
+++ b/config/default/image.style.hs_small_square_200x200.yml
@@ -15,9 +15,3 @@ effects:
       width: 200
       height: 200
       crop_type: focal_point
-  2840e934-cfad-4c5f-9a17-972f84b1a534:
-    uuid: 2840e934-cfad-4c5f-9a17-972f84b1a534
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_spotlight_large_portrait_600x720.yml
+++ b/config/default/image.style.hs_spotlight_large_portrait_600x720.yml
@@ -15,9 +15,3 @@ effects:
       width: 600
       height: 720
       crop_type: focal_point
-  970a1af8-adc6-496b-bf99-b72e669dbc00:
-    uuid: 970a1af8-adc6-496b-bf99-b72e669dbc00
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_spotlight_small_portrait_300x360.yml
+++ b/config/default/image.style.hs_spotlight_small_portrait_300x360.yml
@@ -15,9 +15,3 @@ effects:
       width: 300
       height: 360
       crop_type: focal_point
-  899ac80f-b14e-44c9-bb75-1347f6bdc8c5:
-    uuid: 899ac80f-b14e-44c9-bb75-1347f6bdc8c5
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_vertical_rectangle_360x430.yml
+++ b/config/default/image.style.hs_vertical_rectangle_360x430.yml
@@ -15,9 +15,3 @@ effects:
       width: 360
       height: 430
       crop_type: focal_point
-  96c7df76-7b38-46b6-a795-7a0a204e780e:
-    uuid: 96c7df76-7b38-46b6-a795-7a0a204e780e
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_xl_scaled_700px.yml
+++ b/config/default/image.style.hs_xl_scaled_700px.yml
@@ -13,9 +13,3 @@ effects:
       width: 700
       height: null
       upscale: true
-  250e58a8-21a9-47f0-8eee-907f32a785ad:
-    uuid: 250e58a8-21a9-47f0-8eee-907f32a785ad
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.hs_xlarge_square_700x700.yml
+++ b/config/default/image.style.hs_xlarge_square_700x700.yml
@@ -15,9 +15,3 @@ effects:
       width: 700
       height: 700
       crop_type: focal_point
-  b54a81e2-b781-4b15-b887-e938ad97c2f4:
-    uuid: b54a81e2-b781-4b15-b887-e938ad97c2f4
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.lazy_loading.yml
+++ b/config/default/image.style.lazy_loading.yml
@@ -13,9 +13,3 @@ effects:
       width: 25
       height: 25
       upscale: false
-  c2f47bfc-2984-4fdc-858c-9f30f3cd5f87:
-    uuid: c2f47bfc-2984-4fdc-858c-9f30f3cd5f87
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.linkit_result_thumbnail.yml
+++ b/config/default/image.style.linkit_result_thumbnail.yml
@@ -15,9 +15,3 @@ effects:
       width: 50
       height: 50
       anchor: center-center
-  37ef2550-640f-4be8-8e47-02e59a1ca1a7:
-    uuid: 37ef2550-640f-4be8-8e47-02e59a1ca1a7
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.media_library.yml
+++ b/config/default/image.style.media_library.yml
@@ -18,9 +18,3 @@ effects:
       width: 220
       height: 220
       upscale: false
-  892db931-8d68-49be-9dc9-c05bd4dfd154:
-    uuid: 892db931-8d68-49be-9dc9-c05bd4dfd154
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.medium.yml
+++ b/config/default/image.style.medium.yml
@@ -15,9 +15,3 @@ effects:
       width: 220
       height: 220
       upscale: false
-  16dd1392-2e44-4077-83d7-1cbe7981645e:
-    uuid: 16dd1392-2e44-4077-83d7-1cbe7981645e
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.past_events_442px_.yml
+++ b/config/default/image.style.past_events_442px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 442
       height: 307
       crop_type: focal_point
-  9f5f1b50-1af0-461e-9cca-691f0294faaf:
-    uuid: 9f5f1b50-1af0-461e-9cca-691f0294faaf
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.past_events_488px_.yml
+++ b/config/default/image.style.past_events_488px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 488
       height: 339
       crop_type: focal_point
-  3de00872-6abf-47e8-8598-33617fa04907:
-    uuid: 3de00872-6abf-47e8-8598-33617fa04907
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.past_events_496px_.yml
+++ b/config/default/image.style.past_events_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 356
       height: 247
       crop_type: focal_point
-  96f23038-18ad-4744-a29b-672c6d5f5f9a:
-    uuid: 96f23038-18ad-4744-a29b-672c6d5f5f9a
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.past_events_496px_sm.yml
+++ b/config/default/image.style.past_events_496px_sm.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 344
       crop_type: focal_point
-  dea66127-bd75-466a-9f6c-5d4f5231fb91:
-    uuid: dea66127-bd75-466a-9f6c-5d4f5231fb91
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.past_events_688px_.yml
+++ b/config/default/image.style.past_events_688px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 478
       crop_type: focal_point
-  69528a20-39a9-4ac5-98a0-e4b8ddf18cf1:
-    uuid: 69528a20-39a9-4ac5-98a0-e4b8ddf18cf1
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_list_356px_.yml
+++ b/config/default/image.style.people_grid_list_356px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 356
       height: 356
       crop_type: focal_point
-  8cd2f412-8cfa-4a50-9cd4-e85bae36293e:
-    uuid: 8cd2f412-8cfa-4a50-9cd4-e85bae36293e
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_list_442px_.yml
+++ b/config/default/image.style.people_grid_list_442px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 442
       height: 442
       crop_type: focal_point
-  ff5148b7-de54-4ae1-ae40-700300fd0580:
-    uuid: ff5148b7-de54-4ae1-ae40-700300fd0580
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_list_488px_.yml
+++ b/config/default/image.style.people_grid_list_488px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 488
       height: 488
       crop_type: focal_point
-  e392461d-8284-4e12-b996-36e9fecf6a0a:
-    uuid: e392461d-8284-4e12-b996-36e9fecf6a0a
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_list_496px_.yml
+++ b/config/default/image.style.people_grid_list_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 496
       crop_type: focal_point
-  845ac4fe-1f5d-43e3-821c-2e66cec70d0d:
-    uuid: 845ac4fe-1f5d-43e3-821c-2e66cec70d0d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_list_688px_.yml
+++ b/config/default/image.style.people_grid_list_688px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 688
       crop_type: focal_point
-  fda43292-ba68-46ae-9d2d-7c051901c33d:
-    uuid: fda43292-ba68-46ae-9d2d-7c051901c33d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_square_262px_.yml
+++ b/config/default/image.style.people_grid_square_262px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 262
       height: 262
       crop_type: focal_point
-  f31d33e2-5663-453d-86f8-7077c29104a5:
-    uuid: f31d33e2-5663-453d-86f8-7077c29104a5
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_square_320px_.yml
+++ b/config/default/image.style.people_grid_square_320px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 320
       height: 320
       crop_type: focal_point
-  865c7d8b-941d-499a-aedc-1bbe81120843:
-    uuid: 865c7d8b-941d-499a-aedc-1bbe81120843
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_square_331px_.yml
+++ b/config/default/image.style.people_grid_square_331px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 331
       height: 331
       crop_type: focal_point
-  6066fadf-5ebc-47b3-a599-c218932585dc:
-    uuid: 6066fadf-5ebc-47b3-a599-c218932585dc
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_square_368px_.yml
+++ b/config/default/image.style.people_grid_square_368px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 368
       height: 368
       crop_type: focal_point
-  9503b5ba-0661-4f14-a22c-26b2659e4296:
-    uuid: 9503b5ba-0661-4f14-a22c-26b2659e4296
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.people_grid_square_496px_.yml
+++ b/config/default/image.style.people_grid_square_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 496
       crop_type: focal_point
-  34c138f3-015f-42eb-af2f-6b543069fcd9:
-    uuid: 34c138f3-015f-42eb-af2f-6b543069fcd9
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_grid_272px_.yml
+++ b/config/default/image.style.photo_album_grid_272px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 272
       height: 190
       crop_type: focal_point
-  b70766f8-cdb1-4b1b-b270-d1ec8a6b4fe9:
-    uuid: b70766f8-cdb1-4b1b-b270-d1ec8a6b4fe9
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_grid_339px_.yml
+++ b/config/default/image.style.photo_album_grid_339px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 339
       height: 235
       crop_type: focal_point
-  fb9eb989-73e8-497c-bba9-4f1d8bcf151b:
-    uuid: fb9eb989-73e8-497c-bba9-4f1d8bcf151b
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_grid_360px_.yml
+++ b/config/default/image.style.photo_album_grid_360px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 360
       height: 250
       crop_type: focal_point
-  a39f6301-7ebe-444b-bebc-efb15b96b4ac:
-    uuid: a39f6301-7ebe-444b-bebc-efb15b96b4ac
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_slideshow_1088px_.yml
+++ b/config/default/image.style.photo_album_slideshow_1088px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1088
       height: 816
       crop_type: focal_point
-  fc9c52a5-bde0-49bd-bbe2-40f07f333481:
-    uuid: fc9c52a5-bde0-49bd-bbe2-40f07f333481
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_slideshow_1200px_.yml
+++ b/config/default/image.style.photo_album_slideshow_1200px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1200
       height: 900
       crop_type: focal_point
-  fab99ece-0171-49b5-841f-3404f2898bce:
-    uuid: fab99ece-0171-49b5-841f-3404f2898bce
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_slideshow_496px_.yml
+++ b/config/default/image.style.photo_album_slideshow_496px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 496
       height: 372
       crop_type: focal_point
-  d631add1-b681-4475-8981-d371d67de9ce:
-    uuid: d631add1-b681-4475-8981-d371d67de9ce
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_slideshow_688px_.yml
+++ b/config/default/image.style.photo_album_slideshow_688px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 516
       crop_type: focal_point
-  1af39af9-d947-41bb-9965-831ac527a900:
-    uuid: 1af39af9-d947-41bb-9965-831ac527a900
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.photo_album_slideshow_880px_.yml
+++ b/config/default/image.style.photo_album_slideshow_880px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 880
       height: 660
       crop_type: focal_point
-  28d00b97-ff6f-4d27-b82d-2a8c0f0c7863:
-    uuid: 28d00b97-ff6f-4d27-b82d-2a8c0f0c7863
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_horizontal_356px_.yml
+++ b/config/default/image.style.postcard_horizontal_356px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 356
       height: 356
       crop_type: focal_point
-  13e48b25-dff4-4afa-85f2-4ec3fb7afa3f:
-    uuid: 13e48b25-dff4-4afa-85f2-4ec3fb7afa3f
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_horizontal_442px_.yml
+++ b/config/default/image.style.postcard_horizontal_442px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 442
       height: 442
       crop_type: focal_point
-  9fe6fa80-c73f-4425-ab54-583fa149043a:
-    uuid: 9fe6fa80-c73f-4425-ab54-583fa149043a
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_horizontal_488px_.yml
+++ b/config/default/image.style.postcard_horizontal_488px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 488
       height: 488
       crop_type: focal_point
-  d64a3ecf-9c1a-4b21-9634-e378fe1dc387:
-    uuid: d64a3ecf-9c1a-4b21-9634-e378fe1dc387
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_horizontal_497px_.yml
+++ b/config/default/image.style.postcard_horizontal_497px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 497
       height: 497
       crop_type: focal_point
-  17dc9fe2-df7d-43c2-b090-5677cc335f8d:
-    uuid: 17dc9fe2-df7d-43c2-b090-5677cc335f8d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_horizontal_688px_.yml
+++ b/config/default/image.style.postcard_horizontal_688px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 688
       crop_type: focal_point
-  200ad840-883d-4a77-89e8-f180bfd3ca34:
-    uuid: 200ad840-883d-4a77-89e8-f180bfd3ca34
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_1088px_.yml
+++ b/config/default/image.style.postcard_vertical_1088px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1088
       height: 756
       crop_type: focal_point
-  eb7ac721-5359-41da-b2cd-86099675ec50:
-    uuid: eb7ac721-5359-41da-b2cd-86099675ec50
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_1200px_.yml
+++ b/config/default/image.style.postcard_vertical_1200px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1200
       height: 833
       crop_type: focal_point
-  ad413258-a2ac-4a07-ae2d-b680d6707728:
-    uuid: ad413258-a2ac-4a07-ae2d-b680d6707728
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_497px_.yml
+++ b/config/default/image.style.postcard_vertical_497px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 497
       height: 345
       crop_type: focal_point
-  b14ec404-352f-4a8f-b60e-49171d413fb0:
-    uuid: b14ec404-352f-4a8f-b60e-49171d413fb0
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_657px_.yml
+++ b/config/default/image.style.postcard_vertical_657px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 688
       height: 478
       crop_type: focal_point
-  2bbe7ac9-f025-41b3-a30a-51ae1f2c2a05:
-    uuid: 2bbe7ac9-f025-41b3-a30a-51ae1f2c2a05
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_881px_.yml
+++ b/config/default/image.style.postcard_vertical_881px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 881
       height: 612
       crop_type: focal_point
-  2a2bcce0-c079-4006-903b-8905828c53a4:
-    uuid: 2a2bcce0-c079-4006-903b-8905828c53a4
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_linked_1057px_.yml
+++ b/config/default/image.style.postcard_vertical_linked_1057px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1057
       height: 734
       crop_type: focal_point
-  3bb381b0-8b2a-43a5-bb7a-a02c7af909da:
-    uuid: 3bb381b0-8b2a-43a5-bb7a-a02c7af909da
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_linked_1169px_.yml
+++ b/config/default/image.style.postcard_vertical_linked_1169px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 1169
       height: 812
       crop_type: focal_point
-  45fb06ce-c370-4136-b3c3-dafbce21d653:
-    uuid: 45fb06ce-c370-4136-b3c3-dafbce21d653
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_linked_465px_.yml
+++ b/config/default/image.style.postcard_vertical_linked_465px_.yml
@@ -4,10 +4,4 @@ status: true
 dependencies: {  }
 name: postcard_vertical_linked_465px_
 label: 'Postcard Vertical Linked (465px)'
-effects:
-  f3b3c6ff-e785-4878-a17c-319095ce280b:
-    uuid: f3b3c6ff-e785-4878-a17c-319095ce280b
-    id: image_convert
-    weight: 1
-    data:
-      extension: webp
+effects: {  }

--- a/config/default/image.style.postcard_vertical_linked_658px_.yml
+++ b/config/default/image.style.postcard_vertical_linked_658px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 658
       height: 457
       crop_type: focal_point
-  05122f5a-2a77-458c-9bcd-20dd9018c089:
-    uuid: 05122f5a-2a77-458c-9bcd-20dd9018c089
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.postcard_vertical_linked_850px_.yml
+++ b/config/default/image.style.postcard_vertical_linked_850px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 850
       height: 590
       crop_type: focal_point
-  bb8fd42e-90cb-4f68-9963-18a531e3aa04:
-    uuid: bb8fd42e-90cb-4f68-9963-18a531e3aa04
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_doc_356px_.yml
+++ b/config/default/image.style.publications_doc_356px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 356
       height: null
       upscale: false
-  ec4dbc99-bc83-407f-b003-e75028b12216:
-    uuid: ec4dbc99-bc83-407f-b003-e75028b12216
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_doc_442px_.yml
+++ b/config/default/image.style.publications_doc_442px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 442
       height: null
       upscale: false
-  63974a5d-88fb-4871-a55f-4bd89ce4728f:
-    uuid: 63974a5d-88fb-4871-a55f-4bd89ce4728f
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_doc_488px_.yml
+++ b/config/default/image.style.publications_doc_488px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 488
       height: null
       upscale: false
-  516c0dd6-94cc-4521-b8a0-adca55d9b225:
-    uuid: 516c0dd6-94cc-4521-b8a0-adca55d9b225
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_doc_496px_.yml
+++ b/config/default/image.style.publications_doc_496px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 496
       height: null
       upscale: false
-  d401bda8-9b68-46c8-8630-8206d7c31219:
-    uuid: d401bda8-9b68-46c8-8630-8206d7c31219
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_doc_688px_.yml
+++ b/config/default/image.style.publications_doc_688px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 688
       height: null
       upscale: false
-  03d57fe4-cc48-4bf6-83ee-60f56da12816:
-    uuid: 03d57fe4-cc48-4bf6-83ee-60f56da12816
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_grid_236px_.yml
+++ b/config/default/image.style.publications_grid_236px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 236
       height: null
       upscale: false
-  91904fd7-5495-4d82-96d9-f126e69f3835:
-    uuid: 91904fd7-5495-4d82-96d9-f126e69f3835
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_grid_264px_.yml
+++ b/config/default/image.style.publications_grid_264px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 264
       height: null
       upscale: false
-  e3748ce2-ac80-4761-8060-4b85059399c6:
-    uuid: e3748ce2-ac80-4761-8060-4b85059399c6
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_grid_320px_.yml
+++ b/config/default/image.style.publications_grid_320px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 320
       height: null
       upscale: false
-  9415c1ae-8498-4da6-9e64-6313ba2b80d1:
-    uuid: 9415c1ae-8498-4da6-9e64-6313ba2b80d1
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.publications_grid_496px_.yml
+++ b/config/default/image.style.publications_grid_496px_.yml
@@ -13,9 +13,3 @@ effects:
       width: 496
       height: null
       upscale: false
-  7edcf179-7497-47cd-8263-9ea6b5349994:
-    uuid: 7edcf179-7497-47cd-8263-9ea6b5349994
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_default_576_.yml
+++ b/config/default/image.style.responsive_default_576_.yml
@@ -13,9 +13,3 @@ effects:
       width: 576
       height: null
       upscale: false
-  13405f1e-7bf1-4c0a-a75a-52ee54a172aa:
-    uuid: 13405f1e-7bf1-4c0a-a75a-52ee54a172aa
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_large.yml
+++ b/config/default/image.style.responsive_large.yml
@@ -15,9 +15,3 @@ effects:
       width: 1200
       height: null
       upscale: false
-  974fdabc-d762-434d-ac6a-7961d2ae461a:
-    uuid: 974fdabc-d762-434d-ac6a-7961d2ae461a
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_medium.yml
+++ b/config/default/image.style.responsive_medium.yml
@@ -15,9 +15,3 @@ effects:
       width: 992
       height: null
       upscale: false
-  5c3a1d55-0d59-411d-8244-e75938af9c69:
-    uuid: 5c3a1d55-0d59-411d-8244-e75938af9c69
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_scaled_default_576_.yml
+++ b/config/default/image.style.responsive_scaled_default_576_.yml
@@ -13,9 +13,3 @@ effects:
       width: 576
       height: null
       upscale: true
-  7c2c145a-bf38-47bd-b35f-eb610ac25d75:
-    uuid: 7c2c145a-bf38-47bd-b35f-eb610ac25d75
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_scaled_large_1200_.yml
+++ b/config/default/image.style.responsive_scaled_large_1200_.yml
@@ -13,9 +13,3 @@ effects:
       width: 1200
       height: null
       upscale: true
-  81f504a2-cfc2-4c92-a72d-4b74f911454d:
-    uuid: 81f504a2-cfc2-4c92-a72d-4b74f911454d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_scaled_medium_992_.yml
+++ b/config/default/image.style.responsive_scaled_medium_992_.yml
@@ -13,9 +13,3 @@ effects:
       width: 992
       height: null
       upscale: true
-  f5eb3b5f-8132-46b8-8086-e933e606bc16:
-    uuid: f5eb3b5f-8132-46b8-8086-e933e606bc16
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_scaled_small_768_.yml
+++ b/config/default/image.style.responsive_scaled_small_768_.yml
@@ -13,9 +13,3 @@ effects:
       width: 768
       height: null
       upscale: true
-  dcf4f071-bdc3-4707-90b6-a9164142f962:
-    uuid: dcf4f071-bdc3-4707-90b6-a9164142f962
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.responsive_small.yml
+++ b/config/default/image.style.responsive_small.yml
@@ -15,9 +15,3 @@ effects:
       width: 768
       height: null
       upscale: false
-  7e895454-3b1b-45d2-8fac-0d8e48a76fa0:
-    uuid: 7e895454-3b1b-45d2-8fac-0d8e48a76fa0
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_332px_.yml
+++ b/config/default/image.style.spotlight_332px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 332
       height: 398
       crop_type: focal_point
-  1e8508fc-c73a-4e93-b917-aaf3b3f893be:
-    uuid: 1e8508fc-c73a-4e93-b917-aaf3b3f893be
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_425px_.yml
+++ b/config/default/image.style.spotlight_425px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 425
       height: 510
       crop_type: focal_point
-  a8f3422f-bc9a-4f37-9369-cd9c0a81068c:
-    uuid: a8f3422f-bc9a-4f37-9369-cd9c0a81068c
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_432px_.yml
+++ b/config/default/image.style.spotlight_432px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 432
       height: 518
       crop_type: focal_point
-  dc479d32-27b1-47ff-a5c8-5d3039058e01:
-    uuid: dc479d32-27b1-47ff-a5c8-5d3039058e01
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_475px_.yml
+++ b/config/default/image.style.spotlight_475px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 475
       height: 570
       crop_type: focal_point
-  4e049203-ec25-4ed8-baba-e41d61e3b013:
-    uuid: 4e049203-ec25-4ed8-baba-e41d61e3b013
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_624px_.yml
+++ b/config/default/image.style.spotlight_624px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 624
       height: 749
       crop_type: focal_point
-  ed9e4ab4-1cad-41df-9e03-e28c8a17e82d:
-    uuid: ed9e4ab4-1cad-41df-9e03-e28c8a17e82d
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_short_331px_.yml
+++ b/config/default/image.style.spotlight_short_331px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 331
       height: 230
       crop_type: focal_point
-  7a8583ce-6a5e-473a-853f-7ce1d0697dc3:
-    uuid: 7a8583ce-6a5e-473a-853f-7ce1d0697dc3
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_short_425px_.yml
+++ b/config/default/image.style.spotlight_short_425px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 425
       height: 295
       crop_type: focal_point
-  a04c8b0f-bc17-497d-8a8b-d57db3baa767:
-    uuid: a04c8b0f-bc17-497d-8a8b-d57db3baa767
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_short_432px_.yml
+++ b/config/default/image.style.spotlight_short_432px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 432
       height: 300
       crop_type: focal_point
-  5837daf3-6dac-432e-b08d-306b3910e647:
-    uuid: 5837daf3-6dac-432e-b08d-306b3910e647
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_short_475px_.yml
+++ b/config/default/image.style.spotlight_short_475px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 475
       height: 330
       crop_type: focal_point
-  af8b4771-84d3-403c-a96d-cac55ed690cb:
-    uuid: af8b4771-84d3-403c-a96d-cac55ed690cb
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.spotlight_short_624px_.yml
+++ b/config/default/image.style.spotlight_short_624px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 624
       height: 433
       crop_type: focal_point
-  5907796a-2b16-41d7-bb40-ab36aedcd100:
-    uuid: 5907796a-2b16-41d7-bb40-ab36aedcd100
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.testimonial_100px_.yml
+++ b/config/default/image.style.testimonial_100px_.yml
@@ -15,9 +15,3 @@ effects:
       width: 100
       height: 100
       crop_type: focal_point
-  d7811733-1227-4d57-9d65-9991130f6440:
-    uuid: d7811733-1227-4d57-9d65-9991130f6440
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/image.style.thumbnail.yml
+++ b/config/default/image.style.thumbnail.yml
@@ -15,9 +15,3 @@ effects:
       width: 100
       height: null
       upscale: true
-  cd3540c7-ac74-4d45-825c-1d4307ef639a:
-    uuid: cd3540c7-ac74-4d45-825c-1d4307ef639a
-    id: image_convert
-    weight: 2
-    data:
-      extension: webp

--- a/config/default/imagemagick.settings.yml
+++ b/config/default/imagemagick.settings.yml
@@ -27,8 +27,7 @@ image_formats:
     enabled: false
   WEBP:
     mime_type: image/webp
-    weight: 11
-    enabled: true
+    enabled: false
   TIFF:
     mime_type: image/tiff
     enabled: false

--- a/config/default/webp.settings.yml
+++ b/config/default/webp.settings.yml
@@ -1,3 +1,0 @@
-_core:
-  default_config_hash: 0ube66wBYymHixNiMD-uyY8Tjo8alYV3NII6dv5iBJ8
-quality: 80

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -177,3 +177,10 @@ function su_humsci_profile_update_9004() {
       ->save();
   }
 }
+
+/**
+ * Disable webp module.
+ */
+function su_humsci_profile_update_9405() {
+  \Drupal::service('module_installer')->uninstall(['webp']);
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Remove webp conversion from all image styles

## Need Review By (Date)
- ASAP

## Urgency
- High

## Steps to Test
1. Confirm that the conversion to webp is disabled in all image styles (choose some random ones to test this)
2. Confirm that elements that use a responsive image (e.g. Hero slides) don't have any webp image as an option for the `<picture>` element

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
