### PR TITLE
[DRAFT] HSD8-1778: Update site manager permissions to allow for assigning preparer and reviewer role

### DIFF
--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -85,6 +85,8 @@ permissions:
   - 'assign author role'
   - 'assign contributor role'
   - 'assign intranet_viewer role'
+  - 'assign preparer role'
+  - 'assign reviewer role'
   - 'assign site_manager role'
   - 'create embeddable media'
   - 'create file media'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1669,10 +1669,83 @@ function su_humsci_profile_update_9739() {
   }
   return t('Could not load hs_basic_page entity form display.');
 }
+
+/**
+ * Update node page display image styles.
+ */
+function su_humsci_profile_update_9740() {
+  $to_update = [
+    'hs_event' => [
+      'field' => 'field_hs_event_image',
+      'default_image_style' => 'hs_medium_scaled_360px',
+      'new_image_style' => 'medium_scaled',
+    ],
+    'hs_news' => [
+      'field' => 'field_hs_news_image',
+      'default_image_style' => 'hs_medium_scaled_360px',
+      'new_image_style' => 'medium_scaled',
+    ],
+    'hs_event_series' => [
+      'field' => 'field_hs_event_series_image',
+      'default_image_style' => 'hs_medium_scaled_360px',
+      'new_image_style' => 'medium_scaled',
+    ],
+    'hs_publications' => [
+      'field' => 'field_hs_publication_image',
+      'default_image_style' => 'hs_medium_scaled_360px',
+      'new_image_style' => 'medium_scaled',
+    ],
+    'hs_person' => [
+      'field' => 'field_hs_person_square_img',
+      'default_image_style' => 'hs_medium_square_360x360',
+      'new_image_style' => 'medium_square',
+    ],
+  ];
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+
+  foreach ($to_update as $bundle => $data) {
+    /** @var \Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay $display */
+    $display = $entity_type_manager->getStorage('entity_view_display')
+      ->load("node.{$bundle}.default");
+
+    if (!$display) {
+      continue;
+    }
+
+    $view_changed = FALSE;
+    $sections = $display->getSections();
+
+    foreach ($sections as $section) {
+      $components = $section->getComponents();
+
+      foreach ($components as $component) {
+        if ($component->getPluginId() === "field_block:node:{$bundle}:{$data['field']}") {
+          $configuration = $component->get('configuration');
+          // Skip cases where the default image styles have been overridden.
+          if ($configuration['formatter']['settings']['image_style'] !== $data['default_image_style']) {
+            continue;
+          }
+          // Set the updated image style settings.
+          $configuration['formatter']['type'] = 'media_responsive_image_formatter';
+          $configuration['formatter']['settings']['image_style'] = $data['new_image_style'];
+          $component->setConfiguration($configuration);
+          $view_changed = TRUE;
+        }
+      }
+    }
+
+    // Save the view only if changes were made.
+    if ($view_changed) {
+      $display->save();
+    }
+  }
+}
+
 /**
  * Grants Assign Preparer role and Assign Reviewer role permissions to the Site Manager role
  */
-function su_humsci_profile_update_9742() {
+function su_humsci_profile_update_9741() {
   user_role_grant_permissions('site_manager', [
     'assign preparer role',
     'assign reviewer role',

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1669,3 +1669,12 @@ function su_humsci_profile_update_9739() {
   }
   return t('Could not load hs_basic_page entity form display.');
 }
+/**
+ * Grants Assign Preparer role and Assign Reviewer role permissions to the Site Manager role
+ */
+function su_humsci_profile_update_9742() {
+  user_role_grant_permissions('site_manager', [
+    'assign preparer role',
+    'assign reviewer role',
+  ]);
+}


### PR DESCRIPTION
# Summary

Site managers need the ability to see and assign the Reviewer and Preparer role. This PR enables the Assign Preparer role and Assign Reviewer role for Site Managers

## Backstory

The permission for Site Manager was not enabled by default

## Need Review By (Date)
_[When does this need to be reviewed by? '10/30', 'asap', etc.]_

## Urgency
_['low', 'medium', 'high', etc.]_

## Steps to Test

1. Log in
2. Masquerade as IT Site Manager
3. Go to manage Users and edit IT Contributor
4. Confirm that you can see and assign both the Preparer and Reviewer roles

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
