### PR TITLE
SHS-6112 :: Don't give an error-like message when linking to an anchor on the current page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -256,7 +256,7 @@
                 "https://www.drupal.org/project/hook_event_dispatcher/issues/3354751": "https://git.drupalcode.org/project/hook_event_dispatcher/-/merge_requests/133.patch"
             },
             "drupal/linkit": {
-                "https://www.drupal.org/project/linkit/issues/3209603": "https://git.drupalcode.org/project/linkit/-/merge_requests/3.patch"
+                "https://www.drupal.org/project/linkit/issues/3209603": "patches/contrib/linkit-3209603-mr-3.patch"
             },
             "drupal/menu_link": {
                 "https://www.drupal.org/project/menu_link/issues/3145735": "https://www.drupal.org/files/issues/2022-03-22/menu_link-empty-entity-error-3145735-7.patch",

--- a/composer.json
+++ b/composer.json
@@ -254,6 +254,9 @@
             "drupal/hook_event_dispatcher": {
                 "https://www.drupal.org/project/hook_event_dispatcher/issues/3354751": "https://git.drupalcode.org/project/hook_event_dispatcher/-/merge_requests/133.patch"
             },
+            "drupal/linkit": {
+                "https://www.drupal.org/project/linkit/issues/3209603": "https://git.drupalcode.org/project/linkit/-/merge_requests/3.patch"
+            },
             "drupal/menu_link": {
                 "https://www.drupal.org/project/menu_link/issues/3145735": "https://www.drupal.org/files/issues/2022-03-22/menu_link-empty-entity-error-3145735-7.patch",
                 "https://www.drupal.org/project/menu_link/issues/3092282": "https://git.drupalcode.org/project/menu_link/-/merge_requests/8.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51266700c560cee5173f4595473dd032",
+    "content-hash": "08bef54c1760825a46727b8a97333446",
     "packages": [
         {
             "name": "acquia/blt",

--- a/config/default/linkit.linkit_profile.default.yml
+++ b/config/default/linkit.linkit_profile.default.yml
@@ -32,3 +32,8 @@ matchers:
       substitution_type: media_download_inline
       limit: 100
     weight: 0
+  aab20add-64e1-4071-89f7-9b7caad82b33:
+    id: anchor_basic
+    uuid: aab20add-64e1-4071-89f7-9b7caad82b33
+    settings: {  }
+    weight: 0

--- a/patches/contrib/linkit-3209603-mr-3.patch
+++ b/patches/contrib/linkit-3209603-mr-3.patch
@@ -1,0 +1,71 @@
+diff --git a/src/Plugin/Linkit/Matcher/AnchorMatcher.php b/src/Plugin/Linkit/Matcher/AnchorMatcher.php
+new file mode 100644
+index 0000000000000000000000000000000000000000..0f8230d94039a0eaa13289c414c8bf54e366f0e2
+--- /dev/null
++++ b/src/Plugin/Linkit/Matcher/AnchorMatcher.php
+@@ -0,0 +1,39 @@
++<?php
++
++namespace Drupal\linkit\Plugin\Linkit\Matcher;
++
++use Drupal\Component\Utility\Html;
++use Drupal\linkit\MatcherBase;
++use Drupal\linkit\Suggestion\DescriptionSuggestion;
++use Drupal\linkit\Suggestion\SuggestionCollection;
++
++/**
++ * Provides specific linkit matchers for anchors. Does not check anchor exists.
++ *
++ * @Matcher(
++ *   id = "anchor_basic",
++ *   label = @Translation("Anchor (basic)"),
++ * )
++ */
++class AnchorMatcher extends MatcherBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function execute($string) {
++    $suggestions = new SuggestionCollection();
++
++    // Check for a # and tell people it's an anchor.
++    if (substr($string, 0, 1) == '#' && strlen($string) > 1) {
++      $suggestion = new DescriptionSuggestion();
++      $suggestion->setLabel($this->t('Anchor @anchor', ['@anchor' => $string]))
++        ->setPath(Html::escape($string))
++        ->setGroup($this->t('Anchor'))
++        ->setDescription($this->t('Links to an anchor named @anchor on the current page', ['@anchor' => $string]));
++
++      $suggestions->addSuggestion($suggestion);
++    }
++    return $suggestions;
++  }
++
++}
+diff --git a/tests/src/Kernel/LinkitAutocompleteTest.php b/tests/src/Kernel/LinkitAutocompleteTest.php
+index 5eae284162e2cf2ef562d3fd8f8131e1bca3a23a..5e1e7909515170cc98bcb1a7b7e1503bb00b8a4b 100644
+--- a/tests/src/Kernel/LinkitAutocompleteTest.php
++++ b/tests/src/Kernel/LinkitAutocompleteTest.php
+@@ -114,6 +114,21 @@ class LinkitAutocompleteTest extends LinkitKernelTestBase {
+     $this->assertSame('mailto:' . $email, $data[0]['path'], 'Autocomplete returned email suggestion with an mailto href.');
+   }
+
++  /**
++   * Tests the autocomplete with an anchor (basic).
++   */
++  public function testAutocompletionAnchorBasic() {
++    /** @var \Drupal\linkit\MatcherInterface $plugin */
++    $plugin = $this->matcherManager->createInstance('anchor_basic');
++    $this->linkitProfile->addMatcher($plugin->getConfiguration());
++    $this->linkitProfile->save();
++
++    $anchor = '#example';
++    $data = $this->getAutocompleteResult($anchor);
++    $this->assertSame((string) new FormattableMarkup('Anchor @anchor', ['@anchor' => $anchor]), $data[0]['label'], 'Autocomplete returned anchor suggestion.');
++    $this->assertSame($anchor, $data[0]['path'], 'Autocomplete returned anchor suggestion as entered.');
++  }
++
+   /**
+    * Tests autocompletion in general.
+    */


### PR DESCRIPTION
# Summary
- Add patch and enable anchor matcher plugin for Linkit

## Need Review By (Date)
04/30

## Urgency
medium

## Steps to Test
1. In a text component, click on the link button in CKEditor. Start typing an anchor, ie #example. Verify it shows you text that validates the anchor _"Links to an anchor named #example on the current page"_ rather than an error-like message (see ticket).

<img width="869" alt="Screenshot 2025-04-22 at 12 41 52 PM" src="https://github.com/user-attachments/assets/651ed28a-f232-4099-bfb5-14625cb37ec3" />


# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
