### PR TITLE
feat(shs-5180): add media_entity_download support for stage_file_proxy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -246,6 +246,9 @@
             "drupal/hook_event_dispatcher": {
                 "https://www.drupal.org/project/hook_event_dispatcher/issues/3354751": "https://www.drupal.org/files/issues/2023-04-17/hook_event_dispatcher-4.x-3354751.patch"
             },
+            "drupal/media_entity_download": {
+                "https://www.drupal.org/project/media_entity_download/issues/2951316": "patches/contrib/media_entity_download-2951316.patch"
+            },
             "drupal/menu_block": {
                 "https://www.drupal.org/project/menu_block/issues/3271218": "https://www.drupal.org/files/issues/2022-04-29/menu_block_rendered_empty-3271218-17.patch"
             },

--- a/config/default/config_split.config_split.dev.yml
+++ b/config/default/config_split.config_split.dev.yml
@@ -19,7 +19,9 @@ module:
   purge_queuer_coretags: 0
   purge_ui: 0
   shield: 0
-  stage_file_proxy: 0
+  stage_file_proxy: 
+  hs_media_download: 0
+
 theme: {  }
 blacklist:
   - acquia_connector.settings

--- a/config/default/config_split.config_split.local.yml
+++ b/config/default/config_split.config_split.local.yml
@@ -13,6 +13,7 @@ module:
   devel_generate: 0
   seckit: 0
   stage_file_proxy: 0
+  hs_media_download: 0
   config_inspector: 0
   devel_php: 0
   update: 0

--- a/config/default/config_split.config_split.stage.yml
+++ b/config/default/config_split.config_split.stage.yml
@@ -20,6 +20,7 @@ module:
   purge_ui: 0
   shield: 0
   stage_file_proxy: 0
+  hs_media_download: 0
 theme: {  }
 blacklist:
   - acquia_connector.settings

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -104,6 +104,7 @@ module:
   hs_hero_image_display: 0
   hs_layouts: 0
   hs_masquerade: 0
+  hs_media_download: 0
   hs_megamenu: 0
   hs_migrate: 0
   hs_news: 0

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -104,7 +104,6 @@ module:
   hs_hero_image_display: 0
   hs_layouts: 0
   hs_masquerade: 0
-  hs_media_download: 0
   hs_megamenu: 0
   hs_migrate: 0
   hs_news: 0

--- a/docroot/modules/humsci/hs_media_download/hs_media_download.info.yml
+++ b/docroot/modules/humsci/hs_media_download/hs_media_download.info.yml
@@ -1,0 +1,8 @@
+name: 'H&S Media Download'
+type: module
+description: 'Provides customizations for media entity download'
+package: 'Humanities & Sciences'
+core_version_requirement: ^10
+dependencies:
+  - media_entity_download
+  - stage_file_proxy

--- a/docroot/modules/humsci/hs_media_download/hs_media_download.info.yml
+++ b/docroot/modules/humsci/hs_media_download/hs_media_download.info.yml
@@ -5,4 +5,3 @@ package: 'Humanities & Sciences'
 core_version_requirement: ^10
 dependencies:
   - media_entity_download
-  - stage_file_proxy

--- a/docroot/modules/humsci/hs_media_download/hs_media_download.services.yml
+++ b/docroot/modules/humsci/hs_media_download/hs_media_download.services.yml
@@ -1,0 +1,6 @@
+services:
+  hs_media_download.document_stage_file_proxy_subscriber:
+    class: '\Drupal\hs_media_download\EventSubscriber\DocumentStageFileProxySubscriber'
+    arguments: ['@config.factory', '@lock', '@http_client', '@file_system', '@logger.channel.stage_file_proxy']
+    tags:
+      - { name: 'event_subscriber' }

--- a/docroot/modules/humsci/hs_media_download/src/EventSubscriber/DocumentStageFileProxySubscriber.php
+++ b/docroot/modules/humsci/hs_media_download/src/EventSubscriber/DocumentStageFileProxySubscriber.php
@@ -31,35 +31,35 @@ final class DocumentStageFileProxySubscriber implements EventSubscriberInterface
    *
    * @var string
    */
-  protected $origin;
+  private $origin;
 
   /**
    * The lock backend used to prevent concurrent upstream fetches.
    *
    * @var \Drupal\Core\Lock\LockBackendInterface
    */
-  protected LockBackendInterface $lock;
+  private $lock;
 
   /**
    * The HTTP client.
    *
    * @var \GuzzleHttp\ClientInterface
    */
-  protected ClientInterface $client;
+  private $client;
 
   /**
    * The filesystem.
    *
    * @var \Drupal\Core\File\FileSystemInterface
    */
-  protected FileSystemInterface $filesystem;
+  private $filesystem;
 
   /**
    * The system logger.
    *
    * @var \Psr\Log\LoggerInterface
    */
-  protected LoggerInterface $logger;
+  private $logger;
 
   /**
    * Construct a new DocumentStageFileProxySubscriber.

--- a/docroot/modules/humsci/hs_media_download/src/EventSubscriber/DocumentStageFileProxySubscriber.php
+++ b/docroot/modules/humsci/hs_media_download/src/EventSubscriber/DocumentStageFileProxySubscriber.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Drupal\hs_media_download\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Utility\Error;
+use Drupal\media_entity_download\Events\MediaDownloadEvent;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Download Media Entity Download protected files on locals.
+ *
+ * This is based on an event subscriber currently under development.
+ * It's current state fits our needs so we're storing the patch file
+ * 'patches/media_entity_download-2951316.patch' to avoid potential
+ * breaking changes in the MR.
+ *
+ * @see Drupal\stage_file_proxy\DownloadManager
+ * @see https://www.drupal.org/project/media_entity_download/issues/2951316#comment-14340898
+ */
+final class DocumentStageFileProxySubscriber implements EventSubscriberInterface {
+
+  /**
+   * The origin server URL, provided by Stage File Proxy.
+   *
+   * @var string
+   */
+  private string $origin;
+
+  /**
+   * The lock backend used to prevent concurrent upstream fetches.
+   *
+   * @var \Drupal\Core\Lock\LockBackendInterface
+   */
+  private LockBackendInterface $lock;
+
+  /**
+   * The HTTP client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  private ClientInterface $client;
+
+  /**
+   * The filesystem.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  private FileSystemInterface $filesystem;
+
+  /**
+   * The system logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private LoggerInterface $logger;
+
+  /**
+   * Construct a new DocumentStageFileProxySubscriber.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory used to get the upstream file origin hostname.
+   * @param \Drupal\Core\Lock\LockBackendInterface $lock
+   *   The lock backend used to preven concurrent upstream fetches.
+   * @param \GuzzleHttp\ClientInterface $client
+   *   The HTTP cliet.
+   * @param \Drupal\Core\File\FileSystemInterface $filesystem
+   *   The filesystem used to save the remote file.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   They system logger.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory, LockBackendInterface $lock, ClientInterface $client, FileSystemInterface $filesystem, LoggerInterface $logger) {
+    $this->origin = $configFactory->get('stage_file_proxy.settings')->get('origin');
+    $this->lock = $lock;
+    $this->client = $client;
+    $this->filesystem = $filesystem;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      MediaDownloadEvent::EVENT_NAME => 'onMediaDownload',
+    ];
+  }
+
+  /**
+   * Download media entity download files if needed.
+   *
+   * @param \Drupal\media_entity_download\Events\MediaDownloadEvent $event
+   *   The event triggered when downloading the media item.
+   */
+  public function onMediaDownload(MediaDownloadEvent $event) {
+    if (file_exists($event->getUri())) {
+      return;
+    }
+
+    $url = $this->origin . $event->getRequest()->getRequestUri();
+
+    $lock_id = 'hs_media_download: ' . md5($url);
+    while(!$this->lock->acquire($lock_id)) {
+      $this->lock->wait($lock_id, 1);
+    }
+
+    try {
+      // Fetch remote file.
+      $options ['Connection'] = 'close';
+      $response = $this->client->get($url, $options);
+      $result = $response->getStatusCode();
+
+      if ($result !== Response::HTTP_OK) {
+        $this->logger->warning('HTTP error @errorcode occurred when trying to fetch @remote.', [
+          '@errorcode' => $result,
+          '@remote' => $url,
+        ]);
+        $this->lock->release($lock_id);
+        return;
+      }
+
+      $directory = $this->filesystem->dirname($event->getUri());
+
+      if (!$this->filesystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+        $this->logger->error('Unable to prepare local directory @path.', [
+          '@path' => $directory,
+        ]);
+        $this->lock->release($lock_id);
+        return;
+      }
+
+      $content_length_headers = $response->getHeader('Content-Length');
+      $content_length = (int) array_shift($content_length_headers);
+      $response_data = $response->getBody()->getContents();
+
+      if(isset($content_length) && strlen($response_data) !== $content_length) {
+        $this->logger->error('Incomplete download. Was expecting @content-length bytes, actually got @data-length.', [
+          '@content-length' => $content_length,
+          '@data-length' => $content_length,
+        ]);
+        $this->lock->release($lock_id);
+        return;
+      }
+
+      if ($this->writeFile($event->getUri(), $response_data)) {
+        $this->lock->release($lock_id);
+        return;
+      }
+
+      $this->logger->error('@remote could not be saved to @path.',
+        [
+          '@remote' => $url,
+          '@path' => $directory,
+        ]);
+      $this->lock->release($lock_id);
+      return;
+    }
+    catch (GuzzleException $e) {
+      $this->logger->error('Encountered an error when retrieving file @url. @message in %function (line %line of %file).', Error::decodeException($e) + ['@url' => $url]);
+      $this->lock->release($lock_id);
+      return;
+    }
+  }
+
+  /**
+   * Use write & rename, not just write.
+   *
+   * Perform the replace operation. Since there could be multiple processes
+   * writing to the same file, the best option is to create a temporary file in
+   * the same directory and then rename it to the destination. A temporary file
+   * is needed if the directory is mounted on a separate machine.
+   *
+   * @param string $destination
+   *   A strnig containnig the destination location.
+   * @param string $data
+   *   A string containing the contents of the file.
+   *
+   * @return bool
+   *   True if write was successful. False if write or rename failed.
+   */
+  private function writeFile(string $destination, string $data) {
+    $dir = $this->filesystem->dirname($destination) . '/';
+    $temporary_file = $this->filesystem->tempnam($dir, 'stage_file_proxy_');
+    $temporary_file_copy = $temporary_file;
+
+    $parts = pathinfo($destination);
+    $extension = '.' . $parts['extension'];
+    if ($extension === '.gz') {
+      $parts = pathinfo($parts['filename']);
+      $extension = '.' . $parts['extension'] . $extension;
+    }
+    $temporary_file = str_replace(substr($temporary_file, 0, strpos($temporary_file, 'stage_file_proxy_')), $dir, $temporary_file) . $extension;
+
+    if (!@rename($temporary_file_copy, $temporary_file)) {
+      @unlink($temporary_file_copy);
+      return FALSE;
+    }
+
+    $filepath = $this->filesystem->saveData($data, $temporary_file, FileSystemInterface::EXISTS_REPLACE);
+    if ($filepath) {
+      if (!@rename($filepath, $destination)) {
+        @unlink($destination);
+        if (!@rename($filepath, $destination)) {
+          @unlink($filepath);
+        }
+      }
+    }
+    if (file_exists($destination) && filesize($destination) > 0) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+}

--- a/patches/contrib/media_entity_download-2951316.patch
+++ b/patches/contrib/media_entity_download-2951316.patch
@@ -1,0 +1,226 @@
+diff --git a/src/Controller/DownloadController.php b/src/Controller/DownloadController.php
+index 6b7c0ce50051d932ffb44676d09d91bd8355eafb..05fcace43fd9d9e8f16e65c3c3bced95da007c76 100644
+--- a/src/Controller/DownloadController.php
++++ b/src/Controller/DownloadController.php
+@@ -5,6 +5,8 @@ namespace Drupal\media_entity_download\Controller;
+ use Drupal\Core\Controller\ControllerBase;
+ use Drupal\Core\File\FileSystemInterface;
+ use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
++use Drupal\media_entity_download\Events\MediaDownloadEvent;
++use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+ use Symfony\Component\HttpFoundation\BinaryFileResponse;
+ use Drupal\media\MediaInterface;
+ use Symfony\Component\HttpFoundation\Response;
+@@ -40,6 +42,11 @@ class DownloadController extends ControllerBase {
+    */
+   protected $streamWrapperManager;
+ 
++  /**
++   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
++   */
++  private EventDispatcherInterface $eventDispatcher;
++
+   /**
+    * DownloadController constructor.
+    *
+@@ -50,10 +57,11 @@ class DownloadController extends ControllerBase {
+    * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
+    *   The stream wrapper manager.
+    */
+-  public function __construct(RequestStack $request_stack, FileSystemInterface $file_system, StreamWrapperManagerInterface $stream_wrapper_manager) {
++  public function __construct(RequestStack $request_stack, FileSystemInterface $file_system, StreamWrapperManagerInterface $stream_wrapper_manager, EventDispatcherInterface $event_dispatcher) {
+     $this->requestStack = $request_stack;
+     $this->fileSystem = $file_system;
+     $this->streamWrapperManager = $stream_wrapper_manager;
++    $this->eventDispatcher = $event_dispatcher;
+   }
+ 
+   /**
+@@ -63,7 +71,8 @@ class DownloadController extends ControllerBase {
+     return new static(
+       $container->get('request_stack'),
+       $container->get('file_system'),
+-      $container->get('stream_wrapper_manager')
++      $container->get('stream_wrapper_manager'),
++      $container->get('event_dispatcher')
+     );
+   }
+ 
+@@ -124,7 +133,10 @@ class DownloadController extends ControllerBase {
+     }
+ 
+     $uri = $file->getFileUri();
+-    $scheme = $this->streamWrapperManager->getScheme($uri);
++    $scheme = $this->streamWrapperManager::getScheme($uri);
++
++    $event = new MediaDownloadEvent($this->requestStack->getCurrentRequest(), $media, $file, $delta, $scheme, $uri);
++    $this->eventDispatcher->dispatch($event, MediaDownloadEvent::EVENT_NAME);
+ 
+     // Or item does not exist on disk.
+     if (!$this->streamWrapperManager->isValidScheme($scheme) || !file_exists($uri)) {
+diff --git a/src/Events/MediaDownloadEvent.php b/src/Events/MediaDownloadEvent.php
+new file mode 100644
+index 0000000000000000000000000000000000000000..b69bb6936148231a4d87b664fcf53b1ee29a324e
+--- /dev/null
++++ b/src/Events/MediaDownloadEvent.php
+@@ -0,0 +1,160 @@
++<?php
++
++declare(strict_types=1);
++
++namespace Drupal\media_entity_download\Events;
++
++use Drupal\Component\EventDispatcher\Event;
++use Drupal\file\FileInterface;
++use Drupal\media\MediaInterface;
++use Symfony\Component\HttpFoundation\Request;
++
++/**
++ * Event triggered when downloading a file.
++ */
++final class MediaDownloadEvent extends Event {
++
++  public const EVENT_NAME = 'media_entity_download.media_download';
++
++  /**
++   * The media entity being accessed.
++   *
++   * @var \Drupal\media\MediaInterface
++   */
++  private MediaInterface $media;
++
++  /**
++   * A reference to the file entity that Media Entity Download found.
++   *
++   * @var \Drupal\file\FileInterface
++   */
++  private FileInterface $file;
++
++  /**
++   * The delta in the Media source field the field entity is referenced from.
++   *
++   * @var int|null
++   */
++  private ?int $delta;
++
++  /**
++   * The URI scheme of the file being downloaded.
++   *
++   * @var string
++   */
++  private string $scheme;
++
++  /**
++   * The URI of the file being downloaded.
++   *
++   * @var string
++   */
++  private string $uri;
++
++  /**
++   * The HTTP request that generated the download event.
++   *
++   * @var \Symfony\Component\HttpFoundation\Request
++   */
++  private Request $request;
++
++  /**
++   * Construct a new MediaDownloadEvent.
++   *
++   * @param \Symfony\Component\HttpFoundation\Request $request
++   *   The HTTP request that generated the download event.
++   * @param \Drupal\media\MediaInterface $media
++   *   The media entity being accessed.
++   * @param \Drupal\file\FileInterface $file
++   *   A reference to the file entity that Media Entity Download found.
++   * @param int|null $delta
++   *   (optional) The delta in the Media source field the field entity is
++   *   referenced from.
++   * @param string $scheme
++   *   The URI scheme of the file being downloaded.
++   * @param string $uri
++   *   The URI of the file being downloaded.
++   */
++  public function __construct(Request $request, MediaInterface $media, FileInterface $file, ?int $delta, string $scheme, string $uri) {
++    $this->request = $request;
++    $this->media = $media;
++    $this->file = $file;
++    $this->delta = $delta;
++    $this->scheme = $scheme;
++    $this->uri = $uri;
++  }
++
++  /**
++   * Return the media entity associated with this download event.
++   *
++   * @return \Drupal\media\MediaInterface
++   */
++  public function getMedia(): MediaInterface {
++    return $this->media;
++  }
++
++  /**
++   * Return the file associated with this download event.
++   *
++   * @return \Drupal\file\FileInterface
++   */
++  public function getFile(): FileInterface {
++    return $this->file;
++  }
++
++  /**
++   * Return the delta in the source field of the Media entity.
++   *
++   * @return int|null
++   */
++  public function getDelta(): ?int {
++    return $this->delta;
++  }
++
++  /**
++   * Return the URI scheme of the underlying file.
++   *
++   * @return string
++   */
++  public function getScheme(): string {
++    return $this->scheme;
++  }
++
++  /**
++   * Return the URI of the underlying file.
++   *
++   * @return string
++   */
++  public function getUri(): string {
++    return $this->uri;
++  }
++
++  /**
++   * Set the scheme of the underlying file.
++   *
++   * @param string $scheme
++   */
++  public function setScheme(string $scheme): void {
++    $this->scheme = $scheme;
++  }
++
++  /**
++   * Set the URI of the underlying file.
++   *
++   * @param string $uri
++   */
++  public function setUri(string $uri): void {
++    $this->uri = $uri;
++  }
++
++  /**
++   * Get the HTTP request that generated the download event.
++   *
++   * @return \Symfony\Component\HttpFoundation\Request
++   *   The request object.
++   */
++  public function getRequest(): Request {
++    return $this->request;
++  }
++
++}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Adds `media_entity_download` patch with event subscriber when attempting to download files
Adds `hs_media_download` which implements the event subscriber from the patch

## Steps to Test
Before testing clear the `sites/{sitename}/files/media/file` folder

1. Create a flexible page
2. Add a postcard component
3. In the the postcard link field, add a link to an existing media file
4. Publish and save the new page
5. Navigate to the new page
6. Verify that the following roles can access the file:
  1. Anonymous
  2. Authenticated
  3. Contributor
  4. Author
  5. Site Manager

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
