### PR TITLE
Regression: Link field should generate URL to file, not media entity

### DIFF
--- a/config/default/user.role.anonymous.yml
+++ b/config/default/user.role.anonymous.yml
@@ -6,6 +6,7 @@ dependencies:
     - eck
     - field_permissions
     - media
+    - media_entity_download
     - system
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
@@ -15,6 +16,7 @@ weight: -1
 is_admin: false
 permissions:
   - 'access content'
+  - 'download media'
   - 'view any course_collections entities'
   - 'view any event_collections entities'
   - 'view any publications_collections entities'

--- a/config/default/user.role.authenticated.yml
+++ b/config/default/user.role.authenticated.yml
@@ -12,6 +12,7 @@ dependencies:
     - filter
     - fontawesome
     - media
+    - media_entity_download
     - shortcut
     - system
 _core:
@@ -25,6 +26,7 @@ permissions:
   - 'access fontawesome additional settings'
   - 'access shortcuts'
   - 'delete own files'
+  - 'download media'
   - 'use text format basic_html_without_media'
   - 'use text format webform_default'
   - 'view any course_collections entities'

--- a/docroot/modules/humsci/hs_paragraph_types/modules/hs_postcard/hs_postcard.install
+++ b/docroot/modules/humsci/hs_paragraph_types/modules/hs_postcard/hs_postcard.install
@@ -5,6 +5,8 @@
  * hs_postcard.install
  */
 
+use Drupal\user\UserInterface;
+
 /**
  * Implements hook_install().
  */
@@ -20,4 +22,13 @@ function hs_postcard_install() {
     \Drupal::logger('hs_postcard')->error('Unable to set initial display settings for postcard Paragraph');
   }
 
+}
+
+/**
+ * Set the permissions for the postcard download links.
+ */
+function hs_postcard_update_10000() {
+  $perms = ['download media'];
+  user_role_grant_permissions(UserInterface::ANONYMOUS_ROLE, $perms);
+  user_role_grant_permissions(UserInterface::AUTHENTICATED_ROLE, $perms);
 }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds correct permissions for `media_entity_download` module to allow access to postcard links 

## Steps to Test
1. Create a flexible page
2. Add a postcard component
3. In the the postcard link field, add a link to an existing media file
4. Publish and save the new page
5. Navigate to the new page
6. Verify that the following roles can access the file:
  1. Anonymous
  2. Authenticated
  3. Contributor
  4. Author
  5. Site Manager

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
