### PR TITLE
HSD8-1686: Enable single_content_sync module for administrators

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -87,6 +87,7 @@ module:
   honeypot: 0
   hook_event_dispatcher: 0
   hs_actions: 0
+  hs_admin: 0
   hs_basic_page: 0
   hs_basic_page_display: 0
   hs_blocks: 0
@@ -211,6 +212,7 @@ module:
   shield: 0
   shortcut: 0
   shortcut_menu: 0
+  single_content_sync: 0
   slick: 0
   slick_paragraphs: 0
   smart_date: 0
@@ -270,15 +272,14 @@ module:
   views: 10
   paragraphs: 11
   paragraphs_ee: 15
-  hs_admin: 1000
   su_humsci_profile: 1000
 theme:
+  stable9: 0
   stanford_basic: 0
-  humsci_basic: 0
-  humsci_traditional: 0
-  humsci_colorful: 0
   claro: 0
+  humsci_basic: 0
+  humsci_colorful: 0
+  humsci_traditional: 0
   gin: 0
   su_humsci_gin_admin: 0
-  stable9: 0
 profile: su_humsci_profile

--- a/config/default/single_content_sync.settings.yml
+++ b/config/default/single_content_sync.settings.yml
@@ -1,0 +1,16 @@
+_core:
+  default_config_hash: F--1EKAki5zF_jdKTc4ZLmgN89WJ2SDrMOkwbqj06-Y
+allowed_entity_types:
+  hs_entity: {  }
+  media: {  }
+  node:
+    - hs_basic_page
+    - hs_course
+    - hs_event
+    - hs_event_series
+    - hs_news
+    - hs_person
+    - hs_publications
+    - hs_research
+  taxonomy_term: {  }
+site_uuid_check: true

--- a/config/default/system.action.content_bulk_export.yml
+++ b/config/default/system.action.content_bulk_export.yml
@@ -1,0 +1,15 @@
+uuid: f79dd211-e67b-400d-9414-054edc87a75b
+langcode: en
+status: true
+dependencies:
+  module:
+    - single_content_sync
+_core:
+  default_config_hash: h64R0kZquzABmTQ3k2X7VbJJvANnn0p3ubKUYNtQj8s
+id: content_bulk_export
+label: 'Export content'
+type: node
+plugin: content_bulk_export
+configuration:
+  assets: true
+  translation: true


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Enable single_content_sync module for administrators
[HSD8-1686](https://stanfordits.atlassian.net/browse/HSD8-1686): A solution to copy a piece of content from one HSDP site to another



[HSD8-1686]: https://stanfordits.atlassian.net/browse/HSD8-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ