### PR TITLE
SHS-5671: Bigger Preview Images in the Editing experience

### DIFF
--- a/config/default/core.entity_form_display.media.image.default.yml
+++ b/config/default/core.entity_form_display.media.image.default.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_image_caption
-    - image.style.thumbnail
+    - image.style.hs_small_scaled_200px
     - media.type.image
   module:
     - allowed_formats
@@ -25,7 +25,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: hs_small_scaled_200px
       preview_link: false
       offsets: '50,50'
     third_party_settings: {  }

--- a/config/default/core.entity_form_display.media.image.media_library.yml
+++ b/config/default/core.entity_form_display.media.image.media_library.yml
@@ -6,7 +6,7 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_image_caption
-    - image.style.thumbnail
+    - image.style.hs_small_scaled_200px
     - media.type.image
   module:
     - allowed_formats
@@ -24,7 +24,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: hs_small_scaled_200px
       preview_link: false
       offsets: '50,50'
     third_party_settings: {  }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Make bigger the preview images in the editing experience

## Need Review By (Date)
07/12

## Urgency
medium

## Steps to Test
1. On Colorful and Traditional
2. Go to media and add / edit an Image
3. Confirm the image preview is 2x wide than it was before (Before it was using Thumbnail (100px x 100px). Now t's currently using the `Small Scaled (200px)`)
4. Also, please try to test this by adding/editing an image when creating a page
5. Check the focus still works as expected

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206342478313685