### PR TITLE
fix(shs-5133): removing aria attributes on card images within links

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -258,8 +258,6 @@ function su_humsci_profile_preprocess_image_formatter(&$variables) {
   if (isset($variables['url'])) {
     // Disable screen readers from seeing the link on the image since there
     // should be another link with text nearby.
-    $variables['image']['#attributes']['aria-hidden'] = 'true';
-    $variables['image']['#attributes']['tabindex'] = -1;
     $variables['url']->mergeOptions([
       'attributes' => [
         'tabindex' => -1,
@@ -276,8 +274,6 @@ function su_humsci_profile_preprocess_responsive_image_formatter(&$variables) {
   if (isset($variables['url'])) {
     // Disable screen readers from seeing the link on the image since there
     // should be another link with text nearby.
-    $variables['responsive_image']['#attributes']['aria-hidden'] = 'true';
-    $variables['responsive_image']['#attributes']['tabindex'] = -1;
     $variables['url']->mergeOptions([
       'attributes' => [
         'tabindex' => -1,


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR removes the aria-hidden and tab-index from images within links on cards.

## Urgency
medium

## Steps to Test
1. Visit a page with cards that have a linked image in them, like https://english.suhumsci.loc/
2. Ensure that on cards that have linked images, the images no longer have the `aria-hidden: true` and `tab-index: -1` attributes. 

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
