### PR TITLE
SHS-6369: Add help text to the Private Page Component field

### DIFF
--- a/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
+++ b/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
@@ -19,7 +19,7 @@ field_name: field_hs_priv_page_components
 entity_type: node
 bundle: hs_private_page
 label: Components
-description: "Only files uploaded through the Private Files insert field are completely private.  \r\nFiles and images uploaded through any other mechanism can be viewed by anyone with the URL."
+description: "<strong>Only files uploaded through the Private Files insert field are completely private.</strong><br>\r\nFiles and images uploaded through any other mechanism can be viewed by anyone with the URL."
 required: false
 translatable: false
 default_value: {  }

--- a/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
+++ b/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
@@ -19,7 +19,7 @@ field_name: field_hs_priv_page_components
 entity_type: node
 bundle: hs_private_page
 label: Components
-description: ''
+description: "Only files uploaded through the Private Files insert field are completely private.  \r\nFiles and images uploaded through any other mechanism can be viewed by anyone with the URL."
 required: false
 translatable: false
 default_value: {  }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
@@ -363,12 +363,3 @@
 .paragraph-type--stanford-gallery .hs-paragraphs-tabs.tabs {
   display: none;
 }
-
-// Styles for help text in component field in private page
-[data-drupal-selector="edit-field-hs-priv-page-components"] {
-  [id="edit-field-hs-priv-page-components--description"].form-item__description {
-    margin-top: 3rem;
-    padding-inline: 0.5rem;
-    max-width: 100%;
-  }
-}

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
@@ -363,3 +363,12 @@
 .paragraph-type--stanford-gallery .hs-paragraphs-tabs.tabs {
   display: none;
 }
+
+// Styles for help text in component field in private page
+[data-drupal-selector="edit-field-hs-priv-page-components"] {
+  [id="edit-field-hs-priv-page-components--description"].form-item__description {
+    margin-top: 3rem;
+    padding-inline: 0.5rem;
+    max-width: 100%;
+  }
+}

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -259,3 +259,10 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
   background: var(--gin-color-disabled-bg);
   cursor: not-allowed;
 }
+
+/* Styles for help text in component field in private page */
+[data-drupal-selector="edit-field-hs-priv-page-components"] > [id="edit-field-hs-priv-page-components--description"].form-item__description {
+  margin-top: 3rem;
+  padding-inline: 0.5rem;
+  max-width: 100%;
+}


### PR DESCRIPTION
# Summary
Add help text to the Private Page component field and style it a little bit

## Backstory
[SHS-6369](https://app.clickup.com/t/36718269/SHS-6369)

## Need Review By (Date)
09/09

## Urgency
medium

## Steps to Test
1. Create/Edit a Private Page
2. Confirm there's a help text in the Private Page component field. It should look like this:

<img width="1044" height="620" alt="Screenshot 2025-09-05 at 10 50 58 AM" src="https://github.com/user-attachments/assets/d05c85f3-162e-4219-8a3e-c50db8bafa37" />


# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206342478313829