### PR TITLE
Fix tests workflow deploy branch reference

### DIFF
--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.ref_name }}
       - name: Restore Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -1,6 +1,5 @@
 name: Unit, Acceptance and Functional Tests
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 concurrency:
@@ -219,6 +218,8 @@ jobs:
       options: '--network-alias drupal8ci'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
       - name: Restore Cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
# Summary
Fixes deploy branch reference in latest PR #1951 

## Backstory
The branch reference used previously would load the `develop` branch when we want to load the PR branch. 