### PR TITLE
HSD8-1734: Adjust custom menu_link cache tag to match invalidation

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/src/MenuLinkTreeOverride.php
+++ b/docroot/profiles/humsci/su_humsci_profile/src/MenuLinkTreeOverride.php
@@ -32,7 +32,7 @@ class MenuLinkTreeOverride implements MenuLinkTreeInterface {
    */
   public function build(array $tree) {
     $build = $this->menuTree->build($tree);
-    $build['#cache']['tags'][] = 'stanford_profile_helper:menu_links';
+    $build['#cache']['tags'][] = 'su_humsci_profile:menu_links';
     // Remove node cache tags since we'll use our own cache tag above.
     HumsciCleanup::removeCacheTags($build, [
       '^node:*',


### PR DESCRIPTION
# Summary
Adjusted the custom `menu_link` cache tag to match invalidation tag.

## Backstory
[HSD8-1734](https://stanfordits.atlassian.net/browse/HSD8-1734): Top level menu changes are not reflected immediately

[HSD8-1734]: https://stanfordits.atlassian.net/browse/HSD8-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ