### PR TITLE
SHS-6208: Dashboard | Fix Ajax scroll behavior in Admin theme

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
@@ -1,0 +1,43 @@
+((Drupal) => {
+  Drupal.behaviors.duplicateProfilesAjaxViewScrollOffset = {
+    attach() {
+      // Override the default Drupal Views AJAX scrolling behavior.
+      if (Drupal.AjaxCommands.prototype.scrollTop) {
+        Drupal.AjaxCommands.prototype.scrollTop = function (ajax, response) {
+          // Prevent automatic scrolling by overriding the function.
+          const selector = response.selector;
+
+          // Gets the selector of the updated view that Drupal wants to scroll to.
+          const targetElement = document.querySelector(selector);
+          if (!targetElement) return;
+
+          let scrollTarget = targetElement;
+
+          // Traverse up the DOM until we find a scrollable parent
+          while (
+            scrollTarget.scrollTop === 0 &&
+            scrollTarget.parentElement
+          ) {
+            scrollTarget = scrollTarget.parentElement;
+          }
+
+          const rect = targetElement.getBoundingClientRect();
+          const scrollTop = window.scrollY || document.documentElement.scrollTop;
+          const offsetTop = rect.top + scrollTop;
+
+          // Subtracts a fixed height for the sticky header so the element isn't hidden behind it when scrolling.
+          const headerHeight = 230;
+          const scrollPosition = offsetTop - headerHeight;
+
+          // Scroll only if the element is above the current scroll position
+          if (scrollPosition < scrollTarget.scrollTop) {
+            scrollTarget.scrollTo({
+              top: scrollPosition,
+              behavior: 'smooth',
+            });
+          }
+        };
+      }
+    },
+  };
+})(Drupal);

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
@@ -1,43 +1,81 @@
 ((Drupal) => {
   Drupal.behaviors.duplicateProfilesAjaxViewScrollOffset = {
     attach() {
-      // Override the default Drupal Views AJAX scrolling behavior.
-      if (Drupal.AjaxCommands.prototype.scrollTop) {
-        Drupal.AjaxCommands.prototype.scrollTop = function (ajax, response) {
-          // Prevent automatic scrolling by overriding the function.
-          const selector = response.selector;
+      if (!Drupal.AjaxCommands.prototype.scrollTop) return;
 
-          // Gets the selector of the updated view that Drupal wants to scroll to.
-          const targetElement = document.querySelector(selector);
-          if (!targetElement) return;
-
-          let scrollTarget = targetElement;
-
-          // Traverse up the DOM until we find a scrollable parent
-          while (
-            scrollTarget.scrollTop === 0 &&
-            scrollTarget.parentElement
-          ) {
-            scrollTarget = scrollTarget.parentElement;
-          }
-
-          const rect = targetElement.getBoundingClientRect();
-          const scrollTop = window.scrollY || document.documentElement.scrollTop;
-          const offsetTop = rect.top + scrollTop;
-
-          // Subtracts a fixed height for the sticky header so the element isn't hidden behind it when scrolling.
-          const headerHeight = 230;
-          const scrollPosition = offsetTop - headerHeight;
-
-          // Scroll only if the element is above the current scroll position
-          if (scrollPosition < scrollTarget.scrollTop) {
-            scrollTarget.scrollTo({
-              top: scrollPosition,
-              behavior: 'smooth',
-            });
-          }
-        };
+      // Calculate offset top
+      function calculateElementOffset(element) {
+        const rect = element.getBoundingClientRect();
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        return rect.top + scrollTop;
       }
+
+      // Calculate total sticky offset height
+      function calculateStickyHeaderHeight(element) {
+        let headerHeight = 0;
+
+        // Define an array of elements that contribute to sticky height
+        const stickyElements = [
+          document.getElementById("toolbar-bar"),
+          document.querySelector(".toolbar-tray.is-active"),
+          document.querySelector("header.region-sticky"),
+          element?.parentElement?.parentElement?.querySelector("h2"),
+        ];
+
+        // Loop through elements and add height only if they exist
+        stickyElements.forEach((el) => {
+          if (el && el.offsetHeight) {
+            headerHeight += el.offsetHeight;
+          }
+        });
+
+        // Get padding top from the block element safely
+        const blockElement = element?.parentElement?.parentElement;
+        const computedStyle = blockElement
+          ? getComputedStyle(blockElement)
+          : null;
+        const paddingTop = computedStyle
+          ? parseFloat(computedStyle.paddingTop) || 0
+          : 0;
+
+        headerHeight += paddingTop;
+
+        return headerHeight;
+      }
+
+      // Override the default Drupal Views AJAX scrolling behavior.
+      Drupal.AjaxCommands.prototype.scrollTop = function (ajax, response) {
+        // Prevent automatic scrolling by overriding the function.
+        const selector = response.selector;
+
+        // Gets the selector of the updated view that Drupal wants to scroll to.
+        const targetElement = document.querySelector(selector);
+        if (!targetElement) return;
+
+        let scrollTarget = targetElement;
+
+        // Traverse up the DOM until we find a scrollable parent
+        while (scrollTarget.scrollTop === 0 && scrollTarget.parentElement) {
+          scrollTarget = scrollTarget.parentElement;
+        }
+
+        // Calculate offset top
+        const offsetTop = calculateElementOffset(targetElement);
+
+        // Calculate total sticky offset height
+        const headerHeight = calculateStickyHeaderHeight(targetElement);
+
+        // Subtracts a fixed height for the sticky header so the element isn't hidden behind it when scrolling.
+        const scrollPosition = offsetTop - headerHeight;
+
+        // Scroll only if the element is above the current scroll position
+        if (scrollPosition < scrollTarget.scrollTop) {
+          scrollTarget.scrollTo({
+            top: scrollPosition,
+            behavior: "smooth",
+          });
+        }
+      };
     },
   };
 })(Drupal);

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/ajax-scroll-fix.js
@@ -19,7 +19,7 @@
           document.getElementById("toolbar-bar"),
           document.querySelector(".toolbar-tray.is-active"),
           document.querySelector("header.region-sticky"),
-          element?.parentElement?.parentElement?.querySelector("h2"),
+          element.closest('.block')?.querySelector('h2'),
         ];
 
         // Loop through elements and add height only if they exist
@@ -30,7 +30,7 @@
         });
 
         // Get padding top from the block element safely
-        const blockElement = element?.parentElement?.parentElement;
+        const blockElement = element.closest('.block');
         const computedStyle = blockElement
           ? getComputedStyle(blockElement)
           : null;
@@ -44,7 +44,7 @@
       }
 
       // Override the default Drupal Views AJAX scrolling behavior.
-      Drupal.AjaxCommands.prototype.scrollTop = function (ajax, response) {
+      Drupal.AjaxCommands.prototype.scrollTop = function (_, response) {
         // Prevent automatic scrolling by overriding the function.
         const selector = response.selector;
 
@@ -66,7 +66,7 @@
         const headerHeight = calculateStickyHeaderHeight(targetElement);
 
         // Subtracts a fixed height for the sticky header so the element isn't hidden behind it when scrolling.
-        const scrollPosition = offsetTop - headerHeight;
+        const scrollPosition = offsetTop - headerHeight - 20; // 20px is an additional buffer to make it more visually appealing.
 
         // Scroll only if the element is above the current scroll position
         if (scrollPosition < scrollTarget.scrollTop) {

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
@@ -14,6 +14,12 @@ fix-autocomplete-width:
   js:
     js/fix-autocomplete-width.js: {}
 
+ajax-scroll-fix:
+  js:
+    js/ajax-scroll-fix.js: {}
+  dependencies:
+    - core/drupal
+
 paragraph-previews-slideshow-width:
   js:
     js/paragraph-previews-slideshow-width.js: {}

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -80,6 +80,7 @@ function su_humsci_gin_admin_preprocess_html(&$variables, $hook) {
     // Add a custom class and attach library to a dashboard.
     $variables['attributes']['class'][] = 'dashboard-content';
     $variables['#attached']['library'][] = 'su_humsci_gin_admin/su_humsci_dashboard';
+    $variables['#attached']['library'][] = 'su_humsci_gin_admin/ajax-scroll-fix';
   }
 }
 


### PR DESCRIPTION
# Summary
Fix ajax scroll to top behaviour in dashboard duplicate pages block

## Backstory

[SHS-6208](https://app.clickup.com/t/36718269/SHS-6208)

This task involves adjusting where the ajax pager scrolls to on the Dashboard's Duplicate Profiles block so that when paginating, the page scrolls a few pixels lower to improve user experience by displaying the top of the entire block. 

The issue was identified on sites with multiple pages of duplicate content like economics.stanford.edu


## Need Review By (Date)
06/16

## Urgency
high

## Steps to Test
1. Go to https://history-qhldsdh8ah7udg9flkdqoouqexmxnrws.tugboatqa.com/admin/dashboard
2. Confirm there are duplicate profiles (more than 1 page)... If there aren't, please add duplicate profiles/person
3. Confirm the scroll behaviour when going to a new page in the `Duplicate profiles` block work better and as expected

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210255635768967