### PR TITLE
SHS-6058: Dashboard: Other importers

### DIFF
--- a/docroot/modules/humsci/hs_dashboard/src/Annotation/ImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Annotation/ImporterInfo.php
@@ -39,4 +39,11 @@ class ImporterInfo extends Plugin {
    */
   public $description;
 
+  /**
+   * The default weight of plugin instances used for sorting.
+   *
+   * @var int
+   */
+  public $weight;
+
 }

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "course_importer_info",
  *   label = @Translation("Course Importers"),
  *   description = @Translation("Retrieves event importer information from Localist."),
+ *   weight = 10,
  * )
  */
 class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "event_importer_info",
  *   label = @Translation("Event Importers"),
  *   description = @Translation("Retrieves event importer information from Localist."),
+ *   weight = 20,
  * )
  */
 class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
@@ -26,7 +26,7 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
   /**
    * A list of migration IDs already represented in other ImporterInfo blocks.
    */
-  CONST SKIP_IMPORTERS = [
+  const SKIP_IMPORTERS = [
     'hs_courses',
     'hs_localist_scheduled',
     'hs_capx',
@@ -35,14 +35,14 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
   /**
    * KeyValueStore used to track the import times of each migration.
    *
-   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface $lastImportedStore
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
    */
   protected $lastImportedStore;
 
   /**
    * Migration plugin manager service.
    *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migrationManager
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
    */
   protected $migrationManager;
 
@@ -57,8 +57,10 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory interface.
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value_factory
+   *   The KeyValue factory interface.
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   The migration manager interface.
    */
   public function __construct(
     array $configuration,
@@ -112,10 +114,10 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
    * of the dashboard. Finally, it excludes any migrations that have not run in
    * the last 30 days.
    *
-   * @return boolean
+   * @return bool
    *   TRUE if this site has at least one 'other' migration; otherwise, FALSE.
    */
-  protected function hasActiveMigration() {
+  protected function hasActiveMigration(): bool {
     $all_migrations = array_keys($this->migrationManager->getDefinitions());
     $other_migrations = array_diff($all_migrations, self::SKIP_IMPORTERS);
     foreach ($other_migrations as $id) {

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\hs_dashboard\Plugin\ImporterInfo;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
+use Drupal\hs_dashboard\Plugin\ImporterInfoInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides information about other importers.
+ *
+ * @ImporterInfo(
+ *   id = "other_importer_info",
+ *   label = @Translation("Other Importers"),
+ *   description = @Translation("Displays a message if other importers are active for this site."),
+ *   weight = 100,
+ * )
+ */
+class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * A list of migration IDs already represented in other ImporterInfo blocks.
+   */
+  CONST SKIP_IMPORTERS = [
+    'hs_courses',
+    'hs_localist_scheduled',
+    'hs_capx',
+  ];
+
+  /**
+   * KeyValueStore used to track the import times of each migration.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface $lastImportedStore
+   */
+  protected $lastImportedStore;
+
+  /**
+   * Migration plugin manager service.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migrationManager
+   */
+  protected $migrationManager;
+
+  /**
+   * Constructs a new OtherImporterInfo object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory interface.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    KeyValueFactoryInterface $key_value_factory,
+    MigrationPluginManagerInterface $migration_manager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
+    $this->lastImportedStore = $key_value_factory->get('migrate_last_imported');
+    $this->migrationManager = $migration_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('keyvalue'),
+      $container->get('plugin.manager.migration')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getNoDataCaption(): TranslatableMarkup {
+    // Unlike other ImporterInfo blocks, this plugin never displays data.
+    // Instead, this no-results message is repurposed to communicate that this
+    // website has other active migrations not shown on the dashboard.
+    return $this->t('<em>Other importers are running that cannot be shown on the dashboard.</em>');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function showImporter(): bool {
+    return $this->hasActiveMigration();
+  }
+
+  /**
+   * Check if this site has at least one relevant active migration.
+   *
+   * This method first identifies all enabled migrations, then removes any
+   * migrations listed in the SKIP_IMPORTERS as these are handled in other parts
+   * of the dashboard. Finally, it excludes any migrations that have not run in
+   * the last 30 days.
+   *
+   * @return boolean
+   *   TRUE if this site has at least one 'other' migration; otherwise, FALSE.
+   */
+  protected function hasActiveMigration() {
+    $all_migrations = array_keys($this->migrationManager->getDefinitions());
+    $other_migrations = array_diff($all_migrations, self::SKIP_IMPORTERS);
+    foreach ($other_migrations as $id) {
+      $last_imported = (int) $this->lastImportedStore->get($id, FALSE);
+      if ($last_imported / 1000 >= time() - (30 * 24 * 60 * 60)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "people_importer_info",
  *   label = @Translation("People Importers"),
  *   description = @Translation("Retrieves people importer information from capx_importer entities."),
+ *   weight = 30,
  * )
  */
 class PeopleImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoBase.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoBase.php
@@ -92,4 +92,18 @@ abstract class ImporterInfoBase extends PluginBase implements ImporterInfoInterf
     return $this->t('<em>No import data available.</em>');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getWeight(): int {
+    return $this->getPluginDefinition()['weight'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function showImporter(): bool {
+    return TRUE;
+  }
+
 }

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoInterface.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoInterface.php
@@ -50,4 +50,20 @@ interface ImporterInfoInterface extends PluginInspectionInterface {
    */
   public function getNoDataCaption(): TranslatableMarkup;
 
+  /**
+   * Gets the default weight for the importer.
+   *
+   * @return int
+   *   A no data caption.
+   */
+  public function getWeight(): int;
+
+  /**
+   * Method for conditionally showing or hiding the importer.
+   *
+   * @return bool
+   *   TRUE if the importer should display; FALSE if it should hide.
+   */
+  public function showImporter(): bool;
+
 }

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
@@ -53,7 +53,7 @@ class ImporterInfoManager extends DefaultPluginManager {
       $instances[$plugin_id] = $this->createInstance($plugin_id);
     }
 
-    usort($instances, function($a, $b) {
+    usort($instances, function ($a, $b) {
       return $a->getWeight() - $b->getWeight();
     });
 

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
@@ -53,6 +53,10 @@ class ImporterInfoManager extends DefaultPluginManager {
       $instances[$plugin_id] = $this->createInstance($plugin_id);
     }
 
+    usort($instances, function($a, $b) {
+      return $a->getWeight() - $b->getWeight();
+    });
+
     return $instances;
   }
 
@@ -62,9 +66,15 @@ class ImporterInfoManager extends DefaultPluginManager {
   public function generateTables(): array {
     $tables = [];
 
+    /** @var \Drupal\hs_dashboard\Plugin\ImporterInfoInterface $importer */
     foreach ($this->getImporterInstances() as $plugin_id => $importer) {
       $caption = $importer->getCaption();
       $rows = $importer->getTableRows();
+
+      if (!$importer->showImporter()) {
+        // Skip the importer if its visibility is set to not display.
+        continue;
+      }
 
       if (empty($rows)) {
         $no_data_caption = $importer->getNoDataCaption();


### PR DESCRIPTION
# Summary
Displays a message if 'other' migration importers are running on the website outside of the importers already displayed on the dashboard. A few details:
* The 'other importers' included all migrations that are not included in other importers. This is a relationship that is hardcoded within the plugin as a constant. We decide a migration is active if it has run in the last 30 days.
* A new method is added to the ImporterInfo plugin to show or hide content on the dashboard. This method is used to hide the 'other importers' block when there is no related content.
* A new property is added to the ImporterInfo plugin to define the block weight. This value is used to control the sort order of block when rendering importer information on the dashboard.

## Need Review By (Date)
Not tied to an established deadline

## Urgency
Low

## Steps to Test
1. [Login to a test environment](https://pr1796-7kw9glah6ej6f7oysjsjrfaazk8iiuxj.tugboatqa.com/user)
2. Navigate to [the dashboard](https://pr1796-7kw9glah6ej6f7oysjsjrfaazk8iiuxj.tugboatqa.com/admin/dashboard)
3. Test block existence: Locate the 'Importers' section of the dashboard and verify that the interface includes information for all 4 known ImporterInfo blocks: Course, Event, People, and Other.
4. Validate sort order: Verify that the ImporterInfo blocks are rendered in the following order: Course, Event, People, and Other. This is based on the recent work to set a sort order, as these would have previously been displayed in alphabetical order.
5. Block hides if there are no 'other importers'. I have not found a way to test this on one of the multidevs. to test locally, update the last import time for all migration to be longer than 30 days. The entire 'other importers' block will hide.
```
UPDATE suhumsci_ethicsinsociety.key_value SET value = 'd:1735689600000;' WHERE collection = 'migrate_last_imported';
```

<img width="921" alt="importers" src="https://github.com/user-attachments/assets/615d9444-7e26-4e83-8be5-e9cf01922874" />

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
