### PR TITLE
HSD8-1572: Add photo ID to local event image filename

### DIFF
--- a/config/default/migrate_plus.migration.hs_localist_individual.yml
+++ b/config/default/migrate_plus.migration.hs_localist_individual.yml
@@ -92,6 +92,10 @@ source:
       name: photo_url
       label: photo_url
       selector: event/photo_url
+        -
+      name: photo_id
+      label: photo_id
+      selector: event/photo_id
     -
       name: departments
       label: departments
@@ -294,6 +298,7 @@ process:
       source:
         - constants/image_path
         - urlname
+        - photo_id
   image_destination:
     -
       plugin: skip_on_empty

--- a/config/default/migrate_plus.migration.hs_localist_individual.yml
+++ b/config/default/migrate_plus.migration.hs_localist_individual.yml
@@ -92,7 +92,7 @@ source:
       name: photo_url
       label: photo_url
       selector: event/photo_url
-        -
+    -
       name: photo_id
       label: photo_id
       selector: event/photo_id

--- a/config/default/migrate_plus.migration.hs_localist_individual.yml
+++ b/config/default/migrate_plus.migration.hs_localist_individual.yml
@@ -288,6 +288,23 @@ process:
       delimiter: .
     -
       plugin: array_pop
+  urlname_trimmed:
+    -
+      plugin: substr
+      source: urlname
+      start: 0
+      length: 220
+  image_name:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: '@image_ext'
+    -
+      plugin: concat
+      source:
+        - '@urlname_trimmed'
+        - photo_id
+      delimiter: '_'
   image_destination_part_1:
     -
       plugin: skip_on_empty
@@ -297,8 +314,7 @@ process:
       plugin: concat
       source:
         - constants/image_path
-        - urlname
-        - photo_id
+        - '@image_name'
   image_destination:
     -
       plugin: skip_on_empty

--- a/config/default/migrate_plus.migration.hs_localist_scheduled.yml
+++ b/config/default/migrate_plus.migration.hs_localist_scheduled.yml
@@ -85,6 +85,10 @@ source:
       label: photo_url
       selector: event/photo_url
     -
+      name: photo_id
+      label: photo_id
+      selector: event/photo_id
+    -
       name: departments
       label: departments
       selector: event/departments
@@ -343,6 +347,7 @@ process:
       source:
         - constants/image_path
         - urlname
+        - photo_id
   image_destination:
     -
       plugin: skip_on_empty

--- a/config/default/migrate_plus.migration.hs_localist_scheduled.yml
+++ b/config/default/migrate_plus.migration.hs_localist_scheduled.yml
@@ -337,6 +337,23 @@ process:
       delimiter: .
     -
       plugin: array_pop
+  urlname_trimmed:
+    -
+      plugin: substr
+      source: urlname
+      start: 0
+      length: 220
+  image_name:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: '@image_ext'
+    -
+      plugin: concat
+      source:
+        - '@urlname_trimmed'
+        - photo_id
+      delimiter: '_'
   image_destination_part_1:
     -
       plugin: skip_on_empty
@@ -346,8 +363,7 @@ process:
       plugin: concat
       source:
         - constants/image_path
-        - urlname
-        - photo_id
+        - '@image_name'
   image_destination:
     -
       plugin: skip_on_empty


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add photo ID to local event image filename
- This will create a new image if the event photo changes and prevent long-term caching when an event photo changes
- I also added a trim (substr) on the `urlname` to 220 characters just to ensure there's enough characters left in the filename for the `photo_id` and file extension.

Example filenames from my local:
```
2024_undergraduate_honors_thesis_exhibition_45950742953656.jpg
8th-annual-berkeley-stanford-graduate-symposium-the-fog-comes-and-then-moves-on-on-transience-and-translucence_46014625790837.jpg
art-art-history-open-house-for-new-admits-and-families_46111611068927.jpg
christensen_distinguished_lecture_michael_boyce_gillespie_45526262322317.jpg
```

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
