### PR TITLE
SHS-5872: Implementation light accordion bg and tables

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
@@ -2,8 +2,6 @@
 .hb-table-pattern {
   @include table;
 
-  box-sizing: border-box;
-
   @include grid-media-min('md') {
     display: table;
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_pattern.table-pattern.scss
@@ -2,6 +2,8 @@
 .hb-table-pattern {
   @include table;
 
+  box-sizing: border-box;
+
   @include grid-media-min('md') {
     display: table;
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/elements/_tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/elements/_tables.scss
@@ -1,6 +1,7 @@
 .hb-table-wrap {
   margin: auto;
   overflow-x: auto;
+  box-sizing: border-box;
 
   &:not(:last-child) {
     margin-bottom: hb-spacing-width();

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
@@ -279,18 +279,3 @@ details.hb-accordion-light {
 .hb-clear {
   clear: both;
 }
-
-// Fix tables in accordions
-.ptype-hs-accordion details {
-  &[open] {
-    .revealed-details {
-      .hb-table-wrap {
-        overflow-x: hidden;
-      }
-
-      .hb-table-pattern {
-        width: auto;
-      }
-    }
-  }
-}

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
@@ -271,7 +271,19 @@ details.hb-accordion-light {
         border-top: none;
         border-color: var(--palette--secondary);
       }
+    }
+  }
+}
 
+// Utility class for clearing floats
+.hb-clear {
+  clear: both;
+}
+
+// Fix tables in accordions
+.ptype-hs-accordion details {
+  &[open] {
+    .revealed-details {
       .hb-table-wrap {
         overflow-x: hidden;
       }
@@ -281,9 +293,4 @@ details.hb-accordion-light {
       }
     }
   }
-}
-
-// Utility class for clearing floats
-.hb-clear {
-  clear: both;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_general.scss
@@ -258,18 +258,26 @@ details.hb-accordion-light {
 
     .revealed-details {
       @include hb-colorful {
-        border: none;
-        border-left: $hb-thin-border;
+        background-color: var(--palette--white);
+        border: $hb-thin-border;
         border-width: hb-calculate-rems(2px);
-        border-left-color: var(--palette--secondary);
+        border-color: var(--palette--secondary);
+        border-top: none;
       }
 
       @include hb-traditional {
         background-color: var(--palette--white);
-
         border: $hb-thin-border;
         border-top: none;
         border-color: var(--palette--secondary);
+      }
+
+      .hb-table-wrap {
+        overflow-x: hidden;
+      }
+
+      .hb-table-pattern {
+        width: auto;
       }
     }
   }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
New implementation to light accordion in Colorful and fix table

## Need Review By (Date)
10/09

## Urgency
medium

## Steps to Test
1. Go to https://hs-colorful-0nw8b62tacchew4wasu5nelijddayriq.tugboatqa.com/accordions/accordions-light
2. When open, verify the `Light Accordion` now has a border around the content and also the background it's white. Check the [design](https://www.figma.com/file/hOtD5MStjFIavUrWapHKHN?type=design&node-id=5668%3A501&mode=design)
3. Please, verify the rest of `Accordions` with a table and confirm that the table it's not wider than the container anymore. Test this in [Traditional](https://hs-traditional-0nw8b62tacchew4wasu5nelijddayriq.tugboatqa.com/components/accordions) too.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208442244571836