### PR TITLE
SHS-5790: After using "Load more", the next row of vertical cards do not have top padding

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
@@ -37,7 +37,7 @@
 
   &:not(:first-child) {
     .views-infinite-scroll-content-wrapper & {
-      margin-top: hb-spacing-width();
+      padding-top: hb-spacing-width();
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.grid.scss
@@ -34,4 +34,11 @@
       margin-bottom: 0;
     }
   }
+
+  &:not(:first-child) {
+    .views-infinite-scroll-content-wrapper & {
+      margin-top: hb-spacing-width();
+    }
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fix missing of top padding after loading more vertical cards

## Need Review By (Date)
09/24

## Urgency
medium

## Steps to Test
1. Go to this page https://hs-colorful-hri5tew3xrtex79ufry7xaqwxcoqlfqi.tugboatqa.com/default-views/people
2. Click the "load more" button and check when there's a new row of vertical cards, there's enough padding between them
3. To test it more in other sites, for a view on a grid that uses vertical card postcards:
    a) Edit the view
    b) Set the pager to infinite scroll set to a lower number like 6
    c) It can be made a bit more obvious if the view are using "hb-raised-cards hb-raised-cards--uniform-height"
    d) Save
    e) Go to the page and click the "load more" button
    f) The result should be the same

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208363584779970