### PR TITLE
SHS-5791: Update Stanford University brand bar link

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
@@ -1,5 +1,5 @@
 <section class="su-brand-bar {{ modifier_class }}">
   <div class="su-brand-bar__container hb-page-width">
-    <a class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a>
+    <a class="su-brand-bar__logo" href=" https://www.stanford.edu ">Stanford University</a>
   </div>
 </section>

--- a/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/brandbar.html.twig
@@ -1,5 +1,5 @@
 <section class="su-brand-bar {{ modifier_class }}">
   <div class="su-brand-bar__container hb-page-width">
-    <a class="su-brand-bar__logo" href=" https://www.stanford.edu ">Stanford University</a>
+    <a class="su-brand-bar__logo" href="https://www.stanford.edu">Stanford University</a>
   </div>
 </section>


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Update Stanford University brand bar link

## Need Review By (Date)
09/04

## Urgency
medium

## Steps to Test
1.  Visit the Tugboat site
2. Confirm the link of the brand bar (at the top of the page) is now https://www.stanford.edu/

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208231439272377