### PR TITLE
Shs 5151 headings legacy

### DIFF
--- a/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-grid.html.twig
+++ b/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-grid.html.twig
@@ -1,0 +1,83 @@
+{#
+/**
+ * @file
+ * Default theme implementation for views to display rows in a grid.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the wrapping element.
+ * - title: The title of this group of rows.
+ * - view: The view object.
+ * - rows: The rendered view results.
+ * - options: The view plugin style options.
+ *   - row_class_default: A flag indicating whether default classes should be
+ *     used on rows.
+ *   - col_class_default: A flag indicating whether default classes should be
+ *     used on columns.
+ * - items: A list of grid items. Each item contains a list of rows or columns.
+ *   The order in what comes first (row or column) depends on which alignment
+ *   type is chosen (horizontal or vertical).
+ *   - attributes: HTML attributes for each row or column.
+ *   - content: A list of columns or rows. Each row or column contains:
+ *     - attributes: HTML attributes for each row or column.
+ *     - content: The row or column contents.
+ *
+ * @see template_preprocess_views_view_grid()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'views-view-grid',
+    options.alignment,
+    'cols-' ~ options.columns,
+    'clearfix',
+  ]
+%}
+{% if options.row_class_default %}
+  {%
+    set row_classes = [
+      'views-row',
+      options.alignment == 'horizontal' ? 'clearfix',
+    ]
+  %}
+{% endif %}
+{% if options.col_class_default %}
+  {%
+    set col_classes = [
+      'views-col',
+      options.alignment == 'vertical' ? 'clearfix',
+    ]
+  %}
+{% endif %}
+{% if title %}
+  {% if title|render matches '/<h\\d>/' %}
+    {# Check to see if there is already a heading tag in the rendered title. #}
+    {{ title }}
+  {% else %}
+    <h3>{{ title }}</h3>
+  {% endif %}
+{% endif %}
+<div{{ attributes.addClass(classes) }}>
+  {% if options.alignment == 'horizontal' %}
+    {% for row in items %}
+      <div{{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
+        {% for column in row.content %}
+          <div{{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
+            {{- column.content -}}
+          </div>
+        {% endfor %}
+      </div>
+    {% endfor %}
+  {% else %}
+    {% for column in items %}
+      <div{{ column.attributes.addClass(col_classes, options.col_class_default ? 'col-' ~ loop.index) }}>
+        {% for row in column.content %}
+          <div{{ row.attributes.addClass(row_classes, options.row_class_default ? 'row-' ~ loop.index) }}>
+            {{- row.content -}}
+          </div>
+        {% endfor %}
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>

--- a/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-unformatted.html.twig
+++ b/docroot/themes/humsci/su_humsci_theme/templates/views/views-view-unformatted.html.twig
@@ -16,7 +16,12 @@
  */
 #}
 {% if title %}
-  <h3>{{ title }}</h3>
+  {% if title|render matches '/<h\\d>/' %}
+    {# Check to see if there is already a heading tag in the rendered title. #}
+    {{ title }}
+  {% else %}
+    <h3>{{ title }}</h3>
+  {% endif %}
   {# Wrap the rows when a title is present (grouped views). #}
   <div class="views-rows">
 {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
This PR fixes the bug where the views template needs to check for an h tag from the view before manually printing the h tag in the theme. This time it is for the legacy theme. 


## Urgency
medium

## Steps to Test
1. The issue can be seen in this site:
https://mathematics.stanford.edu/people/department-administration 
2. Visit the same page locally https://mathematics.suhumsci.loc/people/department-administration to see the changes fix in place. If you are logged in, you will no longer see the issue in Editorially. 

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
