### PR TITLE
SHS-5911: Shortcuts Menu third level indicator fix

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -50,7 +50,7 @@ html:not(.gin--dark-mode) .user-logged-in[data-gin-accent="custom"] {
   display: block;
   position: absolute;
   background-color: var(--gin-color-disabled);
-  mask-image: url('../../../contrib/gin/dist/media/sprite.svg#handle-view');
+  mask-image: url('/themes/contrib/gin/dist/media/sprite.svg#handle-view');
   mask-position: center center;
   mask-repeat: no-repeat;
   mask-size: 14px 14px;


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Use absolute path for image URL, to prevent error when Drupal aggregates the CSS

## Need Review By (Date)
12/11

## Urgency
medium

## Steps to Test
1. Log into the [test site](https://hs-colorful-nkzpmrh25a7zdguhg7efel67lbrqvr84.tugboatqa.com/user/login)
2. Visit a page that uses the admin menu (for example the [Manage Content](https://hs-colorful-nkzpmrh25a7zdguhg7efel67lbrqvr84.tugboatqa.com/admin/content) page)
3. Confirm that the arrow that indicates that there's a third level submenu in the Shortcuts menu is present (Site Actions > Edit Main Menu - see screenshot below for details)
4. Repeat the test for a page that uses the user-facing theme (for example the [homepage](https://hs-colorful-nkzpmrh25a7zdguhg7efel67lbrqvr84.tugboatqa.com/) - Just to be safe, this was working correctly before)

<img width="400" alt="Screenshot 2024-12-04 at 12 35 25 PM" src="https://github.com/user-attachments/assets/6960c612-44c9-4f7d-998f-ec963bf5eee2">

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
