### PR TITLE
SHS-5121: Patch paragraph browser jquery/once issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -294,7 +294,8 @@
                 "https://www.drupal.org/project/paragraphs/issues/2895561": "https://www.drupal.org/files/issues/2021-05-06/paragraphs-2895561-32.patch"
             },
             "drupal/paragraphs_browser": {
-                "https://www.drupal.org/project/paragraphs_browser/issues/3381981": "https://www.drupal.org/files/issues/2023-08-22/3381981-sort-by-weight-4.patch"
+                "https://www.drupal.org/project/paragraphs_browser/issues/3381981": "https://www.drupal.org/files/issues/2023-08-22/3381981-sort-by-weight-4.patch",
+                "https://www.drupal.org/project/paragraphs_browser/issues/3340467": "https://www.drupal.org/files/issues/2023-02-09/replace_jquery_once_with_core_once.patch"
             },
             "drupal/path_redirect_import": {
                 "https://www.drupal.org/project/path_redirect_import/issues/3373025": "https://www.drupal.org/files/issues/2023-07-06/path_redirect_import-3373025.patch"


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Adds patch for Paragraphs Browser module to fix removal removal of jQuery/once from D10

## Steps to Test
1. Login as a contributor/editor
2. Create a new flexible page
3. Open browser console
4. Click on "Add Component"
5. Verify no errors in browser console appear
6. Verify the search functionality works in paragraph browser module
7. Verify paragraph component added without errors, and page is saved without errors

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
