### PR TITLE
SHS-5228: Correct heading levels in views cards

### DIFF
--- a/docroot/modules/humsci/hs_layouts/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/date-stacked-vertical-card/date-stacked-vertical-card.html.twig
@@ -43,7 +43,7 @@
 
     {% if title %}
       <div class="hb-card__title">
-        {% if title|render matches '/<h\\d>/' %}
+        {% if title|render matches '/<\\/h\\d>/' %}
           {{ title }}
         {% else %}
           <h2>{{ title }}</h2>

--- a/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/horizontal-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/horizontal-card.html.twig
@@ -24,7 +24,7 @@
 
     {% if title %}
       <div class="hb-card__title">
-        {% if title|render matches '/<h\\d>/' %}
+        {% if title|render matches '/<\\/h\\d>/' %}
           {{ title }}
         {% else %}
           <h2>{{ title }}</h2>

--- a/docroot/modules/humsci/hs_layouts/patterns/vertical-card/vertical-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/vertical-card/vertical-card.html.twig
@@ -17,7 +17,7 @@
 
     {% if title %}
       <div class="hb-card__title">
-        {% if title|render matches '/<h\\d>/' %}
+        {% if title|render matches '/<\\/h\\d>/' %}
           {{ title }}
         {% else %}
           <h2>{{ title }}</h2>

--- a/docroot/modules/humsci/hs_layouts/patterns/vertical-link-card/vertical-link-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/vertical-link-card/vertical-link-card.html.twig
@@ -8,7 +8,7 @@
   {% endif %}
 
   {% if title and button %}
-    {% if title|render matches '/<h\\d>/' %}
+    {% if title|render matches '/<\\/h\\d>/' %}
       <a href="{{ button }}" class="hb-vertical-linked-card__title__link">{{ title }}</a>
     {% else %}
       <h2 class="hb-vertical-linked-card__title">


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Fix regex used for detecting headings in views cards

## Need Review By (Date)
01/26

## Urgency
medium

## Steps to Test
1. Install the `dlcl` site
2. Visit https://dlcl.suhumsci.loc/people/faculty
3. Confirm that the people names are wrapped in an `<h4>` heading and that it's not nested in another heading

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
