### PR TITLE
Update Lando config to work with PHP 8.3

### DIFF
--- a/lando/default.lando.yml
+++ b/lando/default.lando.yml
@@ -2,8 +2,8 @@ name: suhumsci
 recipe: drupal9
 config:
   webroot: docroot
-  php: '8.2'
-  composer_version: '2.4.0'
+  php: '8.3'
+  composer_version: '2.8.2'
   # M1 MacOS specific settings
   xdebug: false
   index: false


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Updates the default Lando config file to work with the latest 11.5.2 release branch changes with PHP 8.3 and latest Composer.

## Need Review By (Date)
2024-11-18

## Urgency
High

## Steps to Test
1. Use this branch (branched off of `11.5.2-release`)
2. Follow the Lando steps here: https://github.com/SU-HSDO/suhumsci/tree/develop/lando
3. Verify that local builds work correctly and there are no errors

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
