### PR TITLE
SHS-5677: Wrong color link for a vertical linked card in Private Collection

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-linked-card.scss
@@ -138,11 +138,20 @@
     color: var(--palette--white);
     text-decoration: none;
 
+    // Warbler color pairing override.
+    .ht-pairing-warbler & {
+      color: var(--palette--white);
+    }
+
     &:hover,
     &:focus {
       color: var(--palette--white);
-
       background-image: none;
+
+      // Warbler color pairing override.
+      .ht-pairing-warbler & {
+        color: var(--palette--white);
+      }
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fix wrong color link for a vertical linked card in Private Collection

## Need Review By (Date)
07/17

## Urgency
medium

## Steps to Test
1. In hs_traditional, edit the theme settings and change the color pairing to "Warbler"
2. Edit https://hs-traditional.suhumsci.loc/components/collections-cards and change one of the links to an external link (starting with https://DOMAIN/)
3. Visit the page and confirm that both regular and external link text is white in both default and hover states

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207747954364742