### PR TITLE
SHS-5885: Remove "Admin Login Path" module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "drupal/acquia_purge": "^1.2",
         "drupal/address": "^2.0",
         "drupal/addtocal": "^3.0",
-        "drupal/admin_login_path": "^2.0",
         "drupal/admin_toolbar": "^3.0",
         "drupal/allowed_formats": "^3.0",
         "drupal/asset_injector": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -2051,63 +2051,6 @@
             }
         },
         {
-            "name": "drupal/admin_login_path",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/admin_login_path.git",
-                "reference": "2.0.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/admin_login_path-2.0.1.zip",
-                "reference": "2.0.1",
-                "shasum": "cc1d4980ce56b4a8d7f954e143922c9dfb1a176b"
-            },
-            "require": {
-                "drupal/core": "^8.9 || ^9 || ^10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.0.1",
-                    "datestamp": "1663526534",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Brian Wald",
-                    "homepage": "https://www.drupal.org/u/bcwald"
-                },
-                {
-                    "name": "Devin Carlson",
-                    "homepage": "https://www.drupal.org/u/devin-carlson"
-                },
-                {
-                    "name": "Ben Voynick",
-                    "homepage": "https://www.drupal.org/u/bvoynick"
-                },
-                {
-                    "name": "See other contributors",
-                    "homepage": "https://www.drupal.org/node/2894919/committers"
-                }
-            ],
-            "description": "A simple module that routes the login pages to use the admin (theme) path.",
-            "homepage": "https://www.drupal.org/project/admin_login_path",
-            "support": {
-                "source": "http://git.drupal.org/project/admin_login_path.git",
-                "issues": "https://www.drupal.org/project/issues/admin_login_path"
-            }
-        },
-        {
             "name": "drupal/admin_toolbar",
             "version": "3.5.0",
             "source": {


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Remove `admin_login_path` from project dependencies

## Need Review By (Date)
11/06

## Urgency
medium

## Steps to Test
1. Log in to the [Tugboat test site](https://pr1674-7f0capyn8pgsllm1hfmwc4ffftug5ovg.tugboatqa.com/user/login)
2. Visit the [modules admin page](https://pr1674-7f0capyn8pgsllm1hfmwc4ffftug5ovg.tugboatqa.com/admin/modules), search for "admin login path". Confirm that the module is not available anymore.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208664616401062