### PR TITLE
Drop level 2 mobile menu functional test

### DIFF
--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Codeception\Util\Locator;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Faker\Factory;
 
 /**
@@ -173,8 +174,28 @@ class FlexiblePageCest {
 
   /**
    * Verify main menu links at mobile size.
+   * @group mobile_menu
    */
   public function testMobileMenu(FunctionalTester $I) {
+    // Create nested menu items for testing.
+    $parent_item = MenuLinkContent::create([
+      'title' => 'Parent',
+      'description' => 'Parent test link',
+      'link' => 'internal:/bar/foo',
+      'weight' => 0,
+      'menu_name' => 'main',
+    ]);
+    $parent_item->save();
+    $menu_item = MenuLinkContent::create([
+      'title' => 'Test link',
+      'description' => 'Test link',
+      'link' => 'internal:/foo/bar',
+      'weight' => 0,
+      'menu_name' => 'main',
+      'parent' => 'menu_link_content:' . $parent_item->uuid(),
+    ]);
+    $menu_item->save();
+
     // Check standard menu item links.
     $I->amOnPage('/');
     $I->resizeWindow(800, 1100);
@@ -226,6 +247,10 @@ class FlexiblePageCest {
     $I->click('.hb-main-nav__toggle');
     $I->seeElement('.hb-main-nav__menu');
     $I->click('.hb-main-nav__link');
+
+    // Delete menu items.
+    $parent_item->delete();
+    $menu_item->delete();
   }
 
   /**

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Codeception\Util\Locator;
-use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Faker\Factory;
 
 /**
@@ -177,25 +176,6 @@ class FlexiblePageCest {
    * @group mobile_menu
    */
   public function testMobileMenu(FunctionalTester $I) {
-    // Create nested menu items for testing.
-    $parent_item = MenuLinkContent::create([
-      'title' => 'Parent',
-      'description' => 'Parent test link',
-      'link' => 'internal:/bar/foo',
-      'weight' => 0,
-      'menu_name' => 'main',
-    ]);
-    $parent_item->save();
-    $menu_item = MenuLinkContent::create([
-      'title' => 'Test link',
-      'description' => 'Test link',
-      'link' => 'internal:/foo/bar',
-      'weight' => 0,
-      'menu_name' => 'main',
-      'parent' => 'menu_link_content:' . $parent_item->uuid(),
-    ]);
-    $menu_item->save();
-
     // Check standard menu item links.
     $I->amOnPage('/');
     $I->resizeWindow(800, 1100);
@@ -219,23 +199,25 @@ class FlexiblePageCest {
       $I->click('.hb-main-nav__link');
     }
 
+    // As of 2025-05-13 there is no secondary level menu items to test on a 
+    // newly provisioned site.
     // This try/catch keeps the toggle consistent between environment testing.
     // Check nested menu item links.
-    try {
-      echo('If you see this, the nested menu link was already available to click.');
-      $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-      // Click nested menu link if it's already visible.
-      $I->click('.hb-main-nav__menu-lv2 a');
-    }
-    catch (\Exception $e) {
-      // Do this if the nested menu link is not already visible.
-      echo('If you see this, the nested menu link needs to be opened to click.');
-      $I->click('.hb-main-nav__toggle');
-      $I->waitForElementVisible('.hb-nested-toggler');
-      $I->click('.hb-nested-toggler');
-      $I->waitForElementVisible('.hb-main-nav__menu-lv2');
-      $I->click('.hb-main-nav__menu-lv2 a');
-    }
+    // try {
+    //   echo('If you see this, the nested menu link was already available to click.');
+    //   $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    //   // Click nested menu link if it's already visible.
+    //   $I->click('.hb-main-nav__menu-lv2 a');
+    // }
+    // catch (\Exception $e) {
+    //   // Do this if the nested menu link is not already visible.
+    //   echo('If you see this, the nested menu link needs to be opened to click.');
+    //   $I->click('.hb-main-nav__toggle');
+    //   $I->waitForElementVisible('.hb-nested-toggler');
+    //   $I->click('.hb-nested-toggler');
+    //   $I->waitForElementVisible('.hb-main-nav__menu-lv2');
+    //   $I->click('.hb-main-nav__menu-lv2 a');
+    // }
 
     // Check standard menu item links for logged in users.
     $I->logInWithRole('contributor');
@@ -247,10 +229,6 @@ class FlexiblePageCest {
     $I->click('.hb-main-nav__toggle');
     $I->seeElement('.hb-main-nav__menu');
     $I->click('.hb-main-nav__link');
-
-    // Delete menu items.
-    $parent_item->delete();
-    $menu_item->delete();
   }
 
   /**


### PR DESCRIPTION
# Summary
Dropped the level 2 mobile menu functional test.
The default site no longer has nested links in the main menu.

## Need Review By (Date)
_[When does this need to be reviewed by? '10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test
1. _[First testing step]_
2. ...

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
