### PR TITLE
fix(shs-5150): fixing empty headings on grid views

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
@@ -29,7 +29,12 @@
 {% set viewItems = [] %}
 
 {% if title %}
-  <h3>{{ title }}</h3>
+  {% if title|render matches '/<h\\d>/' %}
+    {# Check to see if there is already a heading tag in the rendered title. #}
+    {{ title }}
+  {% else %}
+    <h3>{{ title }}</h3>
+  {% endif %}
 {% endif %}
 
 {% for row in items %}

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-unformatted.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-unformatted.html.twig
@@ -17,8 +17,8 @@
 #}
 
 {% if title %}
-  {# Check to see if there is already a heading tag in the rendered title. #}
-  {% if '</h' in title|render %}
+  {% if title|render matches '/<h\\d>/' %}
+    {# Check to see if there is already a heading tag in the rendered title. #}
     {{ title }}
   {% else %}
     <h3>{{ title }}</h3>


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR updates the `views-view-unformatted` and `views-view-grid` templates to check for a heading tag within title markup before printing an `<h3>` tag in the template. 

## Urgency
medium

## Steps to Test
Ensure there are no longer WAVE issues around empty heading tags printing on the following pages:

https://anthropology.suhumsci.loc/people/faculty-and-affiliates/faculty/leadership
https://dlcl.suhumsci.loc/people/faculty
https://shenlab.stanford.edu/people 

Also check:
https://hs-traditional.suhumsci.loc/default-views/people

Please note that I have found one outlying issue that is noticeable in the traditional example. If the view returns "grouped" content, and it is grouped by a field that allows the user to select nothing, the field will print with comments inside the `<h3>`. I believe this will only happen live when logged in (I'm having trouble testing that since I can see template comments logged out locally.) 

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
