### PR TITLE
SHS-5541: The Uniform Height toggle on the Collections should appear below the Raised Cards toggle

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
@@ -21,7 +21,7 @@ mode: default
 content:
   field_hs_collection_items:
     type: paragraphs_browser
-    weight: 5
+    weight: 6
     region: content
     settings:
       title: Component
@@ -51,7 +51,7 @@ content:
     third_party_settings: {  }
   field_hs_collection_uh:
     type: boolean_checkbox
-    weight: 3
+    weight: 5
     region: content
     settings:
       display_label: true


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Moves Uniform Height checkbox to appear below the Raised Cards checkbox in the Collections component

## Steps to Test
1. Create flexible page
2. Add a Collection component
3. Enable the Raised Cards checkbox
4. Verify Uniform Height checkbox appears below the Raised Cards checkbox

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
