### PR TITLE
HSD8-1700: Increase Tugboat Max Allowed Packet size to 512MB.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -44,7 +44,7 @@ services:
       update:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=67108864;'
+        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
         # Sync to hs_colorful, hs_colorful database & files and create user.
         - blt drupal:sync:files --site=hs_colorful
         - drush @hs_colorful.local user:create tugboat --password=pushcar || true
@@ -66,7 +66,7 @@ services:
       build:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=67108864;'
+        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
 
         - drush @hs_colorful.local cr
         - drush @hs_colorful.local eval '\Drupal::moduleHandler()->loadInclude("user", "install");user_update_10000();'
@@ -105,7 +105,7 @@ services:
     image: tugboatqa/mysql:5
     commands:
       update:
-        - mysql -e 'SET GLOBAL max_allowed_packet=67108864;'
+        - mysql -e 'SET GLOBAL max_allowed_packet=536870912;'
         # Delete and recreate the database for each site.
         - mysql -e "DROP DATABASE IF EXISTS hs_colorful; CREATE DATABASE hs_colorful;"
         - mysql -e "DROP DATABASE IF EXISTS hs_traditional; CREATE DATABASE hs_traditional;"


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Updated the MySQL max_allowed_packet from 64MB to 512MB to resolve 'MySQL server has gone away' error.

## Need Review By (Date)


## Urgency
Low

## Steps to Test
1. _[First testing step]_
2. ...

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
