### PR TITLE
Use the head_ref for the deploy_branch step in tests workflow

### DIFF
--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.ref_name }}
       - name: Restore Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -1,6 +1,5 @@
 name: Unit, Acceptance and Functional Tests
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 concurrency:
@@ -219,6 +218,8 @@ jobs:
       options: '--network-alias drupal8ci'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
       - name: Restore Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.head_ref }}
       - name: Restore Cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
# Summary
Fixes deploy branch reference in PR's #1951 and #1952

## Backstory
Updating the workflow to use pull request events as the trigger instead of the push resulted in the incorrect references for the deploy step in the workflow.

The references for pull requests are:

| Reference | Description |
| ----- | ---- |
| `github.head_ref` | The source branch of the PR |
| `github.base_ref` | The target branch of the PR |
| `github.ref_name` | The HEAD commit of the PR event |

The reference we want to use then is the `head_ref` to deploy the source branch of the PR.
