### PR TITLE
SHS-5914: Update new Collection background color name from "Light" to "Vibrant"

### DIFF
--- a/config/default/field.storage.paragraph.field_bg_color.yml
+++ b/config/default/field.storage.paragraph.field_bg_color.yml
@@ -19,7 +19,7 @@ settings:
       label: Gray
     -
       value: light
-      label: Light
+      label: Vibrant
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Rename "Light" option to "Vibrant" in the Collection component background color field

## Need Review By (Date)
11/06

## Urgency
medium

## Steps to Test
1. Log in to the [Tugboat test site](https://pr1669-3otyxy8mawyfhlwomfj4jrb0rziib8us.tugboatqa.com/user/login)
2. Create a Flexible Page. Add a Collection component
3. Confirm that the "Light" option for the "Background Color" field is not present anymore and instead there's a new "Vibrant" option
4. Configure the Collection to use the "Vibrant" background color, add one or more components inside it and save the page. Confirm that the collection looks as expected.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208642172130786