### PR TITLE
HSD8-1762: Add patch to remove destination from request in samlauth login process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -289,6 +289,9 @@
                 "https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2024-08-11/redirect--2024-08-11--3057250-79.patch",
                 "https://www.drupal.org/project/redirect/issues/3018897": "https://www.drupal.org/files/issues/2024-08-12/redirect-3018897-28.patch"
             },
+            "drupal/samlauth": {
+                "https://www.drupal.org/project/samlauth/issues/3530840: Set destination parameter as part of login": "patches/contrib/samlauth-3530840-try.patch"
+            },
             "drupal/shield": {
                 "https://www.drupal.org/project/shield/issues/3479117": "patches/shield-undefined_array_key_explode-3479117.patch"
             },

--- a/patches/contrib/samlauth-3530840-try.patch
+++ b/patches/contrib/samlauth-3530840-try.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Controller/SamlController.php b/src/Controller/SamlController.php
+index 8542af3..516ffb2 100644
+--- a/src/Controller/SamlController.php
++++ b/src/Controller/SamlController.php
+@@ -421,6 +421,15 @@ protected function getRedirectUrlAfterProcessing($after_acs = FALSE, $ignore_rel
+         // Check relay state URL; if it's unsafe (i.e. '' returned) then
+         // fall back to the default.
+         $url = $this->ensureSafeRelayState($relay_state, $after_acs);
++        if ($url) {
++          // If a destination parameter was set by other code in e.g. a login /
++          // logout hook, cancel it.
++          $request_query_parameters = $this->requestStack->getCurrentRequest()->query;
++          $destination = $request_query_parameters->get('destination');
++          if ($destination) {
++            $request_query_parameters->remove('destination');
++          }
++        }
+       }
+     }
+ 


### PR DESCRIPTION
# Summary
Added a patch to remove the `destination` parameter from the Drupal request as part of the `samlauth` login process.

## Backstory
[HSD8-1762](https://stanfordits.atlassian.net/browse/HSD8-1762): Dashboard: On log-in, don't force people to the dashboard if they were going elsewhere
https://www.drupal.org/project/samlauth/issues/3530840

The `samlauth` module uses its own methodology to redirect the user after logging in to the previous page they were on. Essentially it removes the `destination` off the current request, sends it with the Authentication request, receives it back with the Authentication response, and then creates `RedirectResponse` to do the redirect. 

The `dashboard` module simply by being enabled uses a login hook to check for the `destination` parameter on the current request, and if it's not set, sets it redirect to a dashboard.

The problem is because `samlauth` strips the `destination`, the `dashboard` module will always redirect to a dashboard after logging in, even if there was a `destination` to go to. The `samlauth` patch removes any custom set `destination` if `samlauth` has a destination to redirect to.

[HSD8-1762]: https://stanfordits.atlassian.net/browse/HSD8-1762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ