### PR TITLE
SHS-4998: Add hb-raised-cards--uniform-height as checkbox on collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -239,6 +239,9 @@
             "drupal/bricks": {
                 "https://www.drupal.org/project/bricks/issues/3003176": "https://www.drupal.org/files/issues/2018-09-28/bricks-entity_usage-3003176.patch"
             },
+            "drupal/conditional_fields": {
+                "https://www.drupal.org/project/conditional_fields/issues/2902164": "https://www.drupal.org/files/issues/2023-09-28/2902164-149.patch"
+            },
             "drupal/config_ignore": {
                 "https://www.drupal.org/project/config_ignore/issues/2857247": "https://www.drupal.org/files/issues/2020-01-11/support-for-export-2857247-44.patch",
                 "https://www.drupal.org/project/config_ignore/issues/2865419": "https://www.drupal.org/files/issues/2020-07-20/config_ignore-wildcard_force_import.patch"

--- a/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.hs_collection.field_hs_collection_items
     - field.field.paragraph.hs_collection.field_hs_collection_per_row
+    - field.field.paragraph.hs_collection.field_hs_collection_uh
     - field.field.paragraph.hs_collection.field_paragraph_style
     - field.field.paragraph.hs_collection.field_raised_cards
     - paragraphs.paragraphs_type.hs_collection
@@ -17,7 +18,7 @@ mode: default
 content:
   field_hs_collection_items:
     type: paragraphs_browser
-    weight: 3
+    weight: 4
     region: content
     settings:
       title: Component
@@ -36,12 +37,21 @@ content:
       paragraphs_browser: content
       modal_width: 80%
       modal_height: auto
+      show_group_label: true
+      show_group_filter: true
     third_party_settings: {  }
   field_hs_collection_per_row:
     type: options_select
     weight: 0
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_hs_collection_uh:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_paragraph_style:
     type: options_select

--- a/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
@@ -52,7 +52,25 @@ content:
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
+    third_party_settings:
+      conditional_fields:
+        d755369a-3372-40fb-896b-2cfddbdaff67:
+          entity_type: paragraph
+          bundle: hs_collection
+          dependee: field_raised_cards
+          settings:
+            state: visible
+            reset: false
+            condition: checked
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              value: false
+            effect: show
+            effect_options: {  }
+            selector: ''
   field_paragraph_style:
     type: options_select
     weight: 1

--- a/config/default/core.entity_view_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_collection.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.hs_collection.field_hs_collection_items
     - field.field.paragraph.hs_collection.field_hs_collection_per_row
+    - field.field.paragraph.hs_collection.field_hs_collection_uh
     - field.field.paragraph.hs_collection.field_paragraph_style
     - field.field.paragraph.hs_collection.field_raised_cards
     - paragraphs.paragraphs_type.hs_collection
@@ -26,6 +27,7 @@ content:
     region: content
 hidden:
   field_hs_collection_per_row: true
+  field_hs_collection_uh: true
   field_paragraph_style: true
   field_raised_cards: true
   search_api_excerpt: true

--- a/config/default/field.field.paragraph.hs_collection.field_hs_collection_uh.yml
+++ b/config/default/field.field.paragraph.hs_collection.field_hs_collection_uh.yml
@@ -1,0 +1,23 @@
+uuid: 0297c036-02a9-4fd7-8d37-b9effb034279
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hs_collection_uh
+    - paragraphs.paragraphs_type.hs_collection
+id: paragraph.hs_collection.field_hs_collection_uh
+field_name: field_hs_collection_uh
+entity_type: paragraph
+bundle: hs_collection
+label: 'Uniform Height'
+description: 'Applies the uniform height styling to the raised cards. This option is decorative.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.storage.paragraph.field_hs_collection_uh.yml
+++ b/config/default/field.storage.paragraph.field_hs_collection_uh.yml
@@ -1,0 +1,18 @@
+uuid: c9d0623e-1800-4484-ba92-5fdfb0e22159
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hs_collection_uh
+field_name: field_hs_collection_uh
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.deploy.php
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.deploy.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Deploy hooks for paragraph components.
+ */
+
+/**
+ * Update existing hs_collection content if raised cards is enabled.
+ */
+function hs_paragraph_types_deploy_hs_collection_uh_field(&$sandbox) {
+  $paragraph_storage = \Drupal::entityTypeManager()->getStorage('paragraph');
+  if (empty($sandbox['ids'])) {
+    $sandbox['ids'] = $paragraph_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'hs_collection')
+      ->condition('field_raised_cards', TRUE)
+      ->execute();
+    $sandbox['total'] = count($sandbox['ids']);
+  }
+  $paragraph_ids = array_splice($sandbox['ids'], 0, 10);
+
+  /** @var \Drupal\paragraphs\Entity */
+  foreach($paragraph_storage->loadMultiple($paragraph_ids) as $paragraph) {
+    $paragraph->set('field_hs_collection_uh', TRUE);
+    $paragraph->save();
+  }
+
+  $sandbox['#finished'] = count($sandbox['ids']) ? 1 - count($sandbox['ids']) / $sandbox['total'] : 1;
+}

--- a/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
@@ -42,13 +42,17 @@
 {% if paragraph.field_raised_cards.value == true %}
    {% set raised_cards = true %}
 {% endif %}
+{% if paragraph.field_uniform_height.value == true %}
+  {% set uniform_height = true %}
+{% endif %}
 {%
   set classes = [
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
-    raised_cards ? 'hb-raised-cards hb-raised-cards--uniform-height'
+    raised_cards ? 'hb-raised-cards',
+    uniform_height ? 'hb-raised-cards--uniform-height'
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
@@ -52,7 +52,7 @@
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
     raised_cards ? 'hb-raised-cards',
-    uniform_height ? 'hb-raised-cards--uniform-height'
+    raised_cards and uniform_height ? 'hb-raised-cards--uniform-height'
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
@@ -42,7 +42,7 @@
 {% if paragraph.field_raised_cards.value == true %}
    {% set raised_cards = true %}
 {% endif %}
-{% if paragraph.field_uniform_height.value == true %}
+{% if paragraph.field_hs_collection_uh.value == true %}
   {% set uniform_height = true %}
 {% endif %}
 {%


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
1. Adds the `Uniform Height` boolean field to `hs_collection` paragraph
2. Updates `hs_collection` template to set `hb-raised-cards--uniform-height` class based on `Uniform Height` field value 
3. Updates existing `hs_collection` paragraph content to enable `Uniform Height` if `Raised Cards` is already enabled

## Steps to Test
1. Create new Flexible Page
2. Click on the `Add Component` button
3. Add a Collection component
4. Verify that clicking the `Raised Cards` checkbox causes the `Uniform Height` checkbox to appear, already enabled.
5. Set the `Items Per Row` to 2
6. Disable the`Uniform Height` checkbox
8. Using the `Add Component` button in the Collection component, add 2 Postcard components
9. Add a paragraph or two to the first component and add only one line to the second component
10. Save the new page and navigate to it
11. Verify that the postcards are different heights, but still have the styling from the `hb-raised-cards` class
12. Edit the new page
13. Click on the `Edit` button on the Collection component
14. Enable the `Uniform Height` checkbox
15. Save the page and navigate to it
16. Verify that the postcards are now the same height and still have the styling from the `hb-raised-cards` class
17. Check existing content with Collection components. Content with `Raised Cards` enabled should have `Uniform Height` enabled as well. The following were used to test during development:
   -   West site
     1.  `Understanding Attitudes in the West` (Raised Cards enabled)
     2. `Student Profiles` (Raised Cards disabled)
   - Planning site
    1. `Department External Reviews` (Raised Cards disabled)
    2. `Events` (Raised Cards enabled)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
