### PR TITLE
SHS-4981: [EX] Dynamically change label for hs_hero_image paragraph type based on context

### DIFF
--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -31,3 +31,27 @@ function hs_paragraph_types_preprocess_field__field_hs_collection_items(&$variab
   $variables['attributes']['class'][] = "item-per-row--$items_per_row";
   $variables['#attached']['library'][] = 'hs_paragraph_types/hs_collection';
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function hs_paragraph_types_field_widget_single_element_paragraphs_form_alter(&$element, &$form_state, $context) {
+  // Change the paragraph type label for hs_hero_image embedded in hs_carousel.
+  if ($element['#paragraph_type'] === 'hs_hero_image' && $element['#bundle'] === 'hs_carousel') {
+    $label = $element['top']['type']['label']['#markup'];
+    $new_label = str_replace('full overlay and text', 'text box', $label);
+    $element['top']['type']['label']['#markup'] = $new_label;
+  }
+}
+
+/**
+ * Implements hook_field_widget_complete_form_alter().
+ */
+function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+  // Change the add button label for field_hs_carousel_slides
+  if ($field_widget_complete_form['widget']['#field_name'] === "field_hs_carousel_slides") {
+    $field_widget_complete_form['widget']['add_more']['add_more_button_hs_hero_image']['#value'] = t('Add @type', [
+      '@type' => 'Banner image with text box',
+    ]);
+  }
+}

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -53,7 +53,7 @@ function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(&$field_
   // Change the add button label for field_hs_carousel_slides.
   if (
     isset($field_widget_form['widget']['add_more']['add_more_button_hs_hero_image'], $field_widget_form['widget']['#field_name']) &&
-    $field_widget_form['widget']['#field_name'] === "field_hs_carousel_slides"
+    $field_widget_form['widget']['#field_name'] === 'field_hs_carousel_slides'
   ) {
     $field_widget_form['widget']['add_more']['add_more_button_hs_hero_image']['#value'] = t('Add @type', [
       '@type' => 'Banner image with text box',

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -5,6 +5,8 @@
  * hs_paragraph_types.module
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_preprocess_HOOK().
  */

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -35,7 +35,7 @@ function hs_paragraph_types_preprocess_field__field_hs_collection_items(&$variab
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
 function hs_paragraph_types_field_widget_single_element_paragraphs_form_alter(&$element, &$form_state, $context) {
   // Change the paragraph type label for hs_hero_image embedded in hs_carousel.
@@ -47,12 +47,15 @@ function hs_paragraph_types_field_widget_single_element_paragraphs_form_alter(&$
 }
 
 /**
- * Implements hook_field_widget_complete_form_alter().
+ * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
  */
-function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
-  // Change the add button label for field_hs_carousel_slides
-  if ($field_widget_complete_form['widget']['#field_name'] === "field_hs_carousel_slides") {
-    $field_widget_complete_form['widget']['add_more']['add_more_button_hs_hero_image']['#value'] = t('Add @type', [
+function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(&$field_widget_form, FormStateInterface $form_state, $context) {
+  // Change the add button label for field_hs_carousel_slides.
+  if (
+    $field_widget_form['widget']['#field_name'] === "field_hs_carousel_slides" &&
+    isset($field_widget_form['widget']['add_more']['add_more_button_hs_hero_image'])
+  ) {
+    $field_widget_form['widget']['add_more']['add_more_button_hs_hero_image']['#value'] = t('Add @type', [
       '@type' => 'Banner image with text box',
     ]);
   }

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -52,8 +52,8 @@ function hs_paragraph_types_field_widget_single_element_paragraphs_form_alter(&$
 function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(&$field_widget_form, FormStateInterface $form_state, $context) {
   // Change the add button label for field_hs_carousel_slides.
   if (
-    $field_widget_form['widget']['#field_name'] === "field_hs_carousel_slides" &&
-    isset($field_widget_form['widget']['add_more']['add_more_button_hs_hero_image'])
+    isset($field_widget_form['widget']['add_more']['add_more_button_hs_hero_image'], $field_widget_form['widget']['#field_name']) &&
+    $field_widget_form['widget']['#field_name'] === "field_hs_carousel_slides"
   ) {
     $field_widget_form['widget']['add_more']['add_more_button_hs_hero_image']['#value'] = t('Add @type', [
       '@type' => 'Banner image with text box',


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Dynamically change the label for `hs_hero_image` when the paragraph type is referenced inside the `hs_carousel` paragraph type, while using the default label when it's on its own.

## Steps to Test
1. Login as an administrator
2. Create a new flexible page
3. Add an `hs_carousel` (Banner image(s) with text box) component
4. Verify the component's Add button has the text `Add Banner image with text box`
5. Verify the Paragraph type label for all items within the `hs_carousel` component have the text `Banner image with text box`
6. Add an `hs_hero_image` (Banner image with full overlay and text) component
7. Verify the component's Paragraph type label has the text `Banner image with full overlay and text`

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
