### PR TITLE
HSD8-000: FIX | Updated speaker bundle_key in events importer

### DIFF
--- a/config/default/migrate_plus.migration.hs_events_importer.yml
+++ b/config/default/migrate_plus.migration.hs_events_importer.yml
@@ -268,7 +268,7 @@ process:
       source: speaker
       plugin: hs_entity_generate
       entity_type: hs_entity
-      bundle_key: type
+      bundle_key: bundle
       bundle: event_collections__speaker
       value_key: label
       values:


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Updated the speaker `bundle_key` in events importer from "type" to "bundle" to work with post-ECK `hs_entity` entity.