### PR TITLE
HSD8-000: Remove field_paragraph_style permissions

### DIFF
--- a/config/default/user.role.anonymous.yml
+++ b/config/default/user.role.anonymous.yml
@@ -20,7 +20,6 @@ permissions:
   - 'view field_hs_accordion_views'
   - 'view field_hs_text_area_bg_color'
   - 'view field_media_embeddable_code'
-  - 'view field_paragraph_style'
   - 'view humsci entity'
   - 'view media'
   - 'view own field_hs_accordion_views'

--- a/config/default/user.role.authenticated.yml
+++ b/config/default/user.role.authenticated.yml
@@ -32,7 +32,6 @@ permissions:
   - 'view field_hs_accordion_views'
   - 'view field_hs_text_area_bg_color'
   - 'view field_media_embeddable_code'
-  - 'view field_paragraph_style'
   - 'view humsci entity'
   - 'view media'
   - 'view own field_hs_accordion_views'

--- a/config/default/user.role.contributor.yml
+++ b/config/default/user.role.contributor.yml
@@ -23,7 +23,6 @@ dependencies:
     - contextual
     - dropzonejs
     - entity_usage
-    - field_permissions
     - file
     - filter
     - help
@@ -51,7 +50,6 @@ permissions:
   - 'access toolbar'
   - 'administer main menu items'
   - 'create embeddable media'
-  - 'create field_paragraph_style'
   - 'create file media'
   - 'create hs_basic_page content'
   - 'create hs_course content'
@@ -82,9 +80,7 @@ permissions:
   - 'edit any image media'
   - 'edit any video media'
   - 'edit behavior plugin settings'
-  - 'edit field_paragraph_style'
   - 'edit humsci entity'
-  - 'edit own field_paragraph_style'
   - 'edit own file media'
   - 'edit own hs_basic_page content'
   - 'edit own hs_course content'
@@ -114,7 +110,6 @@ permissions:
   - 'use text format basic_html'
   - 'use text format minimal_html'
   - 'use text format minimal_html_with_styles'
-  - 'view field_paragraph_style'
   - 'view hs_basic_page revisions'
   - 'view hs_course revisions'
   - 'view hs_event revisions'
@@ -123,7 +118,6 @@ permissions:
   - 'view hs_person revisions'
   - 'view hs_publications revisions'
   - 'view hs_research revisions'
-  - 'view own field_paragraph_style'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'

--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -40,7 +40,6 @@ dependencies:
     - editoria11y
     - entity_usage
     - entityqueue
-    - field_permissions
     - file
     - filter
     - help
@@ -82,7 +81,6 @@ permissions:
   - 'assign intranet_viewer role'
   - 'assign site_manager role'
   - 'create embeddable media'
-  - 'create field_paragraph_style'
   - 'create file media'
   - 'create hs_basic_block block content'
   - 'create hs_basic_page content'
@@ -163,9 +161,7 @@ permissions:
   - 'edit any image media'
   - 'edit any video media'
   - 'edit behavior plugin settings'
-  - 'edit field_paragraph_style'
   - 'edit humsci entity'
-  - 'edit own field_paragraph_style'
   - 'edit own file media'
   - 'edit own hs_basic_page content'
   - 'edit own hs_course content'
@@ -223,7 +219,6 @@ permissions:
   - 'view 404 reports'
   - 'view any unpublished content'
   - 'view editoria11y checker'
-  - 'view field_paragraph_style'
   - 'view hs_basic_page revisions'
   - 'view hs_course revisions'
   - 'view hs_event revisions'
@@ -233,7 +228,6 @@ permissions:
   - 'view hs_private_page revisions'
   - 'view hs_publications revisions'
   - 'view hs_research revisions'
-  - 'view own field_paragraph_style'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view restricted block content'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1000,3 +1000,29 @@ function su_humsci_profile_update_9712() {
 function su_humsci_profile_update_9713() {
   \Drupal::service('module_installer')->uninstall(['admin_login_path']);
 }
+
+/**
+ * Remove field_paragraph_style permissions.
+ */
+function su_humsci_profile_update_9714() {
+  $entity_type_manager = \Drupal::service('entity_type.manager');
+  $roles = $entity_type_manager->getStorage('user_role')->loadMultiple();
+  if (!$roles) {
+    return;
+  }
+
+  $permissions = [
+    'create field_paragraph_style',
+    'edit field_paragraph_style',
+    'edit own field_paragraph_style',
+    'view field_paragraph_style',
+    'view own field_paragraph_style',
+  ];
+
+  foreach ($roles as $role) {
+    foreach ($permissions as $permission) {
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- The field_paragraph_style was removed in the latest release (11.5.0 #1622) but the permissions were not removed. This removes the permissions.
- Credit to @codechefmarc for discovery and introducing initial fix here: https://github.com/SU-HSDO/suhumsci/pull/1662/commits/e219687205ac9281be9a0b19fe1def0a11a43574

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
