### PR TITLE
HSD8-000: Added Stanford Site Alias to Status Report.

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -5,12 +5,33 @@
  * su_humsci_profile.install
  */
 
-use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Core\DrupalKernel;
 use Drupal\Core\Menu\MenuTreeParameters;
-use Drupal\node\NodeInterface;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\user\UserInterface;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\key\Entity\Key;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_requirements().
+ */
+function su_humsci_profile_requirements($phase)
+{
+  $requirements = [];
+  if ($phase == 'runtime') {
+
+    $site_path = DrupalKernel::findSitePath(\Drupal::request());
+    $site_path = explode('/', $site_path);
+    $site_name = $site_path[1];
+
+    $requirements['stanford_site_alias'] = [
+      'title' => t('Stanford Site Alias'),
+      'value' => $site_name,
+      'severity' => REQUIREMENT_INFO,
+    ];
+  }
+  return $requirements;
+}
 
 /**
  * Implements hook_install_tasks().

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -15,8 +15,7 @@ use Drupal\user\UserInterface;
 /**
  * Implements hook_requirements().
  */
-function su_humsci_profile_requirements($phase)
-{
+function su_humsci_profile_requirements($phase) {
   $requirements = [];
   if ($phase == 'runtime') {
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Added Stanford Site Alias to Status Report.
- Removed `Drupal\field\Entity\FieldConfig` because it was no longer used.

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
