### PR TITLE
SHS-6285: Social Media Footer block setting are expanded by default on Stage

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_block-social-media-footer.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_block-social-media-footer.scss
@@ -1,7 +1,5 @@
-.block-social-media-footer {
-  ul {
-    @include hb-list-empty-styles;
-  }
+.social-media-link__list {
+  @include hb-list-empty-styles;
 
   li {
     display: flex;
@@ -47,7 +45,7 @@
 
 // Grid Layout.
 .block-social-media-footer--layout-grid {
-  ul {
+  .social-media-link__list {
     display: grid;
     gap: hb-calculate-rems(16px);
   }
@@ -59,7 +57,7 @@
 
 // Vertical List Layout.
 .block-social-media-footer--layout-vertical-list {
-  li {
+  .social-media-link__list li {
     margin-bottom: hb-calculate-rems(16px);
   }
 
@@ -85,7 +83,7 @@
   }
 
   .social-media-link__list {
-    grid-template-columns: repeat(auto-fit, minmax(hb-calculate-rems(24px), 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(hb-calculate-rems(32px), 1fr));
   }
 }
 
@@ -96,6 +94,6 @@
   }
 
   .social-media-link__list {
-    grid-template-columns: repeat(auto-fit, minmax(hb-calculate-rems(30px), 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(hb-calculate-rems(48px), 1fr));
   }
 }


### PR DESCRIPTION
# Summary
- Fix conflicting selectors in social media footer block styles
- Minor fix in icon grid dimensions

## Backstory
-[ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6285)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Log into the [colorful](https://hs-colorful-wuux7oocbgnpmjmtnrhlqlyubbvyd0hn.tugboatqa.com/user) and [traditional](https://hs-traditional-wuux7oocbgnpmjmtnrhlqlyubbvyd0hn.tugboatqa.com/user) tugboat sites
2. Scroll down to the footer. Confirm that the social media block is not expanded by default
3. Confirm that you can click on the pencil icon and expand the contextual menu

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
