### PR TITLE
SHS-5899: BUG | Fix placement of button in exposed filters

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/components/_views-exposed-form.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/components/_views-exposed-form.scss
@@ -20,11 +20,10 @@
 
   .form-actions {
     display: flex;
-    align-self: flex-end;
-    margin-bottom: 0;
+    align-self: flex-start;
 
-    @include grid-media-min('md') {
-      margin-bottom: hb-spacing-width('xs');
+    @include grid-media-min('lg') {
+      margin-top: hb-calculate-rems(34px);
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Fix placement of button in exposed filters

## Need Review By (Date)
11/06

## Urgency
medium

## Steps to Test
1. Go to https://english.suhumsci.loc/people/lecturers or any site with exposed filters
2. Verify that the placement of the Apply button and Reset link are not affected by the dropdown option selected. They should stay vertically aligned with the top.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208693055424776