### PR TITLE
SHS-5673: add color variables to wysiwyg css

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/ckeditor/imports.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/ckeditor/imports.scss
@@ -3,6 +3,7 @@
 // the dependencies and the files we need. See _main.scss and
 // _base.scss for reference.
 @charset 'UTF-8';
+@use "sass:map";
 
 // Here we add the path to Font Awesome. This is copied from _main.scss
 // and necessary for icons in CKEditor styles.
@@ -30,7 +31,7 @@ $px-only: true;
   "../tools/mixins.buttons", "../tools/mixins.menu-icons",
   "../tools/mixins.icons", "../tools/mixins.lists", "../tools/mixins.tables",
   "../tools/mixins.heros", "../tools/mixins.slick", "../tools/keyframes.text",
-  "../utilities/color-pairings", "../utilities/fonts", "../utilities/font-awesome", "../utilities/general", 
+  "../utilities/color-pairings", "../utilities/fonts", "../utilities/font-awesome", "../utilities/general",
   "../utilities/lists", "../utilities/raised-cards",
   "../utilities/tables", "../utilities/display-more-link-text",
   "../utilities/dark-pattern", "../utilities/caption-credit", "../utilities/media-embeds",
@@ -40,6 +41,26 @@ $px-only: true;
 
 // See _base.scss in basic theme. We only need the below for CKEditor.
 // Otherwise styles affect the entire admin UI.
+:root {
+  @include hb-themes(("colorful", "airy")) {
+    @each $color, $value in map.get($hc-colorful-pairings, $hb-colorful-default) {
+      --palette--#{$color}: #{$value};
+    }
+    @each $color, $value in $hc-colorful-globals {
+      --palette--#{$color}: #{$value};
+    }
+  }
+
+  @include hb-traditional {
+    @each $color, $value in map.get($ht-traditional-pairings, $hb-traditional-default) {
+      --palette--#{$color}: #{$value};
+    }
+    @each $color, $value in $ht-traditional-globals {
+      --palette--#{$color}: #{$value};
+    }
+  }
+}
+
 .ck-editor__main {
   @include font-smoothing;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.colorful-pairings.scss
@@ -1,5 +1,7 @@
 // COLORFUL
 
+$hb-colorful-default: 'cardinal';
+
 // Each color pairing has a palette of color swatches
 $hc-colorful-pairings: (
   'ocean': (

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -1,5 +1,7 @@
 // TRADITIONAL
 
+$hb-traditional-default: 'cardinal';
+
 // Each color pairing has a palette of color swatches
 $ht-traditional-pairings: (
   'cardinal': (


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add color variables to wysiwyg css

## Need Review By (Date)
06/28

## Urgency
high

## Steps to Test
- Create a Flexible page, add a Text Area and a Post card
- In both cases, confirm that the links, buttons and other styled elements are have the right "Cardinal" red color, both in the text area itself and in the "Styles" dropdown (see image below for an example in colorful)

<img width="1161" alt="Screenshot 2024-06-27 at 8 22 51 AM" src="https://github.com/SU-HSDO/suhumsci/assets/3496574/06b9c580-f04a-4655-86f1-7e2a4fbadccd">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
