### PR TITLE
SHS-6357: Implementation for How Date,  Location, Speaker icons gets displayed on Views

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_card.scss
@@ -160,7 +160,7 @@
 
     &--date {
       // only apply calendar icon when the label exists
-      [class*="views-label-field-hs-event-date"]+.field-content {
+      [class*="views-label"]+.field-content {
         @include hb-icon-type($type: 'calendar', $color: 'secondary');
 
         .hb-dark-pattern &,
@@ -172,7 +172,7 @@
 
     &--location {
       // only apply location pin icon when the label exists
-      [class*="views-label-field-hs-event-location"]+.field-content {
+      [class*="views-label"]+.field-content {
         @include hb-icon-type($type: 'location', $color: 'secondary');
 
         .hb-dark-pattern &,
@@ -184,7 +184,7 @@
 
     &--speaker {
       // only apply speaker icon when the label exists
-      [class*="views-label-field-hs-event-speaker"]+.field-content {
+      [class*="views-label"]+.field-content {
         @include hb-icon-type($type: 'speaker', $color: 'secondary');
 
         .hb-dark-pattern &,


### PR DESCRIPTION
# Summary
- Remove limitation based machine name for adding icons to fields in the "Time", "Speaker" and "Location" regions of date stacked cards.

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6357)

## Need Review By (Date)
09/03

## Urgency
medium

## Steps to Test
1. Log into the [English tugboat site](https://english-vp7iwz6vltl1xjohjvigkdqpl45rl4fb.tugboatqa.com/)
2. Visit the [Event content type field configuration page](https://english-vp7iwz6vltl1xjohjvigkdqpl45rl4fb.tugboatqa.com/admin/structure/types/manage/hs_event/fields) and confirm that there's a custom field named "Alternate Location"
3. Visit the [Upcoming Events List](https://english-vp7iwz6vltl1xjohjvigkdqpl45rl4fb.tugboatqa.com/admin/structure/views/view/custm_english_events/edit/upcoming_list?destination=/node/581) configuration page and confirm that the new field has been added to the view with the following config:
    - Assigned to the "Location" region of the pattern (in Format > Show > Settings)
    <img width="1196" height="165" alt="Screenshot 2025-08-26 at 6 27 27 PM" src="https://github.com/user-attachments/assets/459c8922-2a22-4ba7-b09c-c607a3af0220" />

     - "Alternate Location" field has the default "Style" configuration, no rewrite is used
    <img width="795" height="683" alt="Screenshot 2025-08-26 at 6 26 54 PM" src="https://github.com/user-attachments/assets/77706fed-835b-4425-bc72-2e003b0043d6" />

     - "Alternate Location" field has a label (text is not important, it won't be displayed)
    <img width="610" height="125" alt="Screenshot 2025-08-26 at 6 27 05 PM" src="https://github.com/user-attachments/assets/d5ed1651-d1dc-4120-b10a-6a77aa0c5822" />
5. Visit https://english-vp7iwz6vltl1xjohjvigkdqpl45rl4fb.tugboatqa.com/news-events/upcoming-events. Confirm that the "Alternate Location" field is visible in the card, with the location icon next to it.
6. Only a custom location field was added, but if you want to do further testing, create custom date and speaker fields and add them to the view, with the same configuration detailed above. After that, confirm that the field are visible in the event card, with their respective icon

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211009489841067