### PR TITLE
SHS-6121: Manage Roles link on Users admin page

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -465,20 +465,6 @@ function _su_humsci_clear_menu_cache_tags() {
 }
 
 /**
- * Implements hook_entity_operation_alter().
- */
-function su_humsci_profile_entity_operation_alter(array &$operations, EntityInterface $entity) {
-  $role_delegation = \Drupal::moduleHandler()->moduleExists('role_delegation');
-  if ($entity instanceof UserInterface && $role_delegation) {
-    $operations['roles'] = [
-      'title' => t('Manage Roles'),
-      'weight' => 11,
-      'url' => Url::fromRoute('role_delegation.edit_form', ['user' => $entity->id()]),
-    ];
-  }
-}
-
-/**
  * Implements hook_form_FORM_ID_alter().
  */
 function su_humsci_profile_form_user_admin_permissions_alter(array &$form, FormStateInterface $form_state) {

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -16,7 +16,6 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\menu_position\Entity\MenuPositionRule;
 use Drupal\node\NodeInterface;


### PR DESCRIPTION
# Summary
- Remove "Manage Roles" operation from Users admin view. It links to a 404 page and it's not needed anymore.

## Need Review By (Date)
04/16

## Urgency
low

## Steps to Test
1. Log into the [test site](https://pr1802-kepomw9mpw1j6utjjfevzpxhvxcf5v95.tugboatqa.com/user)
2. Visit the [Manage Users page](https://pr1802-kepomw9mpw1j6utjjfevzpxhvxcf5v95.tugboatqa.com/admin/users)
3. Confirm that "Manage Roles" is not present anymore in the user operations (last column of the table). Depending on your user permissions, you only see "Edit" or "Edit" and "Masquerade as".

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
