### PR TITLE
SHS-5955): When first adding Footer Social Media Links there is strange scrolling when adding another link

### DIFF
--- a/docroot/modules/humsci/hs_blocks/hs_blocks.libraries.yml
+++ b/docroot/modules/humsci/hs_blocks/hs_blocks.libraries.yml
@@ -22,3 +22,9 @@ back_to_top:
       css/hs_blocks.back_to_top.css: {}
   js:
     js/hs_blocks.back_to_top.js: {}
+prevent_modal_scroll:
+  js:
+    js/hs_blocks.prevent_modal_scroll.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/docroot/modules/humsci/hs_blocks/js/hs_blocks.prevent_modal_scroll.js
+++ b/docroot/modules/humsci/hs_blocks/js/hs_blocks.prevent_modal_scroll.js
@@ -1,0 +1,22 @@
+(function (Drupal, once, jQuery) {
+  Drupal.behaviors.preventScroll = {
+    attach: function (context) {
+      once('preventScroll', 'input[name="links_add_more"]', context).forEach((input) => {
+        jQuery(input).on('click', function () {
+
+          // Wait for the AJAX update to complete - due to block_class module?
+          setTimeout(() => {
+            const modal = jQuery('#drupal-modal');
+            const table = modal.find('table[id^="links-values"]');
+            const lastRow = table.find('tr:last');
+
+            if (modal.length && lastRow.length) {
+              const lastRowOffsetTop = lastRow[0].offsetTop - modal[0].offsetTop;
+              modal.scrollTop(lastRowOffsetTop);
+            }
+          }, 400);
+        });
+      });
+    },
+  };
+})(Drupal, once, jQuery);

--- a/docroot/modules/humsci/hs_blocks/src/Plugin/Block/SocialMediaBlock.php
+++ b/docroot/modules/humsci/hs_blocks/src/Plugin/Block/SocialMediaBlock.php
@@ -156,6 +156,16 @@ final class SocialMediaBlock extends BlockBase implements ContainerFactoryPlugin
         'callback' => [get_class($this), 'addMoreAjax'],
         'wrapper' => 'links-wrapper',
         'effect' => 'fade',
+        'event' => 'click',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => NULL,
+        ],
+      ],
+      '#attached' => [
+        'library' => [
+          'hs_blocks/prevent_modal_scroll',
+        ],
       ],
     ];
 


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Prevents scrolling behavior when adding new social media links. Theory: The `block_class` module seems to be taking over to scroll to their own "Attributes" section of the block modal, so, I wrote some JS to wait until that is complete, and then scroll to the appropriate section.

## Need Review By (Date)
2025-01-08

## Urgency
low

## Steps to Test
1. Login to the site and visit the block layout page `/admin/structure/block`
2. Place the Social Media Block into the Footer section
3. In the modal with the fields for the social media footer, click on the "Add another item" button below the Links area
4. Verify that it will refresh with the newly added URL and Label in view instead of it scrolling to the bottom of the form

![Screenshot 2025-01-03 at 5 09 54 PM](https://github.com/user-attachments/assets/0f1e5a9a-c45f-472f-8f17-2f3c109b6296)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
