### PR TITLE
Implement mnsami/composer-custom-directory-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -183,6 +183,7 @@
         "harvesthq/chosen": "^1.8",
         "kenwheeler/slick": "^1.8",
         "leongersen/nouislider": "15.5.1",
+        "mnsami/composer-custom-directory-installer": "^2.0",
         "onlyextart/colorbox": "dev-master#e58476becbc89dc671093d1bcd9f99b2167fa8f7",
         "sainsburys/guzzle-oauth2-plugin": "^3.0",
         "su-sws/ckeditor5_plugins": "^1.0",
@@ -316,7 +317,11 @@
                 "type:drupal-core"
             ],
             "docroot/libraries/{$name}": [
-                "type:drupal-library"
+                "type:drupal-library",
+                "ckeditor/ckeditor",
+                "enyo/dropzone",
+                "components/jquery",
+                "harvesthq/chosen"
             ],
             "docroot/modules/contrib/{$name}": [
                 "type:drupal-module"
@@ -348,11 +353,7 @@
                 "type:stanford-profile"
             ],
             "docroot/libraries/{$name}/": [
-                "type:component",
-                "ckeditor/ckeditor",
-                "enyo/dropzone",
-                "components/jquery",
-                "harvesthq/chosen"
+                "type:component"
             ]
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -318,9 +318,7 @@
             ],
             "docroot/libraries/{$name}": [
                 "type:drupal-library",
-                "ckeditor/ckeditor",
                 "enyo/dropzone",
-                "components/jquery",
                 "harvesthq/chosen"
             ],
             "docroot/modules/contrib/{$name}": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "036226f3870bec1fefee4eb859c0babf",
+    "content-hash": "c5f35f4d14bc480d61e667513d663395",
     "packages": [
         {
             "name": "acquia/blt",
@@ -26474,6 +26474,6 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6aa3f3bb902e6b4d249858184994fa9",
+    "content-hash": "036226f3870bec1fefee4eb859c0babf",
     "packages": [
         {
             "name": "acquia/blt",
@@ -14361,6 +14361,62 @@
             "time": "2016-07-25T17:07:32+00:00"
         },
         {
+            "name": "mnsami/composer-custom-directory-installer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mnsami/composer-custom-directory-installer.git",
+                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
+                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": [
+                    "Composer\\CustomDirectoryInstaller\\LibraryPlugin",
+                    "Composer\\CustomDirectoryInstaller\\PearPlugin",
+                    "Composer\\CustomDirectoryInstaller\\PluginPlugin"
+                ],
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Composer\\CustomDirectoryInstaller": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mina Nabil Sami",
+                    "email": "mina.nsami@gmail.com"
+                }
+            ],
+            "description": "A composer plugin, to help install packages of different types in custom paths.",
+            "keywords": [
+                "composer",
+                "composer-installer",
+                "composer-plugin"
+            ],
+            "support": {
+                "issues": "https://github.com/mnsami/composer-custom-directory-installer/issues",
+                "source": "https://github.com/mnsami/composer-custom-directory-installer/tree/2.0.0"
+            },
+            "time": "2020-08-18T11:00:11+00:00"
+        },
+        {
             "name": "neilime/php-css-lint",
             "version": "v3.2.0",
             "source": {
@@ -26418,6 +26474,6 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
# Summary
Implements the `mnsami/composer-custom-directory-installer` package which allows `type:library` composer packages to be installed in custom directories without having to specify a custom directory for `type:library` packages first.

# Long Summary
We've been using `davidbarratt/custom-installer` to manually install specific `type:library` composer packages into the `docroot/libraries` directory for Drupal. In order for this to work correctly, we also needed to setup a redundant `custom-installer` path for `type:library` packages, otherwise it wouldn't act on individual packages. [See README](https://github.com/davidbarratt/custom-installer?tab=readme-ov-file#package-name-filter):

> Custom Installer will only handle a specific package if a configuration exists that also handles the package type in general.

Unfortunately, when adding PHPCS, this created an error on `composer install`, and the `custom-installer` path was removed in the PHPCS PR: #1686 

Error:
```
$from (vendor/squizlabs/php_codesniffer/) and $to (/home/joegl/apache_www/suhumsci/vendor/drupal/coder/coder_sniffer) must be absolute paths.
```

Lines removed:
```
"vendor/{$vendor}/{$name}/": [
    "type:library"
]
```

Removing this line errantly removed the `harvesthq/chosen` and `enyo/dropzone` libraries from `docroot/libraries`. However, due to the caching system in place in Github workflows, the absence of these libraries was not noticed until the `blt.yml` file was changed for a provision in #1735. #1686 was merged with the line removal without detecting the issue.

To resolve this issue, I found and implemented the `mnsami/composer-custom-directory-installer` package which allows individual `type:library` packages to have a custom defined install path without the need for a custom install path to be defined for all `type:library` packages.

I also looked at `oomphinc/composer-installers-extender` as an option but this had the same requirement as `davidbarratt/custom-installer`, where a custom install path had to be defined for the entire `type:library` in order to act on individual `type:library` packages.
