### PR TITLE
HSD8-1499-1501: Fixed null role dependencies.

### DIFF
--- a/config/default/user.role.intranet_viewer.yml
+++ b/config/default/user.role.intranet_viewer.yml
@@ -1,7 +1,7 @@
 uuid: c3d0e7ba-c576-4abb-a3e1-5d2db98c0892
 langcode: en
 status: true
-dependencies: null
+dependencies: {  }
 id: intranet_viewer
 label: 'Intranet Viewer'
 weight: -6

--- a/config/default/user.role.stanford_faculty.yml
+++ b/config/default/user.role.stanford_faculty.yml
@@ -1,7 +1,7 @@
 uuid: 2032bcd6-6126-490e-919b-e36722d00ddb
 langcode: en
 status: true
-dependencies: null
+dependencies: {  }
 _core:
   default_config_hash: 5Vm5wwYvL9cixzOqX2aUdfHLoZhPTJr0oHrLgP-vrV0
 id: stanford_faculty

--- a/config/default/user.role.stanford_staff.yml
+++ b/config/default/user.role.stanford_staff.yml
@@ -1,7 +1,7 @@
 uuid: 110e86b4-151a-4724-8611-c6112d0378c0
 langcode: en
 status: true
-dependencies: null
+dependencies: {  }
 _core:
   default_config_hash: C2n7EnkHLysQyQE7c3q09n0J3HDC5lK94cvVPBzKWA4
 id: stanford_staff

--- a/config/default/user.role.stanford_student.yml
+++ b/config/default/user.role.stanford_student.yml
@@ -1,7 +1,7 @@
 uuid: d68986fc-b911-4619-bffb-06937e66dd47
 langcode: en
 status: true
-dependencies: null
+dependencies: {  }
 _core:
   default_config_hash: utSJJ9cSylZEVzqaBr7cYV5wyXdC4xubL0L3QevhYRg
 id: stanford_student


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
In the last release 4 role configurations [had their dependencies changed](https://github.com/SU-HSDO/suhumsci/compare/9.4.26...9.5.0#diff-0a5614c0eefd92e41a295e59d9138af0f9eb483e36ed21c3f9fe39b8fe41e174) from empty arrays `{ }` to `null`. This caused an error preventing different configuration pages from being saved:
```
TypeError: array_intersect_key(): Argument #1 ($array) must be of type array, null given in /mnt/www/html/humscigryphon/docroot/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php on line 374 #0 /mnt/www/html/humscigryphon/docroot/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php(374): array_intersect_key(NULL, Array)
```
This PR changes these back to empty arrays to allow these pages to be saved again.


## Need Review By (Date)
ASAP

## Urgency
Med/High

## Steps to Test
1. Pull down a site (such as CCSRE2023)
2. Change any role setting and save this page: `/admin/structure/types/manage/hs_private_page/`
3. Verify you don't get an error

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
