### PR TITLE
Theme sass cleanup bug fixes

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/_main.scss
@@ -210,6 +210,7 @@ $fa-font-path: "../../humsci_basic/node_modules/@fortawesome/fontawesome-free/we
   'utilities/wysiwyg-text-area',
   'utilities/general',
   'utilities/lists',
+  'utilities/card-images',
   'utilities/raised-cards',
   'utilities/tables',
   'utilities/display-more-link-text',

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -51,4 +51,20 @@
       margin-bottom: hb-calculate-rems(14px);
     }
   }
+
+  @include hb-traditional {
+    .ht-pairing-warbler &:not(.hb-dark-pattern) {
+      a:not([class]),
+      a.mailto,
+      a[href^='mailto:'],
+      a.ext {
+        color: var(--palette--tertiary);
+
+        &:hover,
+        &:focus {
+          color: var(--palette--tertiary-darken-20);
+        }
+      }
+    }
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_local-footer.scss
@@ -52,6 +52,7 @@
     }
   }
 
+  // Warbler color pairing override.
   @include hb-traditional {
     .ht-pairing-warbler &:not(.hb-dark-pattern) {
       a:not([class]),

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_card-images.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_card-images.scss
@@ -1,0 +1,33 @@
+// Loops through the number of available columns (12). Classes determine the number
+// of columns that the image in cards will span.
+@mixin hb-image-sizes() {
+  @for $i from 1 through 12 {
+    &-#{$i}-of-12 {
+      .hb-card__graphics {
+        @include flex-column($i);
+      }
+
+      @include grid-media-min($hb-horizontal-card-breakpoint) {
+        .hb-card--horizontal:not(.hb-card--no-image) .hb-card__content {
+          @include flex-column(12 - $i);
+        }
+      }
+    }
+  }
+}
+
+.hb-card-image {
+  // Creates the base classes that are not tied to a media query
+  // Example: .hb-card-image-4-of-12
+  @include hb-image-sizes;
+
+  // Loops though the media query breakpoints to create responsive classes
+  // Example: .hb-card-image-md-4-of-12
+  @each $bp-key, $bp-value in $hb-grid-media {
+    @include grid-media-min($bp-key) {
+      &-#{$bp-key} {
+        @include hb-image-sizes;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add override for local footer link colors when using warbler color pairing
- Restore code that adds utility classes for resizing the card images to the desired grid column count

## Need Review By (Date)
06/26

## Urgency
high

## Steps to Test

### Footer link color

1. Set up `art` and `sociology` sites locally
2. Visit any page and confirm that the links in the footer match the live site ([Art Live Site](https://art.stanford.edu/), [Sociology Live Site](https://sociology.stanford.edu/))

### Card image size

1. Setup `politicalscience`, `economics` and `psychology` sites locally
2. Confirm that the people photos size in the following pages match the live site
    - https://politicalscience.suhumsci.loc/people/faculty ([Live Site](https://politicalscience.stanford.edu/people/faculty))
    - https://economics.suhumsci.loc/people/faculty ([Live Site](https://economics.stanford.edu/people/faculty))
    - https://psychology.suhumsci.loc/people/faculty ([Live Site](https://psychology.stanford.edu/people/faculty))

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
