### PR TITLE
HSD8-1787: Remove Blank Instructor Entity References from Course Imports

### DIFF
--- a/config/default/migrate_plus.migration.hs_courses.yml
+++ b/config/default/migrate_plus.migration.hs_courses.yml
@@ -318,17 +318,13 @@ process:
       key: sunet
       include_source: true
       process:
-        instructor_id:
-          plugin: callback
-          callable: strtolower
-          source: sunet
         target_id:
           plugin: entity_generate
           entity_type: hs_entity
           bundle_key: bundle
           bundle: course_collections__instructor
           value_key: field_migration_id
-          source: '@instructor_id'
+          source: sunet
           values:
             label: name
             field_instructor_role: role


### PR DESCRIPTION
# Summary
Removes blank instructor entity reference entries from Course content nodes by updating the migration process for instructors. Only valid instructor references are now created during import.

## Backstory
[HSD8-1787](https://stanfordits.atlassian.net/browse/HSD8-1787): Instructor data has empty rows on every other row in Course content
Previously, every imported Course node had an row in the Instructors entity reference field for each Instructor imported. This was traced to an unnecessary key (`instructor_id`) in the migration sub_process, which caused blank entries to be created. The fix removes this key and processes the `sunet` value directly, ensuring only valid instructors are referenced.

## Need Review By (Date)
ASAP

## Urgency
Medium

## Steps to Test
1. Run the course importer on a site with multiple instructors per course section.
2. Inspect the imported Course nodes and verify that only valid instructor references are present. No blank entries should appear in the entity reference field.
3. Confirm that the migration works for both single and multiple instructor scenarios.

[HSD8-1787]: https://stanfordits.atlassian.net/browse/HSD8-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211337154197322