### PR TITLE
Disable component preview CSS aggregation

### DIFF
--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.libraries.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.libraries.yml
@@ -9,7 +9,7 @@ base:
 admin-preview:
   css:
     theme:
-      css/preview.css: {}
+      css/preview.css: { preprocess: false }
 
 # Layouts.
 
@@ -30,12 +30,10 @@ collection:
     theme:
       css/collection.css: {}
 
-
 global-message:
   css:
     theme:
       css/global-message.css: {}
-
 
 pattern-grid:
   css:

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.libraries.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.libraries.yml
@@ -9,7 +9,7 @@ base:
 admin-preview:
   css:
     theme:
-      css/preview.css: {}
+      css/preview.css: { preprocess: false }
 
 # Layouts.
 
@@ -30,12 +30,10 @@ collection:
     theme:
       css/collection.css: {}
 
-
 global-message:
   css:
     theme:
       css/global-message.css: {}
-
 
 pattern-grid:
   css:


### PR DESCRIPTION
# Summary
- There were some issues when Drupal aggregated the component preview CSS, so it was disabled for that specific file

## Backstory
- [Slack thread](https://fourkitchens.slack.com/archives/C03DD43ACPK/p1758750793698209)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Enable CSS aggregation
2. Visit the Flexible page and private page node add / edit forms
3. Confirm that the forms look and work as expected
4. Add some components, save the page
5. Edit the node and confirm that the components previews look as expected

# Review Tasks

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Are PHP functions and variables in `snake_case` and not `camelCase`?
- [ ] Does Drupal code follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards/php/php-coding-standards)?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided?

### Code security
- [ ] Is all [user input properly sanitized when rendered](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

### General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?
