### PR TITLE
HOTFIX: Media library images styles

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/templates/field/field--image.html.twig
+++ b/docroot/themes/humsci/su_humsci_gin_admin/templates/field/field--image.html.twig
@@ -1,0 +1,2 @@
+{% set attributes = attributes.addClass(['field', 'field--image']) %}
+{% extends '@humsci_basic/field/field.html.twig' %}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add template for image fields in `su_humsci_gin_admin` theme, adding the correct classes to the fields. This is needed to correctly display the images in the media library.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Create a Flexible Page. Add any component with an image (for example a postcard)
2. Confirm that the images in the media library look as expected

<img width="1103" alt="Screenshot 2024-10-15 at 8 11 43 PM" src="https://github.com/user-attachments/assets/7048b16f-d2d5-4d74-bffa-d6882fcf91e6">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
