### PR TITLE
SHS-5817: Always render caption/credit on banner and spotlight images

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_hero_image.slideshow_slide.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_hero_image.slideshow_slide.yml
@@ -30,7 +30,7 @@ content:
     type: media_responsive_image_formatter
     label: hidden
     settings:
-      view_mode: default
+      view_mode: caption_credit
       link: false
       image_style: hero_with_text
       remove_alt: 0


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Use correct image view mode in `slideshow_slide` view mode of `hs_hero_image` component

## Need Review By (Date)
09/25

## Urgency
medium

## Steps to Test

Visit https://pr1631-5g8zxsjs9cwf9nks7cu1i4sr8uzidhpo.tugboatqa.com/captioncredit-test for a quick check or run the following steps manually:

1. Create a flexible page. Add a "Banner image(s) with text box" component in the "Full-width region" field.
2. Add a slide with an image and leave the rest of the fields empty. Make sure that the image has a caption.
3. Save the node. The caption should be visible in the bottom right corner.
4. Edit the component and add some text to the slide. Save the node and confirm that the caption is still visible.

**Note**: the "Banner image(s) with text box" component was the only one with problems, but if you want to confirm that the caption is visible in all banner components, you can repeat the text with all the component types that can be added in the "Full-width region" field.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
