### PR TITLE
HSD8-1779: Add user.role.custm* to Config Readonly Whitelist for Role Deletion

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -636,6 +636,7 @@ function su_humsci_profile_config_readonly_whitelist_patterns() {
     'field.field.node.hs_basic_page.field_hs_page_components',
     'field.field.node.hs_basic_page.field_hs_page_hero',
     'field.field.node.hs_private_page.field_hs_priv_page_components',
+    'user.role.custm*',
   ];
 }
 


### PR DESCRIPTION
# Summary
Allow deletion of custom user roles (with `custm_` prefix) by whitelisting them in the config_readonly module.

## Backstory
[HSD8-1779](https://stanfordits.atlassian.net/browse/HSD8-1779): Unable to delete Custom Roles on Production Sites
On production sites, custom roles (with the `custm_` prefix) could not be deleted due to the interaction between `hs_config_readonly` and `config_ignore` rules. The intended behavior was for roles matching `user.role.custm*` to be deletable, but the `hs_config_readonly` module logic was blocking them due to the existing `user.role.*:permissions` `config_ignore` rule. After investigation, it was determined that adding `'user.role.custm*'` to the `su_humsci_profile_config_readonly_whitelist_patterns()` hook allows deletion as expected by whitelisting the configuration entirely.

## Need Review By (Date)
ASAP

## Urgency
Medium

## Steps to Test
1. Sync a site with custom roles (e.g., publichumanities) locally.
2. Ensure the `hs_config_readonly` module is enabled and config is imported.
3. Attempt to delete a custom role (with `custm_` prefix) via `/admin/people/roles`.
4. Confirm the delete button is enabled and the role can be deleted.
5. Confirm non-custom roles (without `custm_` prefix) remain protected as before.


[HSD8-1779]: https://stanfordits.atlassian.net/browse/HSD8-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ