### PR TITLE
fix(SHS-6113): duplicate node access records due to bug in su_humsci_profile_update_9723()

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1344,7 +1344,10 @@ function su_humsci_profile_update_9726(&$sandbox) {
         if ($cleanPermissions !== $nodePermissions) {
           $changed = TRUE;
           $nodePermissions = $cleanPermissions;
-          $sandbox['results'][] = t('Cleaned %operation on nid %nid.', ['%operation' => $nodeOperation, '%nid' => $node->id()]);
+          $sandbox['results'][] = t('Cleaned %operation on nid %nid.', [
+            '%operation' => $nodeOperation,
+            '%nid' => $node->id(),
+          ]);
         }
       }
       if ($changed) {

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1278,3 +1278,82 @@ function su_humsci_profile_update_9724() {
 
   $config->set('allowed_entity_types.node', $allowed_entity_types)->save();
 }
+
+/**
+ * Clean-up possible duplicates from su_humsci_profile_update_9723().
+ */
+function su_humsci_profile_update_9725(&$sandbox) {
+  $node_type = 'hs_private_page';
+  $results = [];
+  // Remove any dupes from bundle settings.
+  $settings = content_access_get_settings('all', $node_type);
+  foreach ($settings as $operation => &$permissions) {
+    if (!is_array($permissions)) {
+      // This isn't actually an array of perms, this is another setting.
+      continue;
+    }
+    $cleanPermissions = array_unique($permissions);
+    if ($cleanPermissions !== $permissions) {
+      $permissions = $cleanPermissions;
+      $results[] = t('Cleaned %operation.', ['%operation' => $operation]);
+    }
+  }
+  // Without enforcing per-node settings we got lots of dupes in the
+  // node_access table due to a clash between the manual items set in
+  // su_humsci_profile_update_9723(), plus the automatic entries that Content
+  // Access was trying to add (when per-node was not enabled).  Those dupes
+  // caused fatal exceptions.
+  if (empty($settings['per_node'])) {
+    $settings['per_node'] = TRUE;
+    $results[] = t('Enforced per-node Content Access.');
+  }
+  if ($results) {
+    content_access_set_settings($settings, $node_type);
+    $results[] = t('Saved Content Access settings for Private Pages.');
+    node_access_rebuild(TRUE);
+    $results[] = t('Rebuilt node access.');
+    return implode('  <br />', $results);
+  }
+}
+
+/**
+ * Clean-up possible duplicates from su_humsci_profile_update_9723().
+ */
+function su_humsci_profile_update_9726(&$sandbox) {
+  $node_type = 'hs_private_page';
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  if (empty($sandbox['ids'])) {
+    $sandbox['results'] = [];
+    $ids = $node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', $node_type)
+      ->execute();
+    $sandbox['ids'] = array_combine($ids, $ids);
+    $sandbox['total'] = count($sandbox['ids']);
+  }
+  $nids = array_slice($sandbox['ids'], 0, 50);
+
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($node_storage->loadMultiple($nids) as $node) {
+    // Remove any dupes from per-node settings.
+    $nodeSettings = content_access_get_per_node_settings($node);
+    $changed = FALSE;
+    if ($nodeSettings) {
+      foreach ($nodeSettings as $nodeOperation => &$nodePermissions) {
+        $cleanPermissions = array_unique($nodePermissions);
+        if ($cleanPermissions !== $nodePermissions) {
+          $changed = TRUE;
+          $nodePermissions = $cleanPermissions;
+          $sandbox['results'][] = t('Cleaned %operation on nid %nid.', ['%operation' => $nodeOperation, '%nid' => $node->id()]);
+        }
+      }
+      if ($changed) {
+        content_access_save_per_node_settings($node, $nodeSettings);
+      }
+    }
+    unset($sandbox['ids'][$node->id()]);
+  }
+
+  $sandbox['#finished'] = count($sandbox['ids']) ? 1 - count($sandbox['ids']) / $sandbox['total'] : 1;
+  return implode('  <br />', $sandbox['results']);
+}

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1280,9 +1280,9 @@ function su_humsci_profile_update_9724() {
 }
 
 /**
- * Clean-up possible duplicates from su_humsci_profile_update_9723().
+ * Clean-up possible bundle settings dupes from su_humsci_profile_update_9723().
  */
-function su_humsci_profile_update_9725(&$sandbox) {
+function su_humsci_profile_update_9725() {
   $node_type = 'hs_private_page';
   $results = [];
   // Remove any dupes from bundle settings.
@@ -1292,9 +1292,9 @@ function su_humsci_profile_update_9725(&$sandbox) {
       // This isn't actually an array of perms, this is another setting.
       continue;
     }
-    $cleanPermissions = array_unique($permissions);
-    if ($cleanPermissions !== $permissions) {
-      $permissions = $cleanPermissions;
+    $clean_permissions = array_unique($permissions);
+    if ($clean_permissions !== $permissions) {
+      $permissions = $clean_permissions;
       $results[] = t('Cleaned %operation.', ['%operation' => $operation]);
     }
   }
@@ -1317,7 +1317,7 @@ function su_humsci_profile_update_9725(&$sandbox) {
 }
 
 /**
- * Clean-up possible duplicates from su_humsci_profile_update_9723().
+ * Clean-up possible node settings dupes from su_humsci_profile_update_9723().
  */
 function su_humsci_profile_update_9726(&$sandbox) {
   $node_type = 'hs_private_page';
@@ -1336,22 +1336,22 @@ function su_humsci_profile_update_9726(&$sandbox) {
   /** @var \Drupal\node\NodeInterface $node */
   foreach ($node_storage->loadMultiple($nids) as $node) {
     // Remove any dupes from per-node settings.
-    $nodeSettings = content_access_get_per_node_settings($node);
+    $node_settings = content_access_get_per_node_settings($node);
     $changed = FALSE;
-    if ($nodeSettings) {
-      foreach ($nodeSettings as $nodeOperation => &$nodePermissions) {
-        $cleanPermissions = array_unique($nodePermissions);
-        if ($cleanPermissions !== $nodePermissions) {
+    if ($node_settings) {
+      foreach ($node_settings as $node_operation => &$node_permissions) {
+        $clean_permissions = array_unique($node_permissions);
+        if ($clean_permissions !== $node_permissions) {
           $changed = TRUE;
-          $nodePermissions = $cleanPermissions;
+          $node_permissions = $clean_permissions;
           $sandbox['results'][] = t('Cleaned %operation on nid %nid.', [
-            '%operation' => $nodeOperation,
+            '%operation' => $node_operation,
             '%nid' => $node->id(),
           ]);
         }
       }
       if ($changed) {
-        content_access_save_per_node_settings($node, $nodeSettings);
+        content_access_save_per_node_settings($node, $node_settings);
       }
     }
     unset($sandbox['ids'][$node->id()]);


### PR DESCRIPTION
# Summary
Some update hooks to clean up duplicate node_access records that caused fatal exceptions.  Those dupes were caused because not all sites had per-node Content Access enabled.  So these updates enforce that for the Private Page node type.

## Need Review By (Date)
ASAP.  We need to prevent other people from experiencing fatal exceptions in the live environment. 

## Urgency
high

## Steps to Test
1. Run `drush updb` and observe the output for `su_humsci_profile_update_9725()` and `su_humsci_profile_update_9726()`

On some sites you'll see output for 9725 to say that it enforced per-node Content Access.  I haven't found a site that made any changes in 9726 (I suspect that the `node_access_rebuild()` called at the end of the previous update fixed those problems already). 

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
