### PR TITLE
HSD8-000: Change automated dependency updates from Wednesday to Thursday

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
   dependency_updates:
     triggers:
       - schedule:
-          cron: "0 14 * * 3"
+          cron: "0 14 * * 4"
           filters:
             branches:
               only:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Deploys happen on Wednesday and automated dependency updates can force conflicts that need to resolved before a deployment
- The updates performed on a deploy Wednesday also do not get QA'd on stage at all before they are deployed to Production
- This PR moves these updates to Thursdays

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
