### PR TITLE
SHS-6384: Padding/alignment of media in CKEditor is not representative of the front-end

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
@@ -77,7 +77,7 @@
     aspect-ratio: 16/9;
   }
 
-  .drupal-media,
+  .drupal-media:not(:has(article.hb-media-image)),
   .field-media-oembed-video,
   .media-oembed-content {
     width: 100%;

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -137,6 +137,28 @@
     background-color: transparent;
     font-weight: 400;
   }
+
+  figure.caption-drupal-media {
+    position: relative;
+    z-index: 1;
+    box-sizing: border-box;
+
+    @include hb-themes(('colorful', 'airy')) {
+      margin-bottom: hb-spacing-width('sm');
+    }
+
+    @include hb-traditional {
+      margin-bottom: hb-spacing-width('xs');
+    }
+
+    article:not(.hb-media-video):not(.hb-media-embed) {
+      position: relative;
+
+      + figcaption {
+        @include hb-caption-credit;
+      }
+    }
+  }
 }
 
 .hb-raised-cards--uniform-height

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -361,24 +361,13 @@ $credits: (hs-credits, credits);
   }
 
   figcaption {
-    font-style: italic;
+    @include hb-caption-credit;
+
     font-size: 12px !important;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    z-index: 5;
-    text-align: right;
-    line-height: 140%;
-    height: auto;
     box-sizing: border-box;
     color: var(--palette--white) !important;
     border: none;
     background: linear-gradient(to top, var(--palette--black), transparent) !important;
-
-    @include grid-media-min('sm') {
-      padding: hb-calculate-rems(24px) hb-calculate-rems(12px)
-        hb-calculate-rems(16px) 15% !important;
-    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -339,7 +339,6 @@ $credits: (hs-credits, credits);
 }
 
 .drupal-media-style-align-right,
-// .drupal-media-style-align-center,
 .drupal-media-style-align-left {
   max-width: 100%;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -338,6 +338,45 @@ $credits: (hs-credits, credits);
   }
 }
 
+.drupal-media-style-align-right .align-right,
+.drupal-media-style-align-center .align-center,
+.drupal-media-style-align-left .align-left {
+  max-width: 100%;
+  margin: 0;
+  float: none;
+}
+
+.drupal-media:has(.hb-media-image) {
+  @include hb-themes(('colorful', 'airy')) {
+    margin-bottom: hb-spacing-width('sm');
+  }
+
+  @include hb-traditional {
+    margin-bottom: hb-spacing-width('xs');
+  }
+
+  figcaption {
+    font-style: italic;
+    font-size: 12px !important;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    z-index: 5;
+    text-align: right;
+    line-height: 140%;
+    height: auto;
+    box-sizing: border-box;
+    color: var(--palette--white) !important;
+    border: none;
+    background: linear-gradient(to top, var(--palette--black), transparent) !important;
+
+    @include grid-media-min('sm') {
+      padding: hb-calculate-rems(24px) hb-calculate-rems(12px)
+        hb-calculate-rems(16px) 15% !important;
+    }
+  }
+}
+
 // blockquotes
 // The text area blockquote content is placed inside of a paragraph tag.
 blockquote:nth-child(n) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -368,6 +368,7 @@ $credits: (hs-credits, credits);
     color: var(--palette--white) !important;
     border: none;
     background: linear-gradient(to top, var(--palette--black), transparent) !important;
+    z-index: 1;
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -338,6 +338,12 @@ $credits: (hs-credits, credits);
   }
 }
 
+.drupal-media-style-align-right,
+// .drupal-media-style-align-center,
+.drupal-media-style-align-left {
+  max-width: 100%;
+}
+
 .drupal-media-style-align-right .align-right,
 .drupal-media-style-align-center .align-center,
 .drupal-media-style-align-left .align-left {
@@ -346,7 +352,7 @@ $credits: (hs-credits, credits);
   float: none;
 }
 
-.drupal-media:has(.hb-media-image) {
+.drupal-media:has(article.hb-media-image) {
   @include hb-themes(('colorful', 'airy')) {
     margin-bottom: hb-spacing-width('sm');
   }
@@ -375,6 +381,16 @@ $credits: (hs-credits, credits);
         hb-calculate-rems(16px) 15% !important;
     }
   }
+}
+
+.drupal-media-style-align-center:has(.hb-media-image) figcaption {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+// Override style coming from ckeditor5 module.
+.ck.ck-content .drupal-media-style-align-center article:not(.hb-media-video) {
+  max-width: 100% !important;
 }
 
 // blockquotes


### PR DESCRIPTION
# Summary
Make images in CKEditor and Paragraph Admin Preview look similar to how it looks in the frontend

## Backstory
[SHS-6384](https://app.clickup.com/t/36718269/SHS-6384)

## Need Review By (Date)
10/07

## Urgency
medium

## Steps to Test
1. Log In in [Colorful](https://hs-colorful-tweedmp1bfskotznsp7z7cpp5vuv5gel.tugboatqa.com) and [Traditional](https://hs-traditional-tweedmp1bfskotznsp7z7cpp5vuv5gel.tugboatqa.com)
2. Visit the Text Area in [Colorful](https://hs-colorful-tweedmp1bfskotznsp7z7cpp5vuv5gel.tugboatqa.com/components/text-area-typography) and [Traditional](https://hs-traditional-tweedmp1bfskotznsp7z7cpp5vuv5gel.tugboatqa.com/components/text-area-typography)
3. Edit the page
4. Edit the text areas with media. Confirm the images + caption in the WYSIWYG and paragraph admin preview look similar to what's on the frontend


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211566031442925
  - https://app.asana.com/0/0/1211566031442923