### PR TITLE
SHS-5674: Help text for link fields is confusing

### DIFF
--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -654,23 +654,65 @@ function hs_field_helpers_form_alter(&$form, FormStateInterface $form_state, $fo
   }
 }
 
+/**
+ * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
+ */
 function hs_field_helpers_field_widget_complete_link_default_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+  // Add custom help text to link_default widgets.
+  if (!isset($field_widget_complete_form['widget']) || !is_array($field_widget_complete_form['widget'])) {
+    return;
+  }
+
+  $description = NULL;
+  $appended = NULL;
+
+  // Figure out if link supports internal, external, or both.
   $field_definition = $context['items']->getFieldDefinition();
   $settings = $field_definition->getSettings();
   $link_type = $settings['link_type'];
   $supports_internal = ($link_type & LinkItem::LINK_INTERNAL) === LinkItem::LINK_INTERNAL;
   $supports_external = ($link_type & LinkItem::LINK_EXTERNAL) === LinkItem::LINK_EXTERNAL;
-  $supports_both = $supports_internal && $supports_external;
 
-  dpm("internal:" . $supports_internal);
-  dpm("external:" . $supports_external);
-  dpm("both:" . $supports_both);
+  // Append extra text to the following form_ids.
+  $base_form = $form_state->getBuildInfo()['base_form_id'];
+  $append_extra_text_to = [
+    'shortcut_form',
+    'menu_link_content_form',
+  ];
 
-  if (isset($field_widget_complete_form['widget']) && is_array($field_widget_complete_form['widget'])) {
-    foreach ($field_widget_complete_form['widget'] as $key => &$item) {
-      if (is_array($item) && isset($item['uri'])) {
-        $item['uri']['#description'] = t('Custom hotdogs for sale');
-      }
+  if (in_array($base_form, $append_extra_text_to)) {
+    $appended = t('Enter %front to link to the front page. Enter %no_link to display a menu item that is only text without a link.', [
+      '%front' => '<front>',
+      '%no_link' => '<nolink>',
+    ]);
+  }
+
+  $placeholders = [
+    '%internal_link' => '/about/contact-us',
+    '%external_link' => 'https://www.stanford.edu',
+    '%appended' => $appended,
+  ];
+
+  // Internal link help text.
+  if ($supports_internal && !$supports_external) {
+    $description = t('This must be an internal path such as %internal_link You can also start typing the title of a piece of content to select it. %appended', $placeholders);
+  }
+
+  // External link help text.
+  if (!$supports_internal && $supports_external) {
+    $description = t('This must be an external URL such as %external_link. %appended', $placeholders);
+  }
+
+  // Both internal and external link help text.
+  if ($supports_internal && $supports_external) {
+    $description = t('Start typing the title of a piece of content to select it. You can also enter an internal path such as %internal_link or an external URL such as %external_link. %appended', $placeholders);
+  }
+
+  // Add custom text to help text.
+  foreach ($field_widget_complete_form['widget'] as &$item) {
+    if (is_array($item) && isset($item['uri'])) {
+      $item['uri']['#description'] = $description;
     }
   }
+
 }

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -694,22 +694,22 @@ function hs_field_helpers_field_widget_complete_link_default_form_alter(&$field_
   $placeholders = [
     '%internal_link' => '/about/contact-us',
     '%external_link' => 'https://www.stanford.edu',
-    '%appended' => $appended,
+    '@appended' => $appended,
   ];
 
   // Internal link help text.
   if ($supports_internal && !$supports_external) {
-    $description = t('This must be an internal path such as %internal_link You can also start typing the title of a piece of content to select it. %appended', $placeholders);
+    $description = t('This must be an internal path such as %internal_link You can also start typing the title of a piece of content to select it. @appended', $placeholders);
   }
 
   // External link help text.
   if (!$supports_internal && $supports_external) {
-    $description = t('This must be an external URL such as %external_link. %appended', $placeholders);
+    $description = t('This must be an external URL such as %external_link. @appended', $placeholders);
   }
 
   // Both internal and external link help text.
   if ($supports_internal && $supports_external) {
-    $description = t('Start typing the title of a piece of content to select it. You can also enter an internal path such as %internal_link or an external URL such as %external_link. %appended', $placeholders);
+    $description = t('Start typing the title of a piece of content to select it. You can also enter an internal path such as %internal_link or an external URL such as %external_link. @appended', $placeholders);
   }
 
   // Add custom text to help text.

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -703,12 +703,12 @@ function hs_field_helpers_field_widget_complete_link_default_form_alter(&$field_
   }
 
   // External link help text.
-  if (!$supports_internal && $supports_external) {
+  elseif (!$supports_internal && $supports_external) {
     $description = t('This must be an external URL such as %external_link. @appended', $placeholders);
   }
 
   // Both internal and external link help text.
-  if ($supports_internal && $supports_external) {
+  else {
     $description = t('Start typing the title of a piece of content to select it. You can also enter an internal path such as %internal_link or an external URL such as %external_link. @appended', $placeholders);
   }
 

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -16,9 +16,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Layout\LayoutDefinition;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\field_permissions\Plugin\FieldPermissionTypeInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\FieldStorageConfigInterface;
-use Drupal\field_permissions\Plugin\FieldPermissionTypeInterface;
 use Drupal\hs_field_helpers\Plugin\Field\FieldFormatter\AddToCalFormatter;
 use Drupal\hs_field_helpers\Plugin\Field\FieldFormatter\EntityTitleHeading;
 use Drupal\hs_field_helpers\Plugin\Field\FieldFormatter\HsViewfieldFormatterDefault;
@@ -26,6 +26,7 @@ use Drupal\hs_field_helpers\Plugin\Field\FieldType\DisplayModeField;
 use Drupal\hs_field_helpers\Plugin\Field\FieldWidget\DateTimeYearOnly;
 use Drupal\hs_field_helpers\Plugin\Field\FieldWidget\HsViewfieldWidgetSelect;
 use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
+use Drupal\link\Plugin\Field\FieldType\LinkItem;
 use Drupal\ui_patterns\Element\PatternContext;
 use Drupal\ui_patterns\UiPatterns;
 
@@ -650,5 +651,26 @@ function hs_field_helpers_form_alter(&$form, FormStateInterface $form_state, $fo
     // from the active filters.
     // @link https://www.drupal.org/project/views_bulk_operations/issues/3055770#comment-13116724
     unset($form['header']['views_bulk_operations_bulk_form']['select_all']);
+  }
+}
+
+function hs_field_helpers_field_widget_complete_link_default_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+  $field_definition = $context['items']->getFieldDefinition();
+  $settings = $field_definition->getSettings();
+  $link_type = $settings['link_type'];
+  $supports_internal = ($link_type & LinkItem::LINK_INTERNAL) === LinkItem::LINK_INTERNAL;
+  $supports_external = ($link_type & LinkItem::LINK_EXTERNAL) === LinkItem::LINK_EXTERNAL;
+  $supports_both = $supports_internal && $supports_external;
+
+  dpm("internal:" . $supports_internal);
+  dpm("external:" . $supports_external);
+  dpm("both:" . $supports_both);
+
+  if (isset($field_widget_complete_form['widget']) && is_array($field_widget_complete_form['widget'])) {
+    foreach ($field_widget_complete_form['widget'] as $key => &$item) {
+      if (is_array($item) && isset($item['uri'])) {
+        $item['uri']['#description'] = t('Custom hotdogs for sale');
+      }
+    }
   }
 }

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -673,6 +673,10 @@ function hs_field_helpers_field_widget_complete_link_default_form_alter(&$field_
   $supports_internal = ($link_type & LinkItem::LINK_INTERNAL) === LinkItem::LINK_INTERNAL;
   $supports_external = ($link_type & LinkItem::LINK_EXTERNAL) === LinkItem::LINK_EXTERNAL;
 
+  if (!$supports_internal && !$supports_external) {
+    return;
+  }
+
   // Append extra text to the following form_ids.
   $base_form = $form_state->getBuildInfo()['base_form_id'];
   $append_extra_text_to = [


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Creates dynamic help text for link fields using the default widget (not Linkit widgets) based on internal vs external requirements and regular vs menu usage.

## Need Review By (Date)
2025-01-08

## Urgency
low

## Steps to Test
1. Login to the site as an admin

## Testing internal and external links

1. Add a event
2. Under Map Link, verify that the URL help text is: "Start typing the title of a piece of content to select it. You can also enter an internal path such as /about/contact-us or an external URL such as https://www.stanford.edu."

![Screenshot 2024-12-18 at 5 08 58 PM](https://github.com/user-attachments/assets/aa96e512-3f4c-4d4a-8bd9-57eea8087243)

## Testing external links only

1. Add a course
2. Under Course Link, verify that the help text is: "This must be an external URL such as https://www.stanford.edu."

![Screenshot 2024-12-18 at 5 09 07 PM](https://github.com/user-attachments/assets/f2998f31-be58-41d5-bad9-d771cc236fba)

## Testing menu items and shortcuts
1. Visit the main navigation list `/admin/structure/menu/manage/main`
2. Edit an existing link or create a new link
4. Verify that the Link help text is: "Start typing the title of a piece of content to select it. You can also enter an internal path such as /about/contact-us or an external URL such as https://www.stanford.edu. Enter <front> to link to the front page. Enter <nolink> to display a menu item that is only text without a link."

![Screenshot 2024-12-18 at 5 16 22 PM](https://github.com/user-attachments/assets/c525fe9f-8098-4db8-acbb-541bb8caef54)

6. Visit the shortcuts overview page `/admin/config/user-interface/shortcut/manage/default/customize`
7. Edit an existing or create a new shortcut
8. Verify the Path help text is: "This must be an internal path such as /about/contact-us You can also start typing the title of a piece of content to select it. Enter <front> to link to the front page. Enter <nolink> to display a menu item that is only text without a link."

![Screenshot 2024-12-18 at 5 18 36 PM](https://github.com/user-attachments/assets/0dd9cb12-46b2-4cc1-9168-046b33179c80)

Note: I did not find a field that used internal links only that wasn't the shortcut. So, to test, we can create a dummy field in a content type and set it to use internal links only. I did test this locally and it works fine:

![Screenshot 2024-12-18 at 5 24 59 PM](https://github.com/user-attachments/assets/d8d0e9b2-9601-46ea-a1ba-c788fa6ba193)


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209090732666821