### PR TITLE
HSD8-1723: Remove menu_link_content form alter hook

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -354,13 +354,6 @@ function su_humsci_profile_contextual_links_alter(array &$links, $group, array $
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function su_humsci_profile_form_menu_link_content_menu_link_content_form_alter(array &$form, FormStateInterface $form_state) {
-  $form['link']['widget'][0]['uri']['#description']['#items'][] = t('Enter "@text" for a menu item that is not clickable.', ['@text' => 'route:<nolink>']);
-}
-
-/**
  * Implements hook_link_alter().
  */
 function su_humsci_profile_link_alter(&$variables) {


### PR DESCRIPTION
# Summary
The `su_humsci_profile_form_menu_link_content_menu_link_content_form_alter` was throwing errors when editing menus link created by the `default_content` module, which have a bundle type of `menu_link_content`. Other menu items are not affected because they have different bundle types.

Instead of fixing the error, I opted to remove the hook entirely because the text being added to the field description is already covered now by the default link widget, which adds the following help text:

> Enter \<front\> to link to the front page. Enter \<nolink\> to display a menu item that is only text without a link.

This makes this hook text redundant.
