### PR TITLE
SHS-5513: Colorband link text character limit

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_clr_bnd.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_clr_bnd.default.yml
@@ -30,7 +30,11 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 80
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
   field_hs_clr_bnd_ttl:
     type: string_textfield
     weight: 0

--- a/config/default/field.field.paragraph.hs_clr_bnd.field_hs_clr_bnd_lnk.yml
+++ b/config/default/field.field.paragraph.hs_clr_bnd.field_hs_clr_bnd_lnk.yml
@@ -12,7 +12,7 @@ field_name: field_hs_clr_bnd_lnk
 entity_type: paragraph
 bundle: hs_clr_bnd
 label: Link
-description: 'Both link text and URL are required if using the link option.'
+description: 'Both URL and Link text are required when adding a link. When displayed, the Link text is trimmed to 80 characters. '
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
In the `Colorband` component, update help text for the Link field:
`Both URL and Link text are required when adding a link. When displayed, the Link text is trimmed to 80 characters.`
And as the user typing, they see indication of how many characters they can use (with a "soft" limit)

## Need Review By (Date)
07/01

## Urgency
medium

## Steps to Test
1. On Colorful and Traditional, import configuration
2. Add a `Colorband` component
3. Confirm the help text for the Link field is `Both URL and Link text are required when adding a link. When displayed, the Link text is trimmed to 80 characters.` and that as you're typing, you can see indication of how many characters you can use

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207719828600729