### PR TITLE
fix(shs-5069): restoring status message theming

### DIFF
--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.libraries.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.libraries.yml
@@ -6,6 +6,7 @@ base:
     js/index.js: {}
   dependencies:
     - core/modernizr
+    - classy/messages
 megamenu:
     css:
       theme:

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.libraries.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.libraries.yml
@@ -6,6 +6,7 @@ base:
     js/index.js: {}
   dependencies:
     - core/modernizr
+    - classy/messages
 megamenu:
     css:
       theme:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Pulling in Classy messages styling for messages.

## Urgency
'medium'

## Steps to Test
1. Edit a node in Colorful or Traditional themes
2. Note that the "saved" message is themed with a background color now:
![Screenshot from 2023-09-21 13-10-57](https://github.com/SU-HSDO/suhumsci/assets/2343957/8dd7bec2-21f5-42bd-b752-250c6b9b0bf5)


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
