### PR TITLE
HSD8-1720: Allow private pages to be exported via single_content_sync

### DIFF
--- a/config/default/single_content_sync.settings.yml
+++ b/config/default/single_content_sync.settings.yml
@@ -10,6 +10,7 @@ allowed_entity_types:
     - hs_event_series
     - hs_news
     - hs_person
+    - hs_private_page
     - hs_publications
     - hs_research
   taxonomy_term: {  }


### PR DESCRIPTION
# Summary
Allow private pages to be exported via `single_content_sync`
https://stanfordits.atlassian.net/browse/HSD8-1720

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209216627853349