### PR TITLE
fix(SHS-5648): spotlight link to /media/<id> rendered as wrong URL

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.default.yml
@@ -13,9 +13,10 @@ dependencies:
     - paragraphs.paragraphs_type.hs_spotlight
   module:
     - ds
+    - empty_fields
     - field_formatter_class
     - hs_field_helpers
-    - link
+    - linkit
     - smart_trim
     - stanford_media
 third_party_settings:
@@ -79,6 +80,7 @@ content:
       view_mode: caption_credit
       link: false
       image_style: spotlight_portrait_responsive
+      remove_alt: false
     third_party_settings:
       field_formatter_class:
         class: ''
@@ -87,7 +89,7 @@ content:
     weight: 0
     region: image
   field_hs_spotlight_link:
-    type: link
+    type: linkit
     label: hidden
     settings:
       trim_length: 80
@@ -95,7 +97,10 @@ content:
       url_plain: false
       rel: '0'
       target: '0'
+      linkit_profile: default
     third_party_settings:
+      empty_fields:
+        handler: ''
       field_formatter_class:
         class: ''
       hs_field_helpers:

--- a/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_spotlight.preview.yml
@@ -18,7 +18,7 @@ dependencies:
     - field_formatter_class
     - hs_field_helpers
     - layout_builder
-    - link
+    - linkit
     - smart_trim
     - stanford_media
 third_party_settings:
@@ -96,7 +96,7 @@ content:
     weight: 0
     region: image
   field_hs_spotlight_link:
-    type: link
+    type: linkit
     label: hidden
     settings:
       trim_length: 80
@@ -104,6 +104,7 @@ content:
       url_plain: false
       rel: '0'
       target: '0'
+      linkit_profile: default
     third_party_settings:
       field_formatter_class:
         class: ''


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
https://fourkitchens.clickup.com/t/36718269/SHS-5648

## Need Review By (Date)
2024-06-07

## Urgency
medium

## Steps to Test
1. /node/add/hs_basic_page
2. Add a "Spotlight" component
3. In the "Link" field add a link to a media item (I think this LinkIt profile only allows documents, not images etc.)
4. Save and view the node
5. Hover over the link.  The path should be something like `/media/3246/download?inline=`.  Click it.   The browser will download the file.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
