### PR TITLE
HSD8-1785: Revert "Update default Country value for Person Address field"

### DIFF
--- a/config/default/field.field.node.hs_person.field_hs_person_mail.yml
+++ b/config/default/field.field.node.hs_person.field_hs_person_mail.yml
@@ -17,37 +17,23 @@ label: 'Mailing Address'
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    langcode: null
-    country_code: US
-    administrative_area: ''
-    locality: ''
-    dependent_locality: null
-    postal_code: ''
-    sorting_code: null
-    address_line1: ''
-    address_line2: ''
-    address_line3: null
-    organization: null
-    given_name: null
-    additional_name: null
-    family_name: null
+default_value: {  }
 default_value_callback: ''
 settings:
   available_countries:
     US: US
   langcode_override: ''
-  field_overrides:
-    givenName:
-      override: hidden
-    additionalName:
-      override: hidden
-    familyName:
-      override: hidden
-    organization:
-      override: hidden
-    addressLine3:
-      override: hidden
-  fields: {  }
+  field_overrides: {  }
+  fields:
+    administrativeArea: administrativeArea
+    locality: locality
+    dependentLocality: dependentLocality
+    postalCode: postalCode
+    sortingCode: sortingCode
+    addressLine1: addressLine1
+    addressLine2: addressLine2
+    organization: '0'
+    givenName: '0'
+    additionalName: '0'
+    familyName: '0'
 field_type: address

--- a/docroot/modules/humsci/hs_person/config/install/field.field.node.hs_person.field_hs_person_mail.yml
+++ b/docroot/modules/humsci/hs_person/config/install/field.field.node.hs_person.field_hs_person_mail.yml
@@ -14,37 +14,23 @@ label: 'Mailing Address'
 description: ''
 required: false
 translatable: false
-default_value:
-  -
-    langcode: null
-    country_code: US
-    administrative_area: ''
-    locality: ''
-    dependent_locality: null
-    postal_code: ''
-    sorting_code: null
-    address_line1: ''
-    address_line2: ''
-    address_line3: null
-    organization: null
-    given_name: null
-    additional_name: null
-    family_name: null
+default_value: {  }
 default_value_callback: ''
 settings:
   available_countries:
     US: US
+  fields:
+    administrativeArea: administrativeArea
+    locality: locality
+    dependentLocality: dependentLocality
+    postalCode: postalCode
+    sortingCode: sortingCode
+    addressLine1: addressLine1
+    addressLine2: addressLine2
+    organization: '0'
+    givenName: '0'
+    additionalName: '0'
+    familyName: '0'
   langcode_override: ''
-  field_overrides:
-    givenName:
-      override: hidden
-    additionalName:
-      override: hidden
-    familyName:
-      override: hidden
-    organization:
-      override: hidden
-    addressLine3:
-      override: hidden
-  fields: {  }
+  field_overrides: {  }
 field_type: address


### PR DESCRIPTION
This reverts commit 994f454d615e91534e2c17892c99b5a0f842ab64.
PR #1967

[HSD8-1785](https://stanfordits.atlassian.net/browse/HSD8-1785): Update the default configuration setting for the Mailing Address Country on Person content type
> During testing it was pointed out that by having United States selected by default it makes the field required. Would it be possible to remove this from this week’s prod release?

[HSD8-1785]: https://stanfordits.atlassian.net/browse/HSD8-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ