### PR TITLE
SHS-5086: Add delete local task for developer users

### DIFF
--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -51,9 +51,10 @@ function hs_admin_toolbar_alter(&$items) {
  * Implements hook_menu_local_tasks_alter().
  */
 function hs_admin_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
-  // Disable edit/create node tabs for publish and delete.
+  // Disable edit/create node tabs for publish and delete (non-admin users).
   unset($data['tabs'][0]['entity.node.publish']);
-  unset($data['tabs'][0]['entity.node.delete_form']);
+  if (!\Drupal::currentUser()->hasRole('administrator'))
+    unset($data['tabs'][0]['entity.node.delete_form']);
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Show delete local task for developer user, hide for all others

## Need Review By (Date)
11/27

## Urgency
medium

## Steps to Test
1. Visit nodes of different content types as an user with the "Developer" role. You should be able to see and use the "Delete" local task
2. Repeat the test with a couple of other users with different roles. The "Delete" local task shouldn't be present

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
