### PR TITLE
SHS-5663: Editoria11y custom code cleanup

### DIFF
--- a/config/default/editoria11y.settings.yml
+++ b/config/default/editoria11y.settings.yml
@@ -1,16 +1,19 @@
 _core:
   default_config_hash: 1reSE9XKD6Hu5mLg0A3WHgvh_z0e3LMq6SDGafyVLDc
-content_root: '#main-content'
+content_root: ''
 assertiveness: smart
 no_load: ''
 ignore_all_if_absent: ''
 ignore_elements: '.hb-secondary-nav, .block--local-tasks'
 embedded_content_warning: ''
 download_links: ''
+link_strings_new_windows: ''
 ignore_link_strings: ''
+link_ignore_selector: 'svg.ext, svg.mailto, .link-purpose-text'
 hidden_handlers: ''
 ed11y_theme: sleekTheme
 shadow_components: ''
 disable_sync: false
 preserve_params: 'search,keys,page,language,language_content_entity'
-link_ignore_selector: 'svg.ext, svg.mailto, .link-purpose-text'
+redundant_prefix: ''
+custom_tests: 0

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/editoria11y/editoria11y.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/editoria11y/editoria11y.js
@@ -20,12 +20,15 @@ window.addEventListener('load', () => {
     mutationList.forEach((mutation) => {
       if (mutation.addedNodes.length && mutation.addedNodes[0].nodeName === 'ED11Y-ELEMENT-PANEL') {
         // Once we get the element, we update the styles to make the alert button text black.
-        const style = mutation.addedNodes[0].shadowRoot.querySelector('style');
-        if (style) {
-          style.textContent = `${style.textContent}
-          .shut.errors #toggle {
-            color: #000000;
-          }`;
+        const { shadowRoot } = mutation.addedNodes[0];
+        if (shadowRoot) {
+          const style = document.createElement('style');
+          style.textContent = `
+            .ed11y-shut.ed11y-errors #ed11y-toggle {
+              color: #000000;
+            }
+          `;
+          shadowRoot.appendChild(style);
         }
       }
     });


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Add correct configuration to make Edioria11y work as it was before and uptade the custom code (which it's still needed it, I tried adding that styles in scss but it didn't work) to update the color of the text.

## Need Review By (Date)
07/17

## Urgency
medium

## Steps to Test
1. Import configuration
2. Add a page with images without alternative text and headings inside subheadings to trigger editoria11y
3. Confirm editoria11y is working as expected and it now has the correct color text 

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207747954364746