### PR TITLE
SHS-6226: Fix Secondary Button Active Hover State issue

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/tools/_mixins.buttons.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/tools/_mixins.buttons.scss
@@ -144,6 +144,7 @@
 
   &:active,
   &:focus {
+    color: var(--palette--secondary);
     background-color: transparent;
     box-shadow:
       0 0 0 hb-calculate-rems(2px) var(--palette--white),


### PR DESCRIPTION
# Summary
Fix secondary button active, focus and hover state issue

## Backstory
[SHS-6226](https://app.clickup.com/t/36718269/SHS-6226)
Right now, when you focus and hover at the same time over a secondary button, the text color is changing to white, giving accessibility and contrast issues.

## Need Review By (Date)
06/18

## Urgency
medium

## Steps to Test
1. Go to https://hs-colorful-nrm0bdineex2pr5pci5mm9ldc1t7n7si.tugboatqa.com/components/text-area-typography and https://hs-traditional-nrm0bdineex2pr5pci5mm9ldc1t7n7si.tugboatqa.com/components/text-area-typography
2. Confirm the `Secondary button` looks good in hover, focus and active state in all colorful and traditional pairings.

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210562597655646
  - https://app.asana.com/0/0/1209993231281867