### PR TITLE
HSD8-1727: Added patch to hide oEmbed resource error from anonymous users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -241,7 +241,8 @@
                 "Allow hs group blocks in layout_builder": "patches/layout_builder-allow-hs-blocks.patch",
                 "Allow media items to be edited in a modal when using the field widget https://www.drupal.org/project/drupal/issues/2985168": "https://www.drupal.org/files/issues/2023-12-18/2985168-172.patch",
                 "Cannot read properties of undefined (reading 'settings') with dialog.position.js https://www.drupal.org/project/drupal/issues/3356667": "patches/core/core-mr-8892.patch",
-                "https://www.drupal.org/project/drupal/issues/3207813: ModuleHandler skips all hook implementations when invoked before the module files have been loaded": "patches/core/core-mr-6976.patch"
+                "https://www.drupal.org/project/drupal/issues/3207813: ModuleHandler skips all hook implementations when invoked before the module files have been loaded": "patches/core/core-mr-6976.patch",
+                "https://www.drupal.org/project/drupal/issues/3202896: Do not display oEmbed resource error to anonymous users": "patches/core/core-3202896-mr-9357-20250227.patch"
             },
             "drupal/entity_reference_exposed_filters": {
                 "https://www.drupal.org/project/entity_reference_exposed_filters/issues/3189025": "https://www.drupal.org/files/issues/2023-10-17/entity_reference_exposed_filters-empty_target-3189025-4.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "576a837a17b12da167b5cd627173d263",
+    "content-hash": "51266700c560cee5173f4595473dd032",
     "packages": [
         {
             "name": "acquia/blt",

--- a/patches/core/core-3202896-mr-9357-20250227.patch
+++ b/patches/core/core-3202896-mr-9357-20250227.patch
@@ -1,0 +1,34 @@
+diff --git a/core/modules/media/src/Plugin/media/Source/OEmbed.php b/core/modules/media/src/Plugin/media/Source/OEmbed.php
+index 3f58ca120511badd58c223b8f2e3254eac284ef0..855734dd9f14157c9410ae3978e4b3b8f7ae0c14 100644
+--- a/core/modules/media/src/Plugin/media/Source/OEmbed.php
++++ b/core/modules/media/src/Plugin/media/Source/OEmbed.php
+@@ -33,6 +33,8 @@
+ use Psr\Log\LoggerInterface;
+ use Symfony\Component\DependencyInjection\ContainerInterface;
+ use Symfony\Component\Mime\MimeTypes;
++use Drupal\Core\Render\Markup;
++use Drupal\Core\Link;
+ 
+ /**
+  * Provides a media source plugin for oEmbed resources.
+@@ -243,7 +245,19 @@ public function getMetadata(MediaInterface $media, $name) {
+       $resource = $this->resourceFetcher->fetchResource($resource_url);
+     }
+     catch (ResourceException $e) {
+-      $this->messenger->addError($e->getMessage());
++      if ($media->access('update')) {
++        $link = Link::createFromRoute($this->t('edit'), 'entity.media.edit_form', ['media' => $media->id()]);
++        $this->messenger->addError(Markup::create($e->getMessage() . " Update media entity: " . $link->toString()));
++      }
++      $this->logger->error(
++       'An error occurred while fetching an oEmbed resource for Media ID: %media_id, Embed URL: %media_url, oEmbed Resource URL: %resource_url. Error: @error',
++        [
++          '%resource_url' => !empty($resource_url) ? $resource_url : 'unknown',
++          '%media_url' => $media_url,
++          '%media_id' => $media->id(),
++          '@error' => $e->getMessage(),
++        ]
++      );
+       return NULL;
+     }
+ 


### PR DESCRIPTION
# Summary
Added patch to hide oEmbed resource error from anonymous users

See:
https://stanfordits.atlassian.net/browse/HSD8-1727
https://www.drupal.org/project/drupal/issues/3202896
https://git.drupalcode.org/project/drupal/-/merge_requests/9357/diffs