### PR TITLE
SHS-5013: Add Paragraph Browser to Collection paragraph

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
@@ -9,30 +9,33 @@ dependencies:
     - field.field.paragraph.hs_collection.field_raised_cards
     - paragraphs.paragraphs_type.hs_collection
   module:
-    - paragraphs
+    - paragraphs_browser
 id: paragraph.hs_collection.default
 targetEntityType: paragraph
 bundle: hs_collection
 mode: default
 content:
   field_hs_collection_items:
-    type: paragraphs
+    type: paragraphs_browser
     weight: 3
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
+      title: Component
+      title_plural: Components
       edit_mode: closed
       closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
-      add_mode: dropdown
+      autocollapse: all
+      closed_mode_threshold: '0'
+      add_mode: paragraphs_browser
       form_display_mode: default
       default_paragraph_type: _none
       features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
         duplicate: duplicate
+        collapse_edit_all: collapse_edit_all
+        add_above: 0
+      paragraphs_browser: content
+      modal_width: 80%
+      modal_height: auto
     third_party_settings: {  }
   field_hs_collection_per_row:
     type: options_select

--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -142,3 +142,16 @@ function hs_admin_preprocess_page(&$variables) {
     $variables['#attached']['library'][] = 'su_humsci_gin_admin/login_portal';
   }
 }
+
+/**
+ * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
+ */
+function hs_admin_field_widget_complete_paragraphs_browser_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+  $max_delta = $field_widget_complete_form['widget']['#max_delta'] ?? -1;
+  for ($delta = 0; $delta <= $max_delta; $delta++) {
+    if (isset($field_widget_complete_form['widget'][$delta]['top']['actions']['dropdown_actions']['duplicate_button'])) {
+      $duplicate_button = &$field_widget_complete_form['widget'][$delta]['top']['actions']['dropdown_actions']['duplicate_button'];
+      $duplicate_button['#ajax']['callback'] = 'su_humsci_profile_paragraphs_duplicate_callback';
+    }
+  }
+}

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -67,8 +67,8 @@ class FlexiblePageCest {
     $I->fillField('pb_modal_text', 'Collection');
     $I->click('field_hs_page_components_hs_collection_add_more');
     $I->waitForText('Items Per Row');
-    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more"]');
-    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more"]');
+    $I->scrollTo('[id^="edit-field-hs-page-components-0-subform-field-hs-collection-items-add-more"]');
+    $I->click('[id^="edit-field-hs-page-components-0-subform-field-hs-collection-items-add-more"]');
     $I->waitForText('Browse');
     $I->fillField('pb_modal_text', 'Postcard');
     $I->click('field_hs_collection_items_hs_postcard_add_more');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -480,6 +480,7 @@ class FlexiblePageCest {
 
     $I->amOnPage('/node/add/hs_basic_page');
     $I->fillField('Title', 'Demo Basic Page');
+    // Add a Collection component to the page.
     $I->click('#edit-field-hs-page-components-add-more-browse');
     $I->waitForText('Browse');
     $I->fillField('pb_modal_text', 'Collection');
@@ -488,19 +489,26 @@ class FlexiblePageCest {
     $I->canSeeNumberOfElements('[data-drupal-selector="edit-field-hs-page-components-1-subform-field-hs-collection-per-row"] option', 4);
     $I->selectOption('Items Per Row', 2);
     $I->canSeeOptionIsSelected('Background Color', '- None -');
-    $I->click('.dropbutton__toggle');
-    $I->click('.add-more-button-hs-text-area');
-    $I->scrollTo('.dropbutton__toggle');
+    // Add a Text Area component to the Collection.
+    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->waitForText('Browse');
+    $I->fillField('pb_modal_text', 'Text Area');
+    $I->click('field_hs_collection_items_hs_text_area_add_more');
+    $I->waitForText('Items Per Row');
     $I->waitForText('Text format');
     $I->fillField('.ck-editor__editable_inline:nth-child(1)', 'Foo Bar Baz');
-    $I->scrollTo('.dropbutton__toggle');
-    $I->click('.dropbutton__toggle');
-    $I->click('.add-more-button-hs-postcard');
-    $I->scrollTo('.dropbutton__toggle');
+    // Add a Postcard to the Collection.
+    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->waitForText('Browse');
+    $I->fillField('pb_modal_text', 'Postcard');
+    $I->click('field_hs_collection_items_hs_postcard_add_more');
     $I->waitForText('No media items are selected.');
     $I->scrollTo('.field--name-field-hs-postcard-body');
     $I->fillField('field_hs_page_components[1][subform][field_hs_collection_items][1][subform][field_hs_postcard_title][0][value]', 'Demo card title');
     $I->fillField('.ck-editor__editable_inline:nth-child(1)', 'Bar Foo Baz');
+    // Save the node and verify the components are visible.
     $I->click('Save');
     $I->canSee('Demo Basic Page', 'h1');
     $I->canSee('Foo Bar Baz', '.item-per-row--2');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -67,10 +67,14 @@ class FlexiblePageCest {
     $I->fillField('pb_modal_text', 'Collection');
     $I->click('field_hs_page_components_hs_collection_add_more');
     $I->waitForText('Items Per Row');
-    $I->click('.dropbutton__toggle');
-    $I->scrollTo('.add-more-button-hs-postcard');
-    $I->click('Add Postcard');
+
+    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->waitForText('Browse');
+    $I->fillField('pb_modal_text', 'Postcard');
+    $I->click('field_hs_collection_items_hs_postcard_add_more');
     $I->waitForText('No media items are selected.');
+
     $card_title = $this->faker->words(3, TRUE);
     $I->fillField('field_hs_page_components[0][subform][field_hs_collection_items][0][subform][field_hs_postcard_title][0][value]', $card_title);
     $I->cantSeeElement('.hs-duplicated');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -67,9 +67,8 @@ class FlexiblePageCest {
     $I->fillField('pb_modal_text', 'Collection');
     $I->click('field_hs_page_components_hs_collection_add_more');
     $I->waitForText('Items Per Row');
-
-    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
-    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more-browse"]');
+    $I->scrollTo('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more"]');
+    $I->click('[id^="edit-field-hs-page-components-1-subform-field-hs-collection-items-add-more"]');
     $I->waitForText('Browse');
     $I->fillField('pb_modal_text', 'Postcard');
     $I->click('field_hs_collection_items_hs_postcard_add_more');


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Configures the paragraph reference field within the Collection paragraph so it uses Paragraph Browser instead of the standard dropdown.

## Need Review By (Date)
8/18

## Urgency
medium

## Steps to Test
1. After a standard site setup go to a Flexible Page and add a collection
2. Verify there is an "Add Component" button that, when clicked, triggers a modal with paragraph previews and allows content editors a more visual experience when authoring Collections

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
