### PR TITLE
HSD8-000: Revoke field_hs_hero_overlay_color permissions

### DIFF
--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -225,3 +225,23 @@ function hs_paragraph_types_update_10005() {
   // SHS-5661 - remove legacy Banner image(s) with text box Overlay Color field.
   FieldConfig::loadByName('paragraph', 'hs_hero_image', 'field_hs_hero_overlay_color')->delete();
 }
+
+/**
+ * Remove legacy field field_hs_hero_overlay_color permissions.
+ */
+function hs_paragraph_types_update_10006() {
+  $entityTypeManager = \Drupal::service('entity_type.manager');
+  $roles = $entityTypeManager->getStorage('user_role')->loadMultiple();
+  if ($roles) {
+    foreach (array_keys($roles) as $roleName) {
+      if ($roleName != 'administrator') {
+        user_role_revoke_permissions($roleName, [
+          'edit field_hs_hero_overlay_color',
+          'edit own field_hs_hero_overlay_color',
+          'view field_hs_hero_overlay_color',
+          'view own field_hs_hero_overlay_color',
+        ]);
+      }
+    }
+  }
+}

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -236,6 +236,7 @@ function hs_paragraph_types_update_10006() {
     foreach (array_keys($roles) as $roleName) {
       if ($roleName != 'administrator') {
         user_role_revoke_permissions($roleName, [
+          'create field_hs_hero_overlay_color',
           'edit field_hs_hero_overlay_color',
           'edit own field_hs_hero_overlay_color',
           'view field_hs_hero_overlay_color',


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
https://github.com/SU-HSDO/suhumsci/pull/1584 Removed the `field_hs_hero_overlay_color` field but did not revoke permissions in an update hook. It causes an error for #1542 when revoking media permissions in an update hook.
This adds the permission revoking in the update hook.
