### PR TITLE
HSD8-1736: Replaced patch for oembed error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -242,7 +242,7 @@
                 "Allow media items to be edited in a modal when using the field widget https://www.drupal.org/project/drupal/issues/2985168": "https://www.drupal.org/files/issues/2023-12-18/2985168-172.patch",
                 "Cannot read properties of undefined (reading 'settings') with dialog.position.js https://www.drupal.org/project/drupal/issues/3356667": "patches/core/core-mr-8892.patch",
                 "https://www.drupal.org/project/drupal/issues/3207813: ModuleHandler skips all hook implementations when invoked before the module files have been loaded": "patches/core/core-mr-6976.patch",
-                "https://www.drupal.org/project/drupal/issues/3202896: Do not display oEmbed resource error to anonymous users": "patches/core/core-3202896-mr-9357-20250227.patch"
+                "https://www.drupal.org/project/drupal/issues/3202896: Do not display oEmbed resource error to anonymous users": "patches/core/core-3202896-mr-9357-20250410.patch"
             },
             "drupal/entity_reference_exposed_filters": {
                 "https://www.drupal.org/project/entity_reference_exposed_filters/issues/3189025": "https://www.drupal.org/files/issues/2023-10-17/entity_reference_exposed_filters-empty_target-3189025-4.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51266700c560cee5173f4595473dd032",
+    "content-hash": "8404575ec6695446c6b94f1104b540be",
     "packages": [
         {
             "name": "acquia/blt",

--- a/patches/core/core-3202896-mr-9357-20250410.patch
+++ b/patches/core/core-3202896-mr-9357-20250410.patch
@@ -1,5 +1,5 @@
 diff --git a/core/modules/media/src/Plugin/media/Source/OEmbed.php b/core/modules/media/src/Plugin/media/Source/OEmbed.php
-index 3f58ca120511badd58c223b8f2e3254eac284ef0..855734dd9f14157c9410ae3978e4b3b8f7ae0c14 100644
+index 3f58ca120511badd58c223b8f2e3254eac284ef0..9e1b051f0b4d0d24051380455ecb80e7875739e1 100644
 --- a/core/modules/media/src/Plugin/media/Source/OEmbed.php
 +++ b/core/modules/media/src/Plugin/media/Source/OEmbed.php
 @@ -33,6 +33,8 @@
@@ -11,12 +11,15 @@ index 3f58ca120511badd58c223b8f2e3254eac284ef0..855734dd9f14157c9410ae3978e4b3b8
  
  /**
   * Provides a media source plugin for oEmbed resources.
-@@ -243,7 +245,19 @@ public function getMetadata(MediaInterface $media, $name) {
+@@ -243,7 +245,22 @@ public function getMetadata(MediaInterface $media, $name) {
        $resource = $this->resourceFetcher->fetchResource($resource_url);
      }
      catch (ResourceException $e) {
 -      $this->messenger->addError($e->getMessage());
-+      if ($media->access('update')) {
++      if (
++        $media->id() &&
++        $media->access('update')
++      ) {
 +        $link = Link::createFromRoute($this->t('edit'), 'entity.media.edit_form', ['media' => $media->id()]);
 +        $this->messenger->addError(Markup::create($e->getMessage() . " Update media entity: " . $link->toString()));
 +      }


### PR DESCRIPTION
# Summary
Replaced patch for oembed error
More info here: https://www.drupal.org/project/drupal/issues/3202896#comment-16063266

> I ran into a unique fatal error caused by the patch. In short, the media entity being used to generate the edit link for the error message will not always have an ID or valid edit link. 
> In length, a content type with an oEmbed media entity will reference the media entity using an entity reference field. When using layout builder for the default display for the content type, the content preview for layout builder uses [the generateSampleValue method on the entity reference item](https://git.drupalcode.org/project/drupal/-/blob/11.x/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php?ref_type=heads#L334) to generate a preview. The method attempts to find a random, valid entity to use as a sample value. If it cannot find one, it generates an entity on the fly. The entity generated on the fly is not saved, and does not have a valid ID. This throws a fatal error then when using this code because it attempts to generate an edit link on a media entity without an ID.