### PR TITLE
SHS-5781: Regression: Color contrast issue on Warbler "load more" links

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
@@ -131,6 +131,21 @@
 
         }
 
+        .hs-button,
+        .hs-button--big {
+          &, &:hover, &:focus {
+            color: var(--palette--white);
+          }
+        }
+
+        .hs-secondary-button {
+          color: var(--palette--secondary);
+
+          &:hover, &:focus {
+            color: var(--palette--white);
+          }
+        }
+
         &.is-active {
           a {
             &, &:hover, &:focus {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
@@ -131,14 +131,14 @@
 
         }
 
-        .hs-button,
-        .hs-button--big {
+        .hs-button, .hs-button a,
+        .hs-button--big, .hs-button--big a {
           &, &:hover, &:focus {
             color: var(--palette--white);
           }
         }
 
-        .hs-secondary-button {
+        .hs-secondary-button, .hs-secondary-button a {
           color: var(--palette--secondary);
 
           &:hover, &:focus {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
 Fix regression color contrast issue on Warbler "load more" links

## Need Review By (Date)
08/23

## Urgency
medium

## Steps to Test
1. Change the `Color Pairing` to `Warbler`
2. Go to the following sites and pages:

- https://english.suhumsci.loc/research/british-literature (and other research areas on the English site)
- https://mcs.suhumsci.loc/events-news/news-archive (and other news archive pages on MCS)

3. Check the "load more" looks as expected in all states (normal, hover, focus)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208065790190049