### PR TITLE
Four Kitchens Release - Sprint 57

### DIFF
--- a/docroot/themes/humsci/humsci_basic/backstop/generate-backstop.js
+++ b/docroot/themes/humsci/humsci_basic/backstop/generate-backstop.js
@@ -5,7 +5,7 @@ const backstopFile = './backstop/backstop.json';
 const sites = ['hs-colorful', 'hs-traditional'];
 const colorPairings = {
   'hs-colorful': ['ocean', 'mountain', 'cardinal', 'lake', 'canyon', 'cliff'],
-  'hs-traditional': ['cardinal', 'bluejay', 'warbler', 'firefinch'],
+  'hs-traditional': ['cardinal', 'bluejay', 'warbler', 'firefinch', 'vireo'],
 };
 const testPages = [
   '/',

--- a/docroot/themes/humsci/humsci_basic/docs/color-pairings.md
+++ b/docroot/themes/humsci/humsci_basic/docs/color-pairings.md
@@ -25,3 +25,4 @@ A user can update the color pairing in the Drupal admin by going to Appearance /
 | Blue Jay | ht-pairing-bluejay   |
 | Warbler  | ht-pairing-warbler   |
 | Firefinch| ht-pairing-firefinch |
+| Vireo| ht-pairing-vireo |

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pager.scss
@@ -131,6 +131,21 @@
 
         }
 
+        .hs-button, .hs-button a,
+        .hs-button--big, .hs-button--big a {
+          &, &:hover, &:focus {
+            color: var(--palette--white);
+          }
+        }
+
+        .hs-secondary-button, .hs-secondary-button a {
+          color: var(--palette--secondary);
+
+          &:hover, &:focus {
+            color: var(--palette--white);
+          }
+        }
+
         &.is-active {
           a {
             &, &:hover, &:focus {

--- a/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/settings/_variables.traditional-pairings.scss
@@ -68,6 +68,22 @@ $ht-traditional-pairings: (
     'tertiary-darken-20': darken(#8c1515, 20%),
     'spotlight': #e0e0d1,
   ),
+  'vireo': (
+    'primary': #2b2e13,
+    'secondary': #63692b,
+    'tertiary': #666252,
+    'primary-hero-overlay': rgba(33, 36, 17, 0.8),
+    'primary-dark': #212411,
+    'secondary-active': #666252,
+    'secondary-highlight': #f4f5ec,
+    'secondary-highlight-darken': darken(#f4f5ec, 20%),
+    'secondary-darken-12': darken(#727a32, 12%),
+    'tertiary-highlight': #e9e7e0,
+    'tertiary-highlight-darken-10': darken(#e9e7e0, 10%),
+    'tertiary-reversed': #dbdcde,
+    'tertiary-darken-20': darken(#666252, 20%),
+    'spotlight': #e1dfd5,
+  ),
 );
 
 // Specific shades of gray that compliment traditional pairing palettes

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.icons.scss
@@ -70,6 +70,11 @@
         background-image: svg(hc-get-icons($icon, $icon-color));
       }
 
+      .ht-pairing-vireo & {
+        $icon-color: map-get(map-get($ht-traditional-pairings, 'vireo'), $color);
+        background-image: svg(hc-get-icons($icon, $icon-color));
+      }
+
     }
   }
 }

--- a/docroot/themes/humsci/humsci_traditional/theme-settings.php
+++ b/docroot/themes/humsci/humsci_traditional/theme-settings.php
@@ -31,6 +31,7 @@ function humsci_traditional_form_system_theme_settings_alter(array &$form, FormS
       'bluejay' => t('Blue Jay'),
       'warbler' => t('Warbler'),
       'firefinch' => t('Firefinch'),
+      'vireo' => t('Vireo'),
     ],
     '#default_value' => theme_get_setting('theme_color_pairing'),
   ];


### PR DESCRIPTION
# READY FOR REVIEW

## Summary

- SHS-5781 - Regression: Color contrast issue on Warbler "load more" links
- SHS-5691 - New color palette for Traditional

## Need Review By (Date)
08/28

## Urgency
medium

## Steps to Test

### SHS-5781

1. Change the `Color Pairing` to `Warbler`
2. Go to the following sites and pages:

- https://english.suhumsci.loc/research/british-literature (and other research areas on the English site)
- https://mcs.suhumsci.loc/events-news/news-archive (and other news archive pages on MCS)

3. Check the "load more" looks as expected in all states (normal, hover, focus)

### SHS-5691

1. Go to https://hs-traditional.suhumsci.loc/admin/appearance/settings/humsci_traditional
2. Check there's a new `Color Pairing` that is called 'Vireo' and select it
3. Explore the whole site (Views, Components, Homepage, Mixed pages)
4. Check everything looks good and similar to what's in the [design](https://www.figma.com/design/hOtD5MStjFIavUrWapHKHN/UX%2FDesign-Tickets-Work?node-id=1532-1468&t=dNtrb9yDISRi2SEc-4)
5. Please also check the footer and header looks as good when the dark variation is selected

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
