### PR TITLE
SHS-5613: Bug: Vertical Link Cards with /media/{id} URLs not showing URL to file

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -7,8 +7,6 @@
 
 use Drupal\Core\Template\Attribute;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Render\Element;
-use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\ParagraphInterface;
 

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Template\Attribute;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\ParagraphInterface;
 
@@ -206,7 +208,13 @@ function _humsci_basic_make_title_the_link(&$variables) {
     $dom = new DOMDocument();
     try {
       $button = is_array($variables['button']) ? $variables['button'] : (string) $variables['button'];
-      $dom->loadHTML($renderer->renderPlain($button));
+      // Get the first element index, if one exists.
+      if (!empty($button['field_hs_postcard_link'][0]['#url']) && $button['field_hs_postcard_link'][0]['#url']->isRouted()) {
+        $variables['href'] = ['#markup' => $button['field_hs_postcard_link'][0]['#url']->toString()];
+      }
+      else {
+        $dom->loadHTML($renderer->renderPlain($button));
+      }
     }
     catch (\Throwable $e) {
       return;
@@ -218,8 +226,9 @@ function _humsci_basic_make_title_the_link(&$variables) {
       $variables['href'] = $links->item(0)->nodeValue;
     }
     else {
-      // The markup is just a string with the url, we can use that.
-      $variables['href'] = htmlspecialchars_decode(trim(strip_tags($renderer->renderPlain($variables['button']))));
+      // First check if variables is already set from route url, otherwise
+      // the markup is just a string with the url, we can use that.
+      $variables['href'] = $variables['href'] ?? htmlspecialchars_decode(trim(strip_tags($renderer->renderPlain($variables['button']))));
     }
   }
   if (!empty($variables['title'])) {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fixes theme processing for Vertical Link Cards

## Steps to Test
1. Create new page
2. Add a postcard component, and enable Vertical Link Cards
3. Add a file to the Link field using the autocomplete
4. Publish page
5. Link should redirect to file (download the file locally first if environment has `stage_file_proxy` enabled)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
