### PR TITLE
fix(SHS-6196): catch _any_ exception when fetching the Announcements google spreadsheet

### DIFF
--- a/docroot/modules/humsci/hs_dashboard/src/AnnouncementsManager.php
+++ b/docroot/modules/humsci/hs_dashboard/src/AnnouncementsManager.php
@@ -15,7 +15,6 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/docroot/modules/humsci/hs_dashboard/src/AnnouncementsManager.php
+++ b/docroot/modules/humsci/hs_dashboard/src/AnnouncementsManager.php
@@ -136,7 +136,7 @@ class AnnouncementsManager implements ContainerInjectionInterface {
       return $this->parseCsv($csv_content);
 
     }
-    catch (RequestException $e) {
+    catch (\Exception $e) {
       $this->logger->error('Error retrieving CSV from {url}: {message}', [
         'url' => $csv_url,
         'message' => $e->getMessage(),


### PR DESCRIPTION
# Summary
fatal exception when fetching Announcements google sheet
<img width="1490" alt="Screenshot 2025-05-09 at 11 30 11 AM" src="https://github.com/user-attachments/assets/69633926-33c5-41bf-bfc4-5d77e8a63c4a" />


## Need Review By (Date)
within the next few days, we want to get this into the next release

## Urgency
high

## Steps to Test
1. Honestly, this will be very difficult to reproduce the error.  I think you just gotta go by gut feel.

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
