### PR TITLE
SHS-5656: Upgrade decanter to current version

### DIFF
--- a/docroot/themes/humsci/humsci_basic/package-lock.json
+++ b/docroot/themes/humsci/humsci_basic/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bourbon": "^5.1.0",
-        "decanter": "^6.2.19",
+        "decanter": "^6.3.3",
         "dotenv": "^8.5.1"
       },
       "devDependencies": {
@@ -3789,13 +3789,23 @@
       }
     },
     "node_modules/decanter": {
-      "version": "6.2.19",
-      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.2.19.tgz",
-      "integrity": "sha512-cGsGZfJQfPY562lF0vNfR4dbjXi8JOmm2IqkA5CIDdvAVg2iQVgoMGVn6T/zvLZX330noZ49htL1Ild0DmVj+Q==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.3.3.tgz",
+      "integrity": "sha512-EubzQRguF79EDr4BHi4vQH6jSR3t1fIJNsjKv/cKDGmglF5JZpBmbraypdXDt3xkF64okCZcLViae2dN5Scl6w==",
+      "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^5.15.4",
-        "bourbon": "^5.1"
+        "@fortawesome/fontawesome-free": "^5.15",
+        "bourbon": "^6.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
+    },
+    "node_modules/decanter/node_modules/bourbon": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-6.0.0.tgz",
+      "integrity": "sha512-Skds0R1+GY3c1oBddh9BggYVq39Uo4ySvW33zttPk+4+nfGYpbZqwaDwENkbtV7PYhCk0ctTFkzfTNFv5365ag==",
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",

--- a/docroot/themes/humsci/humsci_basic/package.json
+++ b/docroot/themes/humsci/humsci_basic/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "bourbon": "^5.1.0",
-    "decanter": "^6.2.19",
+    "decanter": "^6.3.3",
     "dotenv": "^8.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
 Upgrade decanter to 6.3.3 version

## Need Review By (Date)
07/28

## Urgency
medium

## Steps to Test
1. This can be tested manually by going to pages with Quotes (in wysiwyg), Testimonials and Footer components on [Colorful](https://hs-colorful.suhumsci.loc/) and [Traditional](https://hs-traditional.suhumsci.loc/)
2. Compare those pages with the ones in stage or dev and check the components looks the same
3. Also go to Percy and confirm there aren't changes in any component
    - https://percy.io/da667d23/suhumsci/builds/34993186 (In this build, the local env didn't have the dark header active on Colorful, that's why it looks different)
    - https://percy.io/da667d23/suhumsci/builds/35011927 (In this build, the local env had the dark footer active on Traditional, that's why it looks different)


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
