### PR TITLE
SHS-6223: Dashboard | Update Accessibility block when there are no issues

### DIFF
--- a/config/default/views.view.editoria11y_results.yml
+++ b/config/default/views.view.editoria11y_results.yml
@@ -877,6 +877,20 @@ display:
         options:
           offset: 0
           items_per_page: 5
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There are no pages with accessibility issues.'
+            format: basic_html
+          tokenize: false
       sorts:
         page_result_count:
           id: page_result_count
@@ -935,6 +949,7 @@ display:
           separator: ''
           hide_empty: false
       defaults:
+        empty: false
         title: false
         pager: false
         use_more: false


### PR DESCRIPTION
# Summary
- Update "no results" behavior in editoria11y dashboard view

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6223)

## Need Review By (Date)
06/18

## Urgency
medium

## Steps to Test
1. All tugboat test sites have multiple pages with accessibility errors, so it's not possible to reproduce the conditions to test this fix. It can be tested locally (or in stage once deployed) in the `integrativeoceans` to confirm the following:
    - The "Pages with the most accessibility issues" dashboard block title stays the same even when there are no pages with accessibility errors
    - The message "There are no pages with accessibility issues." is displayed with when there are no pages with accessibility errors.

<img width="870" alt="Screenshot 2025-06-17 at 10 44 02 AM" src="https://github.com/user-attachments/assets/3a8daa20-3bc6-4178-86b8-feb7ed2b1e4f" />

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?