### PR TITLE
SHS-6416: Private Collection, warbler, title color contrast

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -138,7 +138,7 @@
     font-weight: 400;
   }
 
-  .hb-vertical-linked-card {
+  .hb-vertical-linked-card__title__link.ext {
     --link-base-current-color: var(--palette--white);
     --link-base-hover-current-color: var(--palette--white);
   }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -137,6 +137,11 @@
     background-color: transparent;
     font-weight: 400;
   }
+
+  .hb-vertical-linked-card {
+    --link-base-current-color: var(--palette--white);
+    --link-base-hover-current-color: var(--palette--white);
+  }
 }
 
 .hb-raised-cards--uniform-height


### PR DESCRIPTION
# Summary
Fix title color contrast private collection for warbler (In fact this is happening for all the Traditional sites in the paragraph admin preview)

## Backstory
[SHS-6416](https://app.clickup.com/t/36718269/SHS-6416)

## Need Review By (Date)
10/07

## Urgency
medium

## Steps to Test
1. Go to [Traditional](https://hs-traditional-bgemjdoyopi0qjhfup1nbzhxh6ohdocu.tugboatqa.com/) page
2. Add a private page, 
3. Then add a private collection
4. Add a Postcard vertical linked (or any other postcard)
5. Fill title and links
6. Hit Save
7. Confirm the color contrast issue happening in the preview is not happening anymore (Check it works and looks good in all color pairings)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211566031442919