### PR TITLE
HSD8-1774: Adding back to top to default flexible page layout

### DIFF
--- a/config/default/core.entity_view_display.node.hs_basic_page.default.yml
+++ b/config/default/core.entity_view_display.node.hs_basic_page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - node.type.hs_basic_page
     - system.menu.main
   module:
+    - hs_blocks
     - hs_layouts
     - layout_builder
     - menu_block
@@ -60,18 +61,21 @@ third_party_settings:
             configuration:
               id: 'field_block:node:hs_basic_page:field_hs_page_components'
               label: Components
-              label_display: '0'
+              label_display: ''
               provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
+                view_mode: view_mode
               formatter:
                 type: entity_reference_revisions_entity_view
                 label: hidden
                 settings:
                   view_mode: default
                 third_party_settings:
-                  ds:
-                    ds_limit: ''
+                  field_formatter_class:
+                    class: ''
+                  hs_field_helpers:
+                    inline_contents: 0
             weight: 2
             additional: {  }
           3b1a10ed-5309-47bf-acff-654a1d64f7f0:
@@ -112,13 +116,24 @@ third_party_settings:
               suggestion: menu_block__main
             weight: 0
             additional: {  }
-          de89d1f0-3be8-41be-8930-0c45a6f5cecc:
-            uuid: de89d1f0-3be8-41be-8930-0c45a6f5cecc
+          379db769-29da-4c3f-964a-fc3508e011df:
+            uuid: 379db769-29da-4c3f-964a-fc3508e011df
+            region: main
+            configuration:
+              id: hs_blocks_back_to_top_block
+              label: 'Back To Top Block'
+              label_display: '0'
+              provider: hs_blocks
+              context_mapping: {  }
+            weight: 3
+            additional: {  }
+          9faffe80-0c12-4a93-8924-1a9d59e35f11:
+            uuid: 9faffe80-0c12-4a93-8924-1a9d59e35f11
             region: main
             configuration:
               id: hs_layouts_skipnav_main_anchor
               label: 'Main content anchor target'
-              label_display: visible
+              label_display: hidden
               provider: hs_layouts
               context_mapping: {  }
             weight: 0

--- a/config/default/core.entity_view_display.node.hs_basic_page.default.yml
+++ b/config/default/core.entity_view_display.node.hs_basic_page.default.yml
@@ -61,21 +61,18 @@ third_party_settings:
             configuration:
               id: 'field_block:node:hs_basic_page:field_hs_page_components'
               label: Components
-              label_display: ''
+              label_display: '0'
               provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
-                view_mode: view_mode
               formatter:
                 type: entity_reference_revisions_entity_view
                 label: hidden
                 settings:
                   view_mode: default
                 third_party_settings:
-                  field_formatter_class:
-                    class: ''
-                  hs_field_helpers:
-                    inline_contents: 0
+                  ds:
+                    ds_limit: ''
             weight: 2
             additional: {  }
           3b1a10ed-5309-47bf-acff-654a1d64f7f0:
@@ -116,8 +113,19 @@ third_party_settings:
               suggestion: menu_block__main
             weight: 0
             additional: {  }
-          379db769-29da-4c3f-964a-fc3508e011df:
-            uuid: 379db769-29da-4c3f-964a-fc3508e011df
+          de89d1f0-3be8-41be-8930-0c45a6f5cecc:
+            uuid: de89d1f0-3be8-41be-8930-0c45a6f5cecc
+            region: main
+            configuration:
+              id: hs_layouts_skipnav_main_anchor
+              label: 'Main content anchor target'
+              label_display: visible
+              provider: hs_layouts
+              context_mapping: {  }
+            weight: 0
+            additional: {  }
+          dfb6aba1-952b-4ef8-b868-7991ee1a80e4:
+            uuid: dfb6aba1-952b-4ef8-b868-7991ee1a80e4
             region: main
             configuration:
               id: hs_blocks_back_to_top_block
@@ -126,17 +134,6 @@ third_party_settings:
               provider: hs_blocks
               context_mapping: {  }
             weight: 3
-            additional: {  }
-          9faffe80-0c12-4a93-8924-1a9d59e35f11:
-            uuid: 9faffe80-0c12-4a93-8924-1a9d59e35f11
-            region: main
-            configuration:
-              id: hs_layouts_skipnav_main_anchor
-              label: 'Main content anchor target'
-              label_display: hidden
-              provider: hs_layouts
-              context_mapping: {  }
-            weight: 0
             additional: {  }
         third_party_settings: {  }
 _core:


### PR DESCRIPTION
# Summary

Added the back to top block to the default configuration for the flexible (basic page) layout


## Need Review By (Date)

8/13

## Urgency

Low

## Steps to Test

- Review the Configuration addition and confirm it looks correct

- I believe we can't functionally test unless we have a newly provisioned site but the goal would be that on a newly provisioned website the Back To Top Block is on the Flexible Page Layout Display 

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
