### PR TITLE
SHS-5912: Improve link styles preview

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -186,3 +186,15 @@ body.gin--edit-form .views-exposed-form .select-preact button svg {
 .paragraphs-add-dialog .category-title {
   display: none;
 }
+
+.ck.ck-style-panel .ck-style-grid {
+  grid-template-columns: 1fr !important;
+}
+
+.ck.ck-style-panel .ck-style-grid .ck-style-grid__button {
+  width: 384px !important;
+}
+
+.ck-powered-by-balloon {
+  z-index: 1000 !important;
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Change the layout of the CKEditor "Styles" dropdown, to show only one item per row and improve legibility of the preview.

## Need Review By (Date)
12/04

## Urgency
medium

## Steps to Test
1. Create a Flexible Page
2. In the text area component, add some text, headings, links, etc.
3. Try to apply some custom styles using the "Style" dropdown menu. Confirm that you see only one element per row and that the previews are legible. Confirm that you can apply and remove styles as expected.

<img width="434" alt="Screenshot 2024-11-20 at 6 09 05 PM" src="https://github.com/user-attachments/assets/0f88195e-9911-4790-979a-5a86fe9f7623">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208819259769278