### PR TITLE
HSD8-1773: Apply field_formatter_class patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -251,6 +251,9 @@
             "drupal/entity_reference_exposed_filters": {
                 "https://www.drupal.org/project/entity_reference_exposed_filters/issues/3189025": "https://www.drupal.org/files/issues/2023-10-17/entity_reference_exposed_filters-empty_target-3189025-4.patch"
             },
+            "drupal/field_formatter_class": {
+                "https://www.drupal.org/project/field_formatter_class/issues/3473891": "patches/contrib/field_formatter_class-3473891-mr-10.patch"
+            },
             "drupal/field_group": {
                 "https://www.drupal.org/project/field_group/issues/2969051": "https://www.drupal.org/files/issues/2024-09-13/2969051-166.patch",
                 "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2024-08-05/2787179-highlight-html5-validation-101.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d5b4e738cdd027d3bd566d1b766a97d",
+    "content-hash": "7428938954d05afbefa6f7010c787e7e",
     "packages": [
         {
             "name": "acquia/blt",

--- a/patches/contrib/field_formatter_class-3473891-mr-10.patch
+++ b/patches/contrib/field_formatter_class-3473891-mr-10.patch
@@ -1,0 +1,13 @@
+diff --git a/field_formatter_class.module b/field_formatter_class.module
+index c5b5256d053d2c5f0e9f2a0e595a13928a0b26b0..b99fe6128897f3b9cb1e4faa0942b7a3c6c3edc6 100644
+--- a/field_formatter_class.module
++++ b/field_formatter_class.module
+@@ -139,7 +139,7 @@ function field_formatter_class_field_widget_complete_form_alter(&$field_widget_c
+   }
+ 
+   $field_widget_complete_form['widget']['#third_party_settings']['field_formatter_class'] = $thirdPartySettings;
+-  $field_widget_complete_form['widget']['#object'] = $form_state->getBuildInfo()['callback_object']->getEntity();
++  $field_widget_complete_form['widget']['#object'] = $context['items']->getEntity();
+ }
+ 
+ /**


### PR DESCRIPTION
# Summary
Apply patch for `field_formatter_class` to fix error:
```
Error: Call to undefined method Drupal\views\Form\ViewsForm::getEntity() in field_formatter_class_field_widget_complete_form_alter() (line 142 of /var/www/html/web/modules/contrib/field_formatter_class/field_formatter_class.module).
```

## Backstory
See: https://www.drupal.org/project/field_formatter_class/issues/3473891
[HSD8-1773](https://stanfordits.atlassian.net/browse/HSD8-1773): Batch edit doesn't work on Classics events

## Urgency
Med/High

## Steps to Test

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


[HSD8-1773]: https://stanfordits.atlassian.net/browse/HSD8-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ