### PR TITLE
SHS-5576: Decouple the Raised Cards and Uniform Height toggle

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_collection.default.yml
@@ -96,24 +96,7 @@ content:
     settings:
       display_label: true
     third_party_settings:
-      conditional_fields:
-        ae032945-b707-4d7d-97db-8e7d4075a8a2:
-          entity_type: paragraph
-          bundle: hs_collection
-          dependee: field_raised_cards
-          settings:
-            state: visible
-            reset: false
-            condition: checked
-            grouping: AND
-            values_set: 1
-            value: ''
-            values: {  }
-            value_form:
-              value: false
-            effect: show
-            effect_options: {  }
-            selector: ''
+      conditional_fields: {  }
   field_raised_cards:
     type: boolean_checkbox
     weight: 5

--- a/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
@@ -34,7 +34,25 @@ content:
     region: content
     settings: {  }
     third_party_settings:
-      conditional_fields: {  }
+      conditional_fields:
+      6d910fc3-1e3b-4f69-86c7-679fa8dd308b:
+        entity_type: paragraph
+        bundle: hs_collection
+        dependee: field_bg_color
+        settings:
+          state: visible
+          reset: false
+          condition: value
+          grouping: AND
+          values_set: 5
+          value: ''
+          values: _none
+          value_form:
+            -
+              value: default
+          effect: show
+          effect_options: {  }
+          selector: ''
   field_hs_collection_items:
     type: paragraphs
     weight: 7
@@ -79,24 +97,7 @@ content:
     settings:
       display_label: true
     third_party_settings:
-      conditional_fields:
-        d755369a-3372-40fb-896b-2cfddbdaff67:
-          entity_type: paragraph
-          bundle: hs_collection
-          dependee: field_raised_cards
-          settings:
-            state: visible
-            reset: false
-            condition: checked
-            grouping: AND
-            values_set: 1
-            value: ''
-            values: {  }
-            value_form:
-              value: false
-            effect: show
-            effect_options: {  }
-            selector: ''
+      conditional_fields: {  }
   field_raised_cards:
     type: boolean_checkbox
     weight: 5

--- a/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
@@ -34,25 +34,7 @@ content:
     region: content
     settings: {  }
     third_party_settings:
-      conditional_fields:
-        6d910fc3-1e3b-4f69-86c7-679fa8dd308b:
-          entity_type: paragraph
-          bundle: hs_collection
-          dependee: field_bg_color
-          settings:
-            state: visible
-            reset: false
-            condition: value
-            grouping: AND
-            values_set: 5
-            value: ''
-            values: _none
-            value_form:
-              -
-                value: default
-            effect: show
-            effect_options: {  }
-            selector: ''
+      conditional_fields: {  }
   field_hs_collection_items:
     type: paragraphs
     weight: 7

--- a/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_priv_collection.default.yml
@@ -35,24 +35,24 @@ content:
     settings: {  }
     third_party_settings:
       conditional_fields:
-      6d910fc3-1e3b-4f69-86c7-679fa8dd308b:
-        entity_type: paragraph
-        bundle: hs_collection
-        dependee: field_bg_color
-        settings:
-          state: visible
-          reset: false
-          condition: value
-          grouping: AND
-          values_set: 5
-          value: ''
-          values: _none
-          value_form:
-            -
-              value: default
-          effect: show
-          effect_options: {  }
-          selector: ''
+        6d910fc3-1e3b-4f69-86c7-679fa8dd308b:
+          entity_type: paragraph
+          bundle: hs_collection
+          dependee: field_bg_color
+          settings:
+            state: visible
+            reset: false
+            condition: value
+            grouping: AND
+            values_set: 5
+            value: ''
+            values: _none
+            value_form:
+              -
+                value: default
+            effect: show
+            effect_options: {  }
+            selector: ''
   field_hs_collection_items:
     type: paragraphs
     weight: 7

--- a/config/default/field.field.paragraph.hs_collection.field_hs_collection_uh.yml
+++ b/config/default/field.field.paragraph.hs_collection.field_hs_collection_uh.yml
@@ -15,7 +15,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: 1
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_uh.yml
+++ b/config/default/field.field.paragraph.hs_priv_collection.field_hs_collection_uh.yml
@@ -15,7 +15,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: 1
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -62,6 +62,7 @@ function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(array &$
     'field_hs_carousel_slides',
     'field_hs_sptlght_sldes',
     'field_hs_page_components',
+    'field_hs_priv_page_components',
   ];
   // We need the field name to alter the correct element.
   if (
@@ -104,6 +105,7 @@ function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(array &$
       break;
 
     case 'field_hs_page_components':
+    case 'field_hs_priv_page_components':
       // There are multiple issues with setting and removing the required state
       // from paragraph fields when using the `conditional_fields` module, so
       // use form alter to use the states api instead.
@@ -117,7 +119,7 @@ function hs_paragraph_types_field_widget_complete_paragraphs_form_alter(array &$
         $element = $field_widget_form['widget'][$key];
         if (
           empty($element['#paragraph_type']) ||
-          $element['#paragraph_type'] != 'hs_collection' ||
+          !in_array($element['#paragraph_type'], ['hs_collection', 'hs_priv_collection']) ||
           empty($element['subform']['field_title']) ||
           empty($element['subform']['field_title_settings'])
         ) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -138,3 +138,11 @@ $hb-current-theme: 'traditional' !default;
     font-weight: 400;
   }
 }
+
+.hb-raised-cards--uniform-height .field-hs-collection-items .ptype-hs-postcard .paragraph-admin-preview {
+  display: flex;
+
+  & div:only-child:not(.hb-card__date-tile, .hb-pill) {
+    width: 100%;
+  }
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
@@ -3,8 +3,7 @@
   &--uniform-height .hs-paragraph-style .ptype-hs-postcard,
   &--uniform-height .hs-paragraph-style .hb-grid__item,
   &--uniform-height .hb-grid .hb-grid__item,
-  &--uniform-height .field-hs-collection-items .ptype-hs-postcard,
-  &--uniform-height .field-hs-collection-items .ptype-hs-postcard .paragraph-admin-preview {
+  &--uniform-height .field-hs-collection-items .ptype-hs-postcard {
     display: flex;
 
     & div:only-child:not(.hb-card__date-tile, .hb-pill) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
@@ -3,7 +3,8 @@
   &--uniform-height .hs-paragraph-style .ptype-hs-postcard,
   &--uniform-height .hs-paragraph-style .hb-grid__item,
   &--uniform-height .hb-grid .hb-grid__item,
-  &--uniform-height .field-hs-collection-items .ptype-hs-postcard {
+  &--uniform-height .field-hs-collection-items .ptype-hs-postcard,
+  &--uniform-height .field-hs-collection-items .ptype-hs-postcard .paragraph-admin-preview {
     display: flex;
 
     & div:only-child:not(.hb-card__date-tile, .hb-pill) {

--- a/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-collection.html.twig
@@ -41,21 +41,14 @@
 {{ attach_library( default_theme ~ '/collection') }}
 {{ attach_library('humsci_basic/equal-height-grid') }}
 
-{% set raised_cards = false %}
-{% if paragraph.field_raised_cards.value == true %}
-   {% set raised_cards = true %}
-{% endif %}
-{% if paragraph.field_hs_collection_uh.value == true %}
-  {% set uniform_height = true %}
-{% endif %}
 {%
   set classes = [
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
-    raised_cards ? 'hb-raised-cards',
-    raised_cards and uniform_height ? 'hb-raised-cards--uniform-height'
+    paragraph.field_raised_cards.value ? 'hb-raised-cards',
+    paragraph.field_hs_collection_uh.value ? 'hb-raised-cards--uniform-height'
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-priv-collection.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/components/paragraph--hs-priv-collection.html.twig
@@ -48,7 +48,7 @@
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
     paragraph.field_raised_cards.value ? 'hb-raised-cards',
-    paragraph.field_raised_cards.value and paragraph.field_hs_collection_uh.value ? 'hb-raised-cards--uniform-height'
+    paragraph.field_hs_collection_uh.value ? 'hb-raised-cards--uniform-height'
   ]
 %}
 


### PR DESCRIPTION
# Summary
Decouple the Raised Cards and Uniform Height toggle

## Backstory
[SHS-5576](https://app.clickup.com/t/36718269/SHS-5576)

## Need Review By (Date)
09/23

## Urgency
medium

## Steps to Test
1. In [Traditional](https://hs-traditional-qcryvmdyql0nyyb3wsrxfp6ntq14nyun.tugboatqa.com/) and [Colorful](https://hs-colorful-qcryvmdyql0nyyb3wsrxfp6ntq14nyun.tugboatqa.com/)
2. Create a Flexible Page
3. Add a Collection
4. Confirm the Raised Cards and Uniform Height toggle are now decoupled and don't depend of each other
5. Test by selecting both, only one, and confirm styles are only added based on the option/options enabled
6. Test the same for Private Collections in Private Pages

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211009228755705