### PR TITLE
SHS-5880: Changing <h3> tags in grouping titles to <h2>

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-grid.html.twig
@@ -33,7 +33,7 @@
     {# Check to see if there is already a heading tag in the rendered title. #}
     {{ title }}
   {% else %}
-    <h3>{{ title }}</h3>
+    <h2>{{ title }}</h2>
   {% endif %}
 {% endif %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-unformatted.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-unformatted.html.twig
@@ -21,7 +21,7 @@
     {# Check to see if there is already a heading tag in the rendered title. #}
     {{ title }}
   {% else %}
-    <h3>{{ title }}</h3>
+    <h2>{{ title }}</h2>
   {% endif %}
   {# Wrap the rows when a title is present (grouped views). #}
   <div class="views-rows">


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Update views templates to use `h2` instead of `h3` as the default heading level for the grouping title (it's more common to need `h2` in HSDP sites)

## Need Review By (Date)
10/23

## Urgency
medium

## Steps to Test
- Log in into the [Tugboat Colorful](https://hs-colorful-yezvprvribbtodedav6ugxsr4kklwn2c.tugboatqa.com/user/login) site (you can use any other site that has a view with grouped results, the fix is independent of the theme)
- Visit the [Publications default views](https://hs-colorful-yezvprvribbtodedav6ugxsr4kklwn2c.tugboatqa.com/default-views/publications) page. Scroll down to the "Link URL or Doc Publication List" view.
- Confirm that the grouping titles (the years) are being displayed using a `<h2>` title
    
    <img width="998" alt="Screenshot 2024-10-22 at 6 53 04 PM" src="https://github.com/user-attachments/assets/7216e05b-c096-4922-9ea6-c203ab99ca3b">

- [Edit the view](https://hs-colorful-yezvprvribbtodedav6ugxsr4kklwn2c.tugboatqa.com/admin/structure/views/view/hs_default_publications/edit/block_1?destination=/node/2911). In the "Fields" section, click on the "Content: Publication Year [hidden]" item. Search for the "Rewrite Results" section, check the "Override the output of this field with custom text" option and add the following text:
    
    ```
    <h3>{{ field_hs_publication_year }}</h3>
    ```

    <img width="1078" alt="Screenshot 2024-10-22 at 6 59 41 PM" src="https://github.com/user-attachments/assets/cb3565f1-7c6d-4093-988e-2dac75eddb7f">

- Click on "Apply (This display)" at the bottom of the dialog and then save the view. 
- Visit the [Publications default views](https://hs-colorful-yezvprvribbtodedav6ugxsr4kklwn2c.tugboatqa.com/default-views/publications) page again and confirm that the grouping title is now an `<h3>`.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208611273175018