### PR TITLE
Lock shortcut_menu module to version 3.0.0-beta7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,7 @@
         "drupal/seckit": "^2.0",
         "drupal/selective_better_exposed_filters": "^3.0@beta",
         "drupal/shield": "^1.4",
-        "drupal/shortcut_menu": "^3.0@beta",
+        "drupal/shortcut_menu": "3.0.0-beta7",
         "drupal/single_content_sync": "^1.4",
         "drupal/slick_paragraphs": "^2.0",
         "drupal/smart_date": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "716d976fef5302f3f7e07537a6c2b26f",
+    "content-hash": "9ee17527506957cbab041b8f404cd48e",
     "packages": [
         {
             "name": "acquia/blt",
@@ -10794,17 +10794,17 @@
         },
         {
             "name": "drupal/shortcut_menu",
-            "version": "3.0.0-beta8",
+            "version": "3.0.0-beta7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/shortcut_menu.git",
-                "reference": "3.0.0-beta8"
+                "reference": "3.0.0-beta7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/shortcut_menu-3.0.0-beta8.zip",
-                "reference": "3.0.0-beta8",
-                "shasum": "f83b24c859bc05a545ed2efd309f33474a5d31ee"
+                "url": "https://ftp.drupal.org/files/projects/shortcut_menu-3.0.0-beta7.zip",
+                "reference": "3.0.0-beta7",
+                "shasum": "ff123fb05a4b1eb4f22583b23c4ee2562e91a58f"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11"
@@ -10812,8 +10812,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0-beta8",
-                    "datestamp": "1747240219",
+                    "version": "3.0.0-beta7",
+                    "datestamp": "1728069056",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -26652,7 +26652,6 @@
         "drupal/masquerade": 10,
         "drupal/menu_position": 10,
         "drupal/selective_better_exposed_filters": 10,
-        "drupal/shortcut_menu": 10,
         "drupal/spamspan": 10,
         "drupal/ui_patterns_field_variants": 20,
         "drupal/viewfield": 10,


### PR DESCRIPTION
# Summary
- Lock `shortcut_menu` version to `3.0.0-beta7`

## Backstory

Current version (beta8) this error when the shortcuts menu is visible:

```
Fatal error: Type of Drupal\shortcut_menu\ShortcutMenuLazyBuilder::$entityTypeManager must be ?Drupal\Core\Entity\EntityTypeManagerInterface (as in class Drupal\shortcut\ShortcutLazyBuilders) in /var/lib/tugboat/docroot/modules/contrib/shortcut_menu/src/ShortcutMenuLazyBuilder.php on line 0
```

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Confirm that the error is not present anymore and that it's possible to visit any page when the shortcuts menu is visible.

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
