### PR TITLE
SHS-6210: Dashboard: Update the no importer text on the Importer Blocks

### DIFF
--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
@@ -106,7 +106,7 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    * {@inheritDoc}
    */
   public function getNoDataCaption(): TranslatableMarkup {
-    return $this->t('<em>There are no course importers configured.</em>');
+    return $this->t('<em>There are no Stanford Courses importers configured.</em>');
   }
 
   /**

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
@@ -172,7 +172,7 @@ class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
    * {@inheritDoc}
    */
   public function getNoDataCaption(): TranslatableMarkup {
-    return $this->t('<em>There are no Localist importers configured.</em>');
+    return $this->t('<em>There are no Stanford Events importers configured.</em>');
   }
 
   /**

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
@@ -140,7 +140,7 @@ class PeopleImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    * {@inheritDoc}
    */
   public function getNoDataCaption(): TranslatableMarkup {
-    return $this->t('<em>There are no people importers configured.</em>');
+    return $this->t('<em>There are no Stanford Profiles importers configured.</em>');
   }
 
 }


### PR DESCRIPTION
# Summary
- Update the "no importers configured" message for the events, courses and profiles importers

## Backstory
- ClickUp Ticket

## Need Review By (Date)
06/18

## Urgency
medium

## Steps to Test
1. Log into a [Tugboat test site](https://hs-colorful-ugsa6ejumlivlbbxaoqbzswukavreodw.tugboatqa.com/user)
2. Visit the [Dashboard](https://hs-colorful-ugsa6ejumlivlbbxaoqbzswukavreodw.tugboatqa.com/admin/dashboard), scroll down to the _Importers_ block
3. Confirm that the "no importers configured" message is correct for the courses, events and profiles importers:
    - _There are no Stanford Courses importers configured._
    - _There are no Stanford Events importers configured._
    - _There are no Stanford Profiles importers configured._

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
