### PR TITLE
HSD8-000: Add Simple Content Access module and settings to Config Ignore 

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -48,4 +48,3 @@ ignored_config_entities:
   - 'single_content_sync.settings:allowed_entity_types.node'
   - 'core.extension:module.content_access_simple'
   - content_access_simple.settings
-

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -46,3 +46,6 @@ ignored_config_entities:
   - 'domain_registration.settings:pattern'
   - 'user.settings:register'
   - 'single_content_sync.settings:allowed_entity_types.node'
+  - 'core.extension:module.content_access_simple'
+  - content_access_simple.settings
+

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1365,3 +1365,15 @@ function su_humsci_profile_update_9726(&$sandbox) {
   $sandbox['#finished'] = count($sandbox['ids']) ? 1 - count($sandbox['ids']) / $sandbox['total'] : 1;
   return implode('  <br />', $sandbox['results']);
 }
+
+/**
+ * Update config ignore settings for content_access_simple.
+ */
+function su_humsci_profile_update_9727() {
+  $config = \Drupal::configFactory()->getEditable('config_ignore.settings');
+  $ignored_config_entities = $config->get('ignored_config_entities');
+  $ignored_config_entities[] = 'core.extension:module.content_access_simple';
+  $ignored_config_entities[] = 'content_access_simple.settings';
+  $config->set('ignored_config_entities', $ignored_config_entities);
+  $config->save();
+}


### PR DESCRIPTION
# Summary
Add Simple Content Access module and settings to Config Ignore. This will allow the module and settings to stay enabled on the sited where it's being beta tested instead of leading to errors during syncs, deployments, testing in CI, etc.,
