### PR TITLE
SHS-6340: Optimize loading of Google Fonts

### DIFF
--- a/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
+++ b/docroot/themes/humsci/humsci_airy/humsci_airy.info.yml
@@ -21,3 +21,6 @@ regions:
 
 libraries:
   - humsci_airy/base
+
+preload_fonts:
+  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap'

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -98,7 +98,6 @@ function humsci_basic_preprocess_html(&$vars) {
       'humsci_google_fonts_preconnect_2',
     ];
 
-
     $vars['#attached']['html_head'][] = [
       [
         '#tag' => 'link',

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -60,6 +60,32 @@ function humsci_basic_preprocess_block(&$vars) {
  * Prepares variables for the html.html.twig template.
  */
 function humsci_basic_preprocess_html(&$vars) {
+  // Theme
+  $theme = \Drupal::config('system.theme')->get('default');
+
+  // Map theme names to Google Fonts URLs.
+  $theme_fonts = [
+    'humsci_colorful' => 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap',
+    'humsci_traditional' => 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap',
+  ];
+
+  // Get the font URL for the active theme, fallback to a default if not mapped.
+  $font_url = $theme_fonts[$theme] ?? 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap';
+
+  // Attach the font <link> to the head.
+  if (!empty($font_url)) {
+    $vars['#attached']['html_head'][] = [
+      [
+        '#tag' => 'link',
+        '#attributes' => [
+          'rel' => 'stylesheet',
+          'href' => $font_url,
+        ],
+      ],
+      'humsci_google_fonts',
+    ];
+  }
+
   // Animation enhancements setting.
   $animation_enhancement = theme_get_setting('animation_toggle');
   if ($animation_enhancement) {

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -74,6 +74,31 @@ function humsci_basic_preprocess_html(&$vars) {
 
   // Attach the font <link> to the head.
   if (!empty($font_url)) {
+    // Preconnect to Google Fonts domains.
+    $vars['#attached']['html_head'][] = [
+      [
+        '#tag' => 'link',
+        '#attributes' => [
+          'rel' => 'preconnect',
+          'href' => 'https://fonts.googleapis.com',
+        ],
+      ],
+      'humsci_google_fonts_preconnect_1',
+    ];
+
+    $vars['#attached']['html_head'][] = [
+      [
+        '#tag' => 'link',
+        '#attributes' => [
+          'rel' => 'preconnect',
+          'href' => 'https://fonts.gstatic.com',
+          'crossorigin' => 'anonymous',
+        ],
+      ],
+      'humsci_google_fonts_preconnect_2',
+    ];
+
+
     $vars['#attached']['html_head'][] = [
       [
         '#tag' => 'link',

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -164,40 +164,58 @@ function humsci_basic_preprocess_html(&$vars) {
 /**
  * Implements hook_page_attachments_alter().
  *
- * Preload fonts based on what's in info.yml.
  */
 function humsci_basic_page_attachments_alter(&$attachments) {
+  // Preload fonts based on what's in info.yml.
   $theme = \Drupal::theme()->getActiveTheme();
   $info = $theme->getExtension()->info;
 
-  if (!empty($info['preload_fonts'])) {
-    // Preconnects.
+  if (empty($info['preload_fonts'])) {
+    return;
+  }
+
+  $fonts = $info['preload_fonts'];
+
+  // Check if any of the font URLs are Google Fonts.
+  $has_google_fonts = array_filter($fonts, function ($font) {
+    return strpos($font, 'fonts.googleapis.com') !== FALSE;
+  });
+
+  // Attach preconnects only once if Google Fonts are present.
+  if (!empty($has_google_fonts)) {
     $attachments['#attached']['html_head_link'][] = [[
       'rel' => 'preconnect',
-      'as' => 'link',
       'href' => 'https://fonts.googleapis.com',
-      'crossorigin' => 'anonymous',
     ],
       FALSE,
     ];
     $attachments['#attached']['html_head_link'][] = [[
       'rel' => 'preconnect',
-      'as' => 'link',
       'href' => 'https://fonts.gstatic.com',
       'crossorigin' => 'anonymous',
     ],
       FALSE,
     ];
+  }
 
-    foreach ($info['preload_fonts'] as $font) {
-      $attachments['#attached']['html_head_link'][] = [[
-        'rel' => 'stylesheet',
-        'href' => $font,
-        'crossorigin' => 'anonymous',
-      ],
-        FALSE,
-      ];
-    }
+  // Now attach preload + stylesheet for each font.
+  foreach ($info['preload_fonts'] as $font) {
+    // Preload first.
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'preload',
+      'as' => 'style',
+      'href' => $font,
+    ],
+      FALSE,
+    ];
+
+    // Then stylesheet.
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'stylesheet',
+      'href' => $font,
+    ],
+      FALSE,
+    ];
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -163,7 +163,6 @@ function humsci_basic_preprocess_html(&$vars) {
 
 /**
  * Implements hook_page_attachments_alter().
- *
  */
 function humsci_basic_page_attachments_alter(&$attachments) {
   // Preload fonts based on what's in info.yml.

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -164,7 +164,7 @@ function humsci_basic_preprocess_html(&$vars) {
 /**
  * Implements hook_page_attachments_alter().
  *
- * Preload fonts based on what's in info.yml
+ * Preload fonts based on what's in info.yml.
  */
 function humsci_basic_page_attachments_alter(&$attachments) {
   $theme = \Drupal::theme()->getActiveTheme();
@@ -173,17 +173,21 @@ function humsci_basic_page_attachments_alter(&$attachments) {
   if (!empty($info['preload_fonts'])) {
     // Preconnects.
     $attachments['#attached']['html_head_link'][] = [[
-        'rel' => 'preconnect',
-        'as' => 'link',
-        'href' => 'https://fonts.googleapis.com',
-        'crossorigin' => 'anonymous',
-      ], FALSE];
+      'rel' => 'preconnect',
+      'as' => 'link',
+      'href' => 'https://fonts.googleapis.com',
+      'crossorigin' => 'anonymous',
+    ],
+      FALSE,
+    ];
     $attachments['#attached']['html_head_link'][] = [[
-        'rel' => 'preconnect',
-        'as' => 'link',
-        'href' => 'https://fonts.gstatic.com',
-        'crossorigin' => 'anonymous',
-      ], FALSE];
+      'rel' => 'preconnect',
+      'as' => 'link',
+      'href' => 'https://fonts.gstatic.com',
+      'crossorigin' => 'anonymous',
+    ],
+      FALSE,
+    ];
 
     foreach ($info['preload_fonts'] as $font) {
       $attachments['#attached']['html_head_link'][] = [[
@@ -192,9 +196,10 @@ function humsci_basic_page_attachments_alter(&$attachments) {
         'href' => $font,
         'type' => 'font/' . pathinfo($font, PATHINFO_EXTENSION),
         'crossorigin' => 'anonymous',
-      ], FALSE];
+      ],
+        FALSE,
+      ];
     }
-
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -191,10 +191,8 @@ function humsci_basic_page_attachments_alter(&$attachments) {
 
     foreach ($info['preload_fonts'] as $font) {
       $attachments['#attached']['html_head_link'][] = [[
-        'rel' => 'preload',
-        'as' => 'font',
+        'rel' => 'stylesheet',
         'href' => $font,
-        'type' => 'font/' . pathinfo($font, PATHINFO_EXTENSION),
         'crossorigin' => 'anonymous',
       ],
         FALSE,

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -176,8 +176,8 @@ function humsci_basic_page_attachments_alter(&$attachments) {
   $fonts = $info['preload_fonts'];
 
   // Check if any of the font URLs are Google Fonts.
-  $has_google_fonts = array_filter($fonts, function ($font) {
-    return strpos($font, 'fonts.googleapis.com') !== FALSE;
+  $has_google_fonts = array_find($fonts, function ($font) {
+    return str_contains($font, 'fonts.googleapis.com');
   });
 
   // Attach preconnects only once if Google Fonts are present.

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -60,7 +60,7 @@ function humsci_basic_preprocess_block(&$vars) {
  * Prepares variables for the html.html.twig template.
  */
 function humsci_basic_preprocess_html(&$vars) {
-  // Theme
+  // Theme.
   $theme = \Drupal::config('system.theme')->get('default');
 
   // Map theme names to Google Fonts URLs.

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -60,56 +60,6 @@ function humsci_basic_preprocess_block(&$vars) {
  * Prepares variables for the html.html.twig template.
  */
 function humsci_basic_preprocess_html(&$vars) {
-  // Theme.
-  $theme = \Drupal::config('system.theme')->get('default');
-
-  // Map theme names to Google Fonts URLs.
-  $theme_fonts = [
-    'humsci_colorful' => 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap',
-    'humsci_traditional' => 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap',
-  ];
-
-  // Get the font URL for the active theme, fallback to a default if not mapped.
-  $font_url = $theme_fonts[$theme] ?? 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap';
-
-  // Attach the font <link> to the head.
-  if (!empty($font_url)) {
-    // Preconnect to Google Fonts domains.
-    $vars['#attached']['html_head'][] = [
-      [
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'preconnect',
-          'href' => 'https://fonts.googleapis.com',
-        ],
-      ],
-      'humsci_google_fonts_preconnect_1',
-    ];
-
-    $vars['#attached']['html_head'][] = [
-      [
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'preconnect',
-          'href' => 'https://fonts.gstatic.com',
-          'crossorigin' => 'anonymous',
-        ],
-      ],
-      'humsci_google_fonts_preconnect_2',
-    ];
-
-    $vars['#attached']['html_head'][] = [
-      [
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'stylesheet',
-          'href' => $font_url,
-        ],
-      ],
-      'humsci_google_fonts',
-    ];
-  }
-
   // Animation enhancements setting.
   $animation_enhancement = theme_get_setting('animation_toggle');
   if ($animation_enhancement) {
@@ -208,6 +158,43 @@ function humsci_basic_preprocess_html(&$vars) {
     if ($image_referenced) {
       humsci_basic_preload_full_width_image($image_referenced, $style_name, $vars);
     }
+  }
+}
+
+/**
+ * Implements hook_page_attachments_alter().
+ *
+ * Preload fonts based on what's in info.yml
+ */
+function humsci_basic_page_attachments_alter(&$attachments) {
+  $theme = \Drupal::theme()->getActiveTheme();
+  $info = $theme->getExtension()->info;
+
+  if (!empty($info['preload_fonts'])) {
+    // Preconnects.
+    $attachments['#attached']['html_head_link'][] = [[
+        'rel' => 'preconnect',
+        'as' => 'link',
+        'href' => 'https://fonts.googleapis.com',
+        'crossorigin' => 'anonymous',
+      ], FALSE];
+    $attachments['#attached']['html_head_link'][] = [[
+        'rel' => 'preconnect',
+        'as' => 'link',
+        'href' => 'https://fonts.gstatic.com',
+        'crossorigin' => 'anonymous',
+      ], FALSE];
+
+    foreach ($info['preload_fonts'] as $font) {
+      $attachments['#attached']['html_head_link'][] = [[
+        'rel' => 'preload',
+        'as' => 'font',
+        'href' => $font,
+        'type' => 'font/' . pathinfo($font, PATHINFO_EXTENSION),
+        'crossorigin' => 'anonymous',
+      ], FALSE];
+    }
+
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/fonts/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/fonts/_fonts.scss
@@ -1,9 +1,3 @@
-// Source Sans 3.
-@import 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap';
-
-// Source Serif 4.
-@import 'https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap';
-
 // Ligature font: Stanford.
 // The Stanford font is being hosted and loaded from our AWS bucket.
 @font-face {

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -62,6 +62,11 @@
     <meta name="msapplication-square150x150logo" content="https://www-media.stanford.edu/assets/favicon/mstile-150x150.png" />
     <meta name="msapplication-square310x310logo" content="https://www-media.stanford.edu/assets/favicon/mstile-310x310.png" />
 
+    {# Google Fonts Source Sans 3 and Source Serif 4. #}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap" rel="stylesheet">
+
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -65,7 +65,6 @@
     {# Google Fonts Source Sans 3 and Source Serif 4. #}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap" rel="stylesheet">
 
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">

--- a/docroot/themes/humsci/humsci_basic/templates/html.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/html.html.twig
@@ -62,10 +62,6 @@
     <meta name="msapplication-square150x150logo" content="https://www-media.stanford.edu/assets/favicon/mstile-150x150.png" />
     <meta name="msapplication-square310x310logo" content="https://www-media.stanford.edu/assets/favicon/mstile-310x310.png" />
 
-    {# Google Fonts Source Sans 3 and Source Serif 4. #}
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
@@ -22,3 +22,6 @@ regions:
 
 libraries:
   - humsci_colorful/base
+
+preload_fonts:
+  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap'

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
@@ -22,3 +22,6 @@ regions:
 
 libraries:
   - humsci_traditional/base
+
+preload_fonts:
+  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap'

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.info.yml
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.info.yml
@@ -29,3 +29,6 @@ regions:
   sidebar_first: "First sidebar"
 regions_hidden:
   - sidebar_first
+
+preload_fonts:
+  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap'


### PR DESCRIPTION
# Summary
Optimize loading Google Fonts only (We are using a Drupal module for Fontawesome, and there's no way to optimize loading)

## Backstory
[SHS-6340](https://app.clickup.com/t/36718269/SHS-6340)

## Need Review By (Date)
09/09

## Urgency
low

## Steps to Test
1. Visit Colorful and Traditional
2. Confirm both fonts `Source Sans 3` and `Source Serif 4` are being loaded in Traditional, and only `Source Sans 3` in Colorful
3. Confirm everything looks as expected
 
# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211224291891624