### PR TITLE
HSD8-1778: Allow Site Managers to assign Reviewer and Preparer roles

### DIFF
--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -85,6 +85,8 @@ permissions:
   - 'assign author role'
   - 'assign contributor role'
   - 'assign intranet_viewer role'
+  - 'assign preparer role'
+  - 'assign reviewer role'
   - 'assign site_manager role'
   - 'create embeddable media'
   - 'create file media'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1743,7 +1743,7 @@ function su_humsci_profile_update_9740() {
 }
 
 /**
- * Grant the assign preparer role and assign reviewer role permissions to the Site Manager role
+ * Update Site Manager user role grant permissions
  */
 function su_humsci_profile_update_9741() {
   user_role_grant_permissions('site_manager', [

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1743,7 +1743,7 @@ function su_humsci_profile_update_9740() {
 }
 
 /**
- * Update Site Manager user role grant permissions
+ * Update Site Manager user role grant permissions.
  */
 function su_humsci_profile_update_9741() {
   user_role_grant_permissions('site_manager', [

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1741,3 +1741,13 @@ function su_humsci_profile_update_9740() {
     }
   }
 }
+
+/**
+ * Grant the assign preparer role and assign reviewer role permissions to the Site Manager role
+ */
+function su_humsci_profile_update_9741() {
+  user_role_grant_permissions('site_manager', [
+    'assign preparer role',
+    'assign reviewer role',
+  ]);
+}


### PR DESCRIPTION
# Summary

Site managers need the ability to see and assign the Reviewer and Preparer role. 

This PR enables the _assign preparer role_ and _assign reviewer role_ permissions for Site Mangers on new and existing sites. 

The PR includes an update to the Site manger configuration permissions and and an update hook to update the permissions on existing sites.

## Backstory

Site managers could not see or assign the preparer or reviewer roles.

## Need Review By (Date)

8/27

## Urgency

med

## Steps to Test

1. Log in
2. Masquerade as IT Site Manager
3. Go to manage Users and edit IT Contributor
4. Confirm that you can see and assign both the Preparer and Reviewer roles

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
