### PR TITLE
SHS-5693: Vertical Button Card link color fix in warbler

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_buttons.scss
@@ -28,12 +28,6 @@ $buttons: (
     .hb-dark-inversion .views-element-container & {
       color: var(--palette--white);
     }
-
-    @include hb-traditional {
-      .ht-pairing-warbler & {
-        color: white !important;
-      }
-    }
   }
 }
 
@@ -70,12 +64,6 @@ button.more-link,
   .hb-dark-pattern &,
   .hb-dark-inversion .views-element-container & {
     color: var(--palette--white);
-  }
-
-  @include hb-traditional {
-    .ht-pairing-warbler &:hover {
-      color: white !important;
-    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-button-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_vertical-button-card.scss
@@ -43,6 +43,15 @@
       right: 0;
       border-width: 0;
       border-top-width: 2px;
+
+      // Warbler color pairing override.
+      .ht-pairing-warbler & {
+        color: var(--palette--secondary);
+
+        &:hover, &:focus {
+          color: var(--palette--white);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Fix color of links in vertical color cards when using warbler color pairing

## Need Review By (Date)
07/31

## Urgency
high

## Steps to Test
In a site with traditional theme:
1. Switch color pairing to warbler
2. Create a flexible page, add a collection with two postcards, both with the style field set to "Vertical Button Card", one with an internal link and the other with an external link.
3. Save the node and visit the page. Confirm that the card links look as expected for both internal and external links (see screenshots below)

### Default state

<img width="396" alt="Screenshot 2024-07-30 at 6 51 55 PM" src="https://github.com/user-attachments/assets/0dbb0a96-e36d-49e6-ac97-343893b090a2">

### hover and focus

<img width="407" alt="Screenshot 2024-07-30 at 6 52 03 PM" src="https://github.com/user-attachments/assets/fd5bf845-2391-45c0-a64d-4ceae85b9ac3">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
