### PR TITLE
HSD8-000: Fix functional tests and change Github workflow caches

### DIFF
--- a/.github/workflows/acquia-cleanup.yml
+++ b/.github/workflows/acquia-cleanup.yml
@@ -28,10 +28,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Clean up backups and branches
         env:
           SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -18,10 +18,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Copy databases
         env:
           SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,10 +19,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Run PHPCS
         run: |
           composer install -n &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Deploy Tag
         if: ${{ steps.tag.outputs.tag }}
         run: |

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -39,10 +39,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - run: git config --system --add safe.directory '*'
       - name: Install Dependencies
         run: |
@@ -74,10 +70,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - id: set-matrix
         run: |
           composer install -n &&
@@ -143,10 +135,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -219,10 +207,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - run: git config --system --add safe.directory '*'
       - name: Install Site
         run: |
@@ -275,10 +259,6 @@ jobs:
             docroot/libraries
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-            1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-
-            1.0-${{ hashFiles('blt/blt.yml') }}-
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -111,6 +111,7 @@ class FlexiblePageCest {
     $I->fillField('URL', 'http://google.com');
     $I->fillField('Link text', 'Google CTA');
     $I->click('Save');
+    $I->waitForText('Demo Basic Page');
     $I->canSeeNumberOfElements('.field-hs-page-components img', 1);
     $I->canSee('Overlay Title');
     $I->canSee('Google CTA', 'a');
@@ -152,6 +153,7 @@ class FlexiblePageCest {
     $I->waitForText('Display Mode');
     $I->click('Save');
 
+    $I->waitForText('Demo Basic Page');
     $I->canSee('Demo Basic Page', 'h1');
     $I->canSee('Photo Album Headline', 'h2');
     $I->canSeeNumberOfElements('.su-gallery-images img', 1);
@@ -164,6 +166,7 @@ class FlexiblePageCest {
     $I->selectOption('Style', 'Slideshow');
     $I->executeJS('window.scrollTo(0,0);');
     $I->click('Save');
+
     $I->waitForText('Demo Basic Page');
     $I->canSeeNumberOfElements('.slick img', 1);
   }
@@ -218,6 +221,7 @@ class FlexiblePageCest {
     $I->amOnPage('node/add/hs_basic_page');
     $I->fillField('Title', 'Demo Basic Page');
     $I->click('Save');
+    $I->waitForText('Demo Basic Page');
     $I->canSeeInCurrentUrl('/demo-basic-page');
     $I->click('.hb-main-nav__toggle');
     $I->seeElement('.hb-main-nav__menu');
@@ -231,8 +235,9 @@ class FlexiblePageCest {
   public function testSpotlightSlider(FunctionalTester $I) {
     $I->logInWithRole('contributor');
     $I->amOnPage('node/add/hs_basic_page');
+    $page_title = $this->faker->words(3, TRUE);
     $node = $I->createEntity([
-      'title' => $this->faker->words(3, TRUE),
+      'title' => $page_title,
       'type' => 'hs_basic_page',
     ]);
     $I->amOnPage($node->toUrl('edit-form')->toString());
@@ -243,6 +248,7 @@ class FlexiblePageCest {
     $I->waitForText('No media items are selected');
     $I->scrollTo('.paragraph-type--hs-sptlght-slder');
     $I->click('Save');
+    $I->waitForText($page_title);
     // Populating spotlight #1.
     $I->amOnPage($node->toUrl('edit-form')->toString());
     $I->click('field_hs_page_components_0_edit');
@@ -291,6 +297,7 @@ class FlexiblePageCest {
     $I->waitForText('The maximum number of media items have been selected');
     $I->click('Save');
     // Check spotlight 2.
+    $I->waitForText($page_title);
     $I->click('.slick-next');
     $I->waitForText('Spotlight #2 Title');
     $I->canSee('Aliquet porttitor lacus luctus accumsan tortor posuere ac.');
@@ -307,6 +314,7 @@ class FlexiblePageCest {
   public function testVerticalTimeline(FunctionalTester $I) {
     $I->logInWithRole('administrator');
     $I->amOnPage('node/add/hs_basic_page');
+
     $I->fillField('Title', $this->faker->words(3, TRUE));
     $I->click('#field-hs-page-components-values tr:last-child .paragraphs-features__add-in-between__button');
     $I->waitForText('Add Component');
@@ -363,9 +371,9 @@ class FlexiblePageCest {
     $I->fillField('Link text', 'Praesent egestas tristique nibh');
     $I->click('Save');
 
-    $I->canSeeInCurrentUrl('/demo-basic-page');
     $I->waitForText('Nam at tortor in tellus');
     $I->waitForText('Maecenas vestibulum mollis diam.');
+    $I->canSeeInCurrentUrl('/demo-basic-page');
     $I->seeElement(Locator::href('http://google.com'));
   }
 
@@ -384,6 +392,7 @@ class FlexiblePageCest {
     $I->fillField('Summary', 'Sed augue ipsum egestas nec');
     $I->fillField('.ck-editor__editable_inline', 'Vivamus in erat ut urna cursus vestibulum. Sed augue ipsum, egestas nec, vestibulum et, malesuada adipiscing, dui. Curabitur suscipit suscipit tellus. Suspendisse enim turpis, dictum sed, iaculis a, condimentum nec, nisi. Nullam vel sem.');
     $I->click('Save');
+    $I->waitForText('Demo Basic Page');
     $I->canSeeInCurrentUrl('/demo-basic-page');
     $I->canSee('Demo Basic Page', 'h1');
     $I->canSee('Sed augue ipsum egestas nec');
@@ -414,6 +423,7 @@ class FlexiblePageCest {
     $I->fillField('.ck-editor__editable_inline', $this->faker->paragraphs(10, TRUE));
     $I->click('Save');
 
+    $I->waitForText('Back To Top');
     $I->click('Layout', '.tabs');
     $I->scrollTo('.layout-builder__link--add');
     $I->canSee('Add Block', 'a');
@@ -457,6 +467,7 @@ class FlexiblePageCest {
     $I->fillField('.ck-editor__editable_inline', $paragraph);
     $I->click('Save');
 
+    $I->waitForText('Demo Basic Page');
     $I->canSeeInCurrentUrl('/demo-basic-page');
     $I->canSee('Demo Basic Page', 'h1');
     $I->canSee($paragraph);
@@ -510,6 +521,7 @@ class FlexiblePageCest {
     // Save the node and verify the components are visible.
     $I->executeJS('window.scrollTo(0,0);');
     $I->click('Save');
+    $I->waitForText('Demo Basic Page');
     $I->canSee('Demo Basic Page', 'h1');
     $I->canSee('Foo Bar Baz', '.item-per-row--2');
     $I->canSee('Demo card title', '.item-per-row--2 h3');

--- a/tests/codeception/functional/Install/Content/VideoEmbedCest.php
+++ b/tests/codeception/functional/Install/Content/VideoEmbedCest.php
@@ -30,7 +30,8 @@ class VideoEmbedCest {
     // Login and add flexible page.
     $I->logInWithRole('contributor');
     $I->amOnPage('node/add/hs_basic_page');
-    $I->fillField('Title', $this->faker->words(3, TRUE));
+    $page_title = $this->faker->words(3, TRUE);
+    $I->fillField('Title', $page_title);
 
     // Add text field.
     $I->click('#field-hs-page-components-values tr:last-child .paragraphs-features__add-in-between__button');
@@ -60,6 +61,7 @@ class VideoEmbedCest {
     $I->click('Save');
 
     // Verify figure and figcaption.
+    $I->waitForText($page_title);
     $I->seeElement('figure');
     $I->seeElement('figcaption');
     $I->scrollTo('figcaption');

--- a/tests/codeception/functional/Install/InstallStateCest.php
+++ b/tests/codeception/functional/Install/InstallStateCest.php
@@ -36,6 +36,7 @@ class InstallStateCest {
     $I->checkOption('Provide a menu link');
     $I->fillField('Menu link title', $parent_page->label());
     $I->click('Save');
+    $I->waitForText('has been updated');
     $I->canSee($parent_page->label(), 'h1');
     $I->canSee($parent_page->label(), 'nav a[data-unpublished-node]');
 
@@ -53,6 +54,7 @@ class InstallStateCest {
     $I->waitForAjaxToFinish();
 
     $I->click('Save');
+    $I->waitForText('has been updated');
     $I->canSee($child_page->label(), 'h1');
     $I->canSee($child_page->label(), 'nav a[data-unpublished-node]');
 

--- a/tests/codeception/functional/MediaCest.php
+++ b/tests/codeception/functional/MediaCest.php
@@ -70,6 +70,7 @@ class MediaCest {
     $I->canSee('1 error has been found');
     $I->fillField('Video URL', 'https://www.youtube.com/watch?v=-DYSucV1_9w');
     $I->click('Save');
+    $I->waitForText('Media');
     $I->canSee('Test Video has been created.');
   }
 }

--- a/tests/codeception/functional/MediaCest.php
+++ b/tests/codeception/functional/MediaCest.php
@@ -22,6 +22,7 @@ class MediaCest {
     $I->waitForText('Name');
     $I->fillField('Name', 'Demo Text File');
     $I->click('Save');
+    $I->waitForText('Media');
     $I->canSee('Saved 1 Media Items');
     $I->canSeeInCurrentUrl('/admin/content/media');
     $I->canSee('Demo Text File');
@@ -52,6 +53,7 @@ class MediaCest {
     $I->uncheckOption('Decorative Image');
     $I->fillField('Alternative text', 'Stanford Logo');
     $I->click('Save');
+    $I->waitForText('Media');
     $I->canSee('Saved 1 Media Items');
     $I->canSeeInCurrentUrl('/admin/content/media');
     $I->canSee('Logo File');

--- a/tests/codeception/functional/MediaCest.php
+++ b/tests/codeception/functional/MediaCest.php
@@ -69,6 +69,7 @@ class MediaCest {
     $I->fillField('Name', 'Test Video');
     $I->fillField('Video URL', 'http://google.com');
     $I->click('Save');
+    $I->waitForText('Name');
     $I->canSee('1 error has been found');
     $I->fillField('Video URL', 'https://www.youtube.com/watch?v=-DYSucV1_9w');
     $I->click('Save');

--- a/tests/codeception/functional/MediaCest.php
+++ b/tests/codeception/functional/MediaCest.php
@@ -5,6 +5,7 @@
  *
  * @group install
  * @group existingSite
+ * @group media
  */
 class MediaCest {
 
@@ -18,6 +19,7 @@ class MediaCest {
     $I->dropFileInDropzone(__DIR__ . '/test.txt');
     $I->wait(1);
     $I->click('Upload');
+    $I->waitForText('Name');
     $I->fillField('Name', 'Demo Text File');
     $I->click('Save');
     $I->canSee('Saved 1 Media Items');
@@ -45,6 +47,7 @@ class MediaCest {
     $I->click('Bulk Upload');
     $I->dropFileInDropzone(__DIR__ . '/logo.jpg');
     $I->click('Upload');
+    $I->waitForText('Name');
     $I->fillField('Name', 'Logo File');
     $I->uncheckOption('Decorative Image');
     $I->fillField('Alternative text', 'Stanford Logo');

--- a/tests/codeception/functional/MegaMenuCest.php
+++ b/tests/codeception/functional/MegaMenuCest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Drupal\Core\Url;
 use Faker\Factory;
 
 /**
@@ -46,6 +45,7 @@ class MegaMenuCest {
       $I->checkOption('Enable New Mega Menu');
       $I->click('Save');
       $I->runDrush('cache:rebuild');
+      $I->waitForText('Site Options');
     }
 
     $topLevelTitle = $this->faker->words(3, TRUE);
@@ -63,6 +63,8 @@ class MegaMenuCest {
     $I->scrollTo(['css' => '.form-submit']);
     $I->click('Save');
 
+    $I->waitForText($topLevelTitle . ' has been updated');
+
     $second_level = $I->createEntity([
       'title' => $secondLevelTitle,
       'type' => 'hs_basic_page',
@@ -76,6 +78,8 @@ class MegaMenuCest {
     $I->waitForAjaxToFinish();
     $I->scrollTo(['css' => '.form-submit']);
     $I->click('Save');
+
+    $I->waitForText($secondLevelTitle . ' has been updated');
 
     $I->amOnPage('/admin/structure/menu/manage/main');
     $I->see($topLevelTitle);


### PR DESCRIPTION
# Summary
Fixes for media functional tests.
- An update to selenium-standalone appears to have caused more sensitivity in the functional tests. Specifically, when a form submit button was clicked (such as a "Save" button) a `waitFor()` step was typically not needed before running checks on the page loaded after submitting the form. Now a `waitFor()` step is required before running checks on the page.
- This also removes the `restore-keys` from the Github workflow caches to ensure we're using an appropriate cache.