### PR TITLE
FIX: Add correct class to Spotlights in views

### DIFF
--- a/docroot/modules/humsci/hs_layouts/hs_layouts.module
+++ b/docroot/modules/humsci/hs_layouts/hs_layouts.module
@@ -96,7 +96,11 @@ function hs_layouts_preprocess_container(&$variables) {
  * Implements hook_preprocess_preprocess_pattern_spotlight().
  */
 function hs_layouts_preprocess_pattern_spotlight(&$variables) {
-  $paragraph = $variables['context']->getProperty('entity');
+  $context = $variables['context'];
+  $paragraph = $context->getProperty('entity');
+  if ($context->isOfType('views_row')) {
+    $variables['attributes']->addClass('hb-spotlight--classic');
+  }
   if (
     $paragraph instanceof ParagraphInterface &&
     $paragraph->hasField('field_hs_spotlight_bg') &&


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Adds correct class to spotlight pattern elements when used in views

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
- Install `ccsre` site locally
- Visit https://ccsre.suhumsci.loc/academic-programs/asian-american-studies-program, scroll down to the "Spotlight" section
- Confirm that the spotlight component looks like expected (see screenshot below - or compare with the [live site](https://ccsre.stanford.edu/academic-programs/asian-american-studies-program))

<img width="908" alt="Screenshot 2024-08-19 at 2 22 09 PM" src="https://github.com/user-attachments/assets/5c91ea0f-5442-46f1-adf1-87b3f2cbf3c6">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
