### PR TITLE
SHS-5571: A11y Level A: Empty headings on Vertical Timeline components

### DIFF
--- a/docroot/modules/humsci/hs_layouts/patterns/timeline/timeline.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/timeline/timeline.html.twig
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% set timeline_content = timeline %}
-{% if timeline['field_hs_time_title'] is defined %}
+{% if timeline['field_hs_time_title'] is defined and timeline['field_hs_time_title'][0] %}
   {% set timeline_content %}
     <{{ heading_tag }} class="hb-timeline__title">
       {{ timeline['field_hs_time_title'] }}

--- a/docroot/modules/humsci/hs_layouts/patterns/timeline/timeline.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/timeline/timeline.html.twig
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% set timeline_content = timeline %}
-{% if timeline['field_hs_time_title'] is defined and timeline['field_hs_time_title'][0] %}
+{% if timeline['field_hs_time_title'] is defined and timeline['field_hs_time_title'][0] is defined %}
   {% set timeline_content %}
     <{{ heading_tag }} class="hb-timeline__title">
       {{ timeline['field_hs_time_title'] }}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fix empty headings on Vertical Timeline components

## Need Review By (Date)
04/19

## Urgency
medium

## Steps to Test
1. Go to the following pages
    -  https://biology.suhumsci.loc/academics/student-awards
    - https://chemistry.suhumsci.loc/research/centers-affiliates/center-molecular-analysis-and-design/apply
    - https://anthropology.suhumsci.loc/recommended-timeline
    - https://physics.suhumsci.loc/undergraduate/senior-thesis-and-honors

2. Confirm that if there isn't a title on a Vertical Timeline component, there isn't an empty heading
3. Add a title and confirm there's a heading only when there's a title on the Vertical Timeline component

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
