### PR TITLE
Shs 5134 photo album aria

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
@@ -14,13 +14,14 @@
  */
 #}
 
-{# set a generic link label in case there is no alt attribute on the image or a caption #}
+{# set a generic link label in case there is no alt attribute on the image #}
 {% set link_label = "Open image in the gallery" %}
-{# If the image has an alt attribute, use it as the link label. #}
-{% if attributes['data-cbox-img-attrs']|render != '{&quot;alt&quot;:&quot;&quot;}' %}
-  {% set link_label = "Open " ~ attributes['data-cbox-img-attrs'] ~ " image in the gallery" %}
+
+{# If the image has an alt attribute, use it in the link label. #}
+{% set alt_text = image['#alt'] %}
+
+{% if alt_text %}
+  {% set link_label = "Open " ~ alt_text ~ " image in the gallery" %}
 {% endif %}
-{% set link_label = link_label|raw %}
-{% set link_label = link_label|replace({'{&quot;alt&quot;:&quot;':'', '&quot;}':''}) %}
 
 <a href="{{ url }}" aria-controls="colorbox" aria-label="{{ link_label }}" role="button" {{ attributes }}>{{ image }}</a>

--- a/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a formatted colorbox image field.
+ *
+ * Available variables:
+ * - image: A collection of image data.
+ * - url: An URL the image can be linked to.
+ * - attributes: Link attributes.
+ *
+ * @see template_preprocess_colorbox_formatter()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{# set a generic link label in case there is no alt attribute on the image or a caption #}
+{% set link_label = "Thumbnail Image" %}
+{# If the image has an alt attribute, use it as the link label. #}
+{% if attributes['data-cbox-img-attrs']|render != "{&quot;alt&quot;:&quot;&quot;}" %}
+  {% set link_label = attributes['data-cbox-img-attrs'] %}
+{# If the image has a title attribute, use it as the link label. #}
+{% elseif attributes['title']|render != "" %}
+  {% set link_label = attributes['title'] %}
+{% endif %}
+
+<a href="{{ url }}" aria-controls="colorbox" role="button" aria-title="{{ link_label|raw }}" data-cbox-img-attrs="{{ link_label|raw }}" {{ attributes }}>{{ image }}</a>

--- a/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
@@ -23,4 +23,4 @@
 {% set link_label = link_label|raw %}
 {% set link_label = link_label|replace({'{&quot;alt&quot;:&quot;':'', '&quot;}':''}) %}
 
-<a href="{{ url }}" aria-controls="colorbox" role="button" aria-label="{{ link_label }}" data-cbox-img-attrs="{{ link_label }}" {{ attributes }}>{{ image }}</a>
+<a href="{{ url }}" aria-controls="colorbox" aria-label="{{ link_label }}" role="button" {{ attributes }}>{{ image }}</a>

--- a/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/contrib/colorbox-formatter.html.twig
@@ -15,13 +15,12 @@
 #}
 
 {# set a generic link label in case there is no alt attribute on the image or a caption #}
-{% set link_label = "Thumbnail Image" %}
+{% set link_label = "Open image in the gallery" %}
 {# If the image has an alt attribute, use it as the link label. #}
-{% if attributes['data-cbox-img-attrs']|render != "{&quot;alt&quot;:&quot;&quot;}" %}
-  {% set link_label = attributes['data-cbox-img-attrs'] %}
-{# If the image has a title attribute, use it as the link label. #}
-{% elseif attributes['title']|render != "" %}
-  {% set link_label = attributes['title'] %}
+{% if attributes['data-cbox-img-attrs']|render != '{&quot;alt&quot;:&quot;&quot;}' %}
+  {% set link_label = "Open " ~ attributes['data-cbox-img-attrs'] ~ " image in the gallery" %}
 {% endif %}
+{% set link_label = link_label|raw %}
+{% set link_label = link_label|replace({'{&quot;alt&quot;:&quot;':'', '&quot;}':''}) %}
 
-<a href="{{ url }}" aria-controls="colorbox" role="button" aria-title="{{ link_label|raw }}" data-cbox-img-attrs="{{ link_label|raw }}" {{ attributes }}>{{ image }}</a>
+<a href="{{ url }}" aria-controls="colorbox" role="button" aria-label="{{ link_label }}" data-cbox-img-attrs="{{ link_label }}" {{ attributes }}>{{ image }}</a>


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR makes adjustments to how the colorbox gallery pulls in attributes for identifying link purposes.

## Urgency
medium

## Steps to Test
1. Visit an example page with a Photo Gallery like http://hs-colorful.suhumsci.loc/components/photo-album
2. The thumbnail gallery images should be links. In the markup, the links should have an `aria-title` attribute. This attribute should be (in this order): the alt text of the image if it isn't blank, the caption if it isn't blank, or generic text "Thumbnail Image" if neither of those exist.

I realize this strays from the original AC. But I'm realizing that the problem here is that the aria-title exists because sometimes the images don't have alt text. And that's a problem for describing the to the user what they are clicking on and why. At the same time, there's some sort of bug with the colorbox templates where even if there's no alt text on the image, it pulls in some weird additional markup (`{"alt":""}` or something like that), so there won't ever be an error saying "hey, there's no alt text here." 

I tried to approach this with giving best to worst aria-title text possible to the link. Maybe the generic text could be improved. Please let me know what you think! 

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
