### PR TITLE
Bug | Fix duplicated roles in user edit form

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -921,7 +921,7 @@ function su_humsci_profile_form_user_form_alter(&$form, FormStateInterface $form
   $is_admin = in_array('administrator', $roles);
   $is_manager = in_array('site_manager', $roles);
   $is_admin_or_manager = $is_admin || $is_manager;
-  $is_saml_user = $authmap->get($account->id(), 'samlauth');
+  $is_saml_user = !empty($account->id()) && $authmap->get($account->id(), 'samlauth');
 
   if ($is_saml_user) {
     // Changes to the user form for SAML users.
@@ -932,7 +932,6 @@ function su_humsci_profile_form_user_form_alter(&$form, FormStateInterface $form
     ];
     $form['account']['mail']['#disabled'] = !$is_admin;
     $form['account']['name']['#access'] = $is_admin_or_manager;
-    $form['account']['roles']['#access'] = $is_admin_or_manager;
     $form['account']['status']['#access'] = $is_admin_or_manager;
     $form['account']['pass']['#access'] = FALSE;
   }
@@ -943,7 +942,6 @@ function su_humsci_profile_form_user_form_alter(&$form, FormStateInterface $form
     $form['account']['name']['#description'] = t('Warning: This person uses their username to log in.  Please notify them before changing.');
     $form['account']['pass']['#description'] = t('Warning: This person uses their password to log in.  Please notify them before changing.');
     $form['account']['pass']['#access'] = TRUE;
-    $form['account']['roles']['#access'] = $is_admin_or_manager;
     $form['account']['status']['#access'] = $is_admin_or_manager;
   }
 


### PR DESCRIPTION
# Summary
- The role checkboxes was being duplicated in the user edit form for non-admin users. This PR fixes it.

## Backstory
- Fixed as part of #1870, however it was decided to create a separate PR to make review easier (see [this slack thread](https://fourkitchens.slack.com/archives/C03DD43ACPK/p1750284262004689)).

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Log into a [tugboat test site](https://hs-colorful-e0wrc0pbpq2gz9ptfwzzmekx6ylccktr.tugboatqa.com/user)
2. Masquerade as a Site Manager user (e.g. `Lindsey`)
3. Visit the [users admin list](https://hs-colorful-e0wrc0pbpq2gz9ptfwzzmekx6ylccktr.tugboatqa.com/admin/users) and edit any existing user.
4. Confirm that the roles checkboxes are not duplicated 

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210604602064028