### PR TITLE
SHS-5640: Empty headings on Gender/Clayman (views grouping)

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
@@ -29,7 +29,7 @@
 {% set viewItems = [] %}
 
 {% if title %}
-  {% if title|render matches '/<h\\d>/' %}
+  {% if title|render matches '/<\\/h\\d>/' %}
     {# Check to see if there is already a heading tag in the rendered title. #}
     {{ title }}
   {% else %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fixes empty heading on views grouping

## Need Review By (Date)
05/31

## Urgency
medium

## Steps to Test
1. Go to this page https://gender.suhumsci.loc/people/adrian-daub/fellows
2. Confirm there aren't empty heading on views grouping

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
