### PR TITLE
SHS-5796: Remove colorful's half-background link style, use trad's style instead

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_block-layout.scss
@@ -52,7 +52,7 @@
   word-break: break-all;
 
   a {
-    @include hb-link--inline($icon: false);
+    @include hb-link--inline;
   }
 
   [class^="fa-"] {

--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_linked-cards.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_linked-cards.scss
@@ -17,7 +17,7 @@
 
     @include hb-colorful {
       .hb-raised-cards & {
-        border-color: var(--palette--secondary-darken-12);
+        text-decoration-color: var(--palette--secondary-darken-12);
       }
     }
 
@@ -29,18 +29,7 @@
     .hb-card__title a,
     .hb-card__title a > div > * {
       color: var(--palette--black);
-
-      @include hb-themes(('airy', 'colorful')) {
-        border-bottom-color: var(--palette--tertiary-highlight-darken-10);
-        transition-delay: 0s, 0s;
-        box-shadow: inset 0 hb-calculate-rems(-14px) 0 var(--palette--tertiary-highlight);
-      }
-
-      @include hb-traditional {
-        color: var(--palette--black);
-        background-image: none;
-        text-decoration-color: var(--palette--primary);
-      }
+      text-decoration-color: var(--palette--primary);
     }
   }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.general.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.general.scss
@@ -256,24 +256,6 @@
   border-color: var(--palette--gray);
 }
 
-// Used for link typography mixins across all themes
-// both with and without icons
-@mixin hb-link-background-image($icon, $icon-width, $icon-position) {
-  // For links without an icon
-  // Color Pairing Custom Variable
-  background-image: linear-gradient(to top, transparent 50%, var(--palette--tertiary-highlight) 50%);
-
-  // For links with an icon
-  // Changes the value passed into background-image to
-  // create space for the external link space to exist
-  @if $icon {
-    $icon-width: calc(100% - #{$icon-width});
-
-    // Color Pairing Custom Variable
-    background-image: linear-gradient(to $icon-position, var(--palette--tertiary-highlight) $icon-width, transparent $icon-width);
-  }
-}
-
 @mixin hb-well {
   @include hb-themes(('colorful', 'airy')) {
     background-color: var(--palette--gray-light);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.links.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.links.scss
@@ -69,24 +69,17 @@
 
 // Link style for main content that is not a heading
 // The default $icon-width is set for the width of external link icons
-@mixin hb-link--inline($icon: false, $icon-width: 16px, $icon-position: right) {
+@mixin hb-link--inline {
   // no font size by default
   color: var(--palette--tertiary);
 
   @include hb-themes(('colorful', 'airy')) {
-    @include hb-link-background-image($icon, $icon-width, $icon-position);
-    background-size: 100% 200%;
-    background-position-y: -102%;
-    background-repeat: no-repeat;
-
     .hc-pairing-ocean .hb-well & {
       color: var(--palette--primary);
     }
   }
 
   @include hb-traditional {
-    background-image: none;
-
     // Warbler color pairing override.
     .ht-pairing-warbler & {
       color: var(--palette--secondary);
@@ -97,10 +90,6 @@
   &:focus {
     color: var(--palette--tertiary-darken-20);
 
-    @include hb-themes(('colorful', 'airy')) {
-      background-position-y: -50%;
-    }
-
     @include hb-traditional {
       // Warbler color pairing override.
       .ht-pairing-warbler & {
@@ -110,12 +99,9 @@
   }
 
   .hb-local-footer & {
-    background-image: none;
-
     &:hover,
     &:focus {
       color: var(--palette--tertiary-darken-20);
-      background-image: none;
     }
   }
 
@@ -144,7 +130,6 @@
         color: var(--palette--tertiary-highlight);
         border-bottom-color: var(--palette--tertiary-highlight);
         box-shadow: none;
-        background-position-y: bottom;
       }
 
       @include hb-traditional {
@@ -419,10 +404,6 @@
 
   &:hover,
   &:focus {
-    @include hb-themes(('colorful', 'airy')) {
-      @include hb-link-background-image(true, 0.9em, left);
-    }
-
     .hb-local-footer.hb-dark-pattern &::before {
       @include hb-colorful {
         color: var(--palette--gray-medium);

--- a/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.links.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/tools/_mixins.links.scss
@@ -3,39 +3,18 @@
   // no font size by default
   color: var(--palette--black);
   font-weight: hb-theme-font-weight(semibold);
+  text-decoration: underline;
+  transition: hb-transition(text-decoration-color);
+  text-decoration-color: var(--palette--gray-medium);
 
-  @include hb-themes(('colorful', 'airy')) {
-    border-bottom: 2px solid var(--palette--gray-medium);
-    margin-bottom: 0.0625em;
-    text-decoration: none;
-    transition: box-shadow 100ms 0s, border-bottom-color 0s 100ms;
+  &:hover,
+  &:focus {
+    color: var(--palette--black);
+    text-decoration-color: var(--palette--primary);
 
-    &:hover,
-    &:focus {
-      color: var(--palette--black);
-      transition-delay: 0s, 0s;
-      border-bottom-color: var(--palette--tertiary-highlight-darken-10);
-      box-shadow: inset 0 hb-calculate-rems(-14px) 0 var(--palette--tertiary-highlight);
-
-      .hb-dark-pattern &,
-      .hb-dark-inversion .views-element-container & {
-        border-bottom-color: var(--palette--tertiary-highlight);
-        box-shadow: none;
-        background-position-y: bottom;
-      }
-    }
-  }
-
-  @include hb-traditional {
-    text-decoration: underline;
-    transition: hb-transition(text-decoration-color);
-    text-decoration-color: var(--palette--gray-medium);
-
-    &:hover,
-    &:focus {
-      color: var(--palette--black);
-      background-image: none;
-      text-decoration-color: var(--palette--primary);
+    .hb-dark-pattern &,
+    .hb-dark-inversion .views-element-container & {
+      border-bottom-color: var(--palette--tertiary-highlight);
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/utilities/_wysiwyg-text-area.scss
@@ -310,7 +310,7 @@ blockquote:nth-child(n) {
 a[href*="//"].hs-external-link,
 .hs-external-link a[href*="//"]
 {
-  @include hb-link--inline($icon: true);
+  @include hb-link--inline;
   @include hb-external-link-icon;
 
   .hb-dark-pattern.hb-local-footer & {
@@ -346,10 +346,6 @@ a.private-link,
 .private-link a {
   @include hb-link--inline;
   color: var(--palette--secondary);
-
-  @include hb-themes(('colorful', 'airy')) {
-    @include hb-link-background-image(true, 18px, left);
-  }
 
   .hb-dark-pattern.hb-local-footer & {
     @include hb-colorful {
@@ -404,10 +400,6 @@ a.private-link,
 .hs-mailto-link a,
 a.hs-mailto-link {
   @include hb-fa-mailto-icon;
-
-  @include hb-themes(('colorful', 'airy')) {
-    @include hb-link-background-image(true, 22px, right);
-  }
 
   // The font awesome icon is hidden by default in themes, this shows it
   .fa-mailto {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Remove colorful's half-background link style and use traditional style instead

## Need Review By (Date)
11/05

## Urgency
medium

## Steps to Test
1. Visit https://hs-colorful-ycq1d7e1inzqa0ydu1lcdisx0hwtspbq.tugboatqa.com/components/text-area-typography
2. Hover any kind of link and confirm that they don't have the half-background style anymore. They should look similar to the ones in the traditional theme

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
