### PR TITLE
SHS-6128: Relabel "drupalisms" around entityqueues

### DIFF
--- a/config/default/views.view.dashboard_entityqueue.yml
+++ b/config/default/views.view.dashboard_entityqueue.yml
@@ -30,7 +30,7 @@ display:
           entity_type: null
           entity_field: title
           plugin_id: field
-          label: Type
+          label: 'Listing name'
           exclude: false
           alter:
             alter_text: false
@@ -153,10 +153,10 @@ display:
           set_precision: false
           precision: 0
           decimal: .
-          format_plural: 0
-          format_plural_string: !!binary MQNAY291bnQ=
+          format_plural: 1
+          format_plural_string: !!binary MSBpdGVtA0Bjb3VudCBpdGVtcw==
           prefix: ''
-          suffix: ' item(s)'
+          suffix: ''
         view_entity_subqueue:
           id: view_entity_subqueue
           table: entity_subqueue

--- a/config/default/views.view.manage_listings.yml
+++ b/config/default/views.view.manage_listings.yml
@@ -158,15 +158,15 @@ display:
           format_plural_string: !!binary MSBpdGVtA0Bjb3VudCBpdGVtcw==
           prefix: ''
           suffix: ''
-        operations:
-          id: operations
+        edit_entity_subqueue:
+          id: edit_entity_subqueue
           table: entity_subqueue
-          field: operations
+          field: edit_entity_subqueue
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: entity_subqueue
-          plugin_id: entity_operations
+          plugin_id: entity_link_edit
           label: Operations
           exclude: false
           alter:
@@ -208,7 +208,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          destination: false
+          text: 'Reorder items'
+          output_url_as_text: false
+          absolute: false
       pager:
         type: full
         options:

--- a/config/default/views.view.manage_listings.yml
+++ b/config/default/views.view.manage_listings.yml
@@ -1,0 +1,295 @@
+uuid: 1326f3ad-13af-422f-8de3-01f156ed5f99
+langcode: en
+status: true
+dependencies:
+  module:
+    - entityqueue
+    - user
+id: manage_listings
+label: 'Manage Listings'
+module: views
+description: 'Overrides the entityqueue collection route.'
+tag: ''
+base_table: entity_subqueue_field_data
+base_field: name
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Reorder profiles and other listings'
+      fields:
+        title:
+          id: title
+          table: entity_subqueue_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: title
+          plugin_id: field
+          label: 'Listing name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        items_target_id:
+          id: items_target_id
+          table: entity_subqueue__items
+          field: items_target_id
+          relationship: none
+          group_type: count
+          admin_label: ''
+          entity_type: entity_subqueue
+          entity_field: items
+          plugin_id: field
+          label: Items
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 1
+          format_plural_string: !!binary MSBpdGVtA0Bjb3VudCBpdGVtcw==
+          prefix: ''
+          suffix: ''
+        operations:
+          id: operations
+          table: entity_subqueue
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: entity_subqueue
+          plugin_id: entity_operations
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manipulate entityqueues'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      group_by: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/structure/entityqueue
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -84,3 +84,12 @@ if ($siteimprove_api_key && $siteimprove_username) {
     'username' => $siteimprove_username,
   ];
 }
+
+// Translation overrides to replace Drupalisms with more user-friendly terms.
+$settings['locale_custom_strings_en'][''] = [
+  'Entityqueues' => 'Listing',
+  'Edit Entity Queue' => 'Edit listing',
+  'Edit subqueue %label' => 'Edit listing %label',
+  'The entity subqueue %label has been added.' => 'The listing %label has been added.',
+  'The entity subqueue %label has been updated.' => 'The listing %label has been updated.',
+];


### PR DESCRIPTION
# Summary
- Creates a new 'Manage Listings' view to override and improve the Entity Queue admin interface. This view uses the same conventions set in other content management views on the platform.
- Translates several strings to replace entity queue references with more common descriptions.
- Updates the entity queue dashboard block to match the new view.

## Backstory
Entity queues are very useful use a difficult to understand language. This work is to refine admin interfaces around the entity queues to make the more approachable and to ensure site managers feel empowered to make changes.

## Need Review By (Date)
Not set.

## Urgency
Not set.

## Steps to Test
1. [Log in to a test environment](https://pr1965-5vlcpgbcnx1xs1vujq1j7ofbi8wuincw.tugboatqa.com/user) as an administrative user.
2. [Navigate to the Dashboard](https://pr1965-5vlcpgbcnx1xs1vujq1j7ofbi8wuincw.tugboatqa.com/admin/) and locate the 'Reorder profiles and other listings' block. Verify changes to this block:
  a. The first column has been updated to use heading "Listing name"
  b. The data in the 'Items' columns use a single/multiple-aware suffix saying 'items" or "item". It no longer says "item(s)"
3. [Navigate to the entityqueue collection admin interface](https://pr1965-5vlcpgbcnx1xs1vujq1j7ofbi8wuincw.tugboatqa.com/admin/structure/entityqueue). This has been replaced with a view. Verify the following details:
  a. Columns:  Listing name, Items, Operations
  b. With content: Queue name as label, count of items with suffix items or item, and operation link 'Reorder items'
  c. Enabled and disabled queues appear in this view.
4. [Edit one of the queues](https://pr1965-5vlcpgbcnx1xs1vujq1j7ofbi8wuincw.tugboatqa.com/admin/structure/entityqueue/hs_person/hs_person?destination=/admin/structure/entityqueue) using one of the 'Reorder items' links. This will take you to the Edit entity queue form. Verify the following:
  a. Breadcrumb following the format: Administration / Structure / Reorder profiles and other listings / Edit listing / View People
  b. Interface has the title following the format: "Edit listing %label"
  c. When making a change and saving the queue, a message display following the format: "The listing %label  has been updated."
  d. When creating a new queue, a message displays in the following format: "The listing %label has been added."

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211009229147353