### PR TITLE
SHS-6339: Optimize loading of Stanford font

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -177,7 +177,7 @@ function humsci_basic_page_attachments_alter(&$attachments) {
 
   // Check if any of the font URLs are Google Fonts.
   $has_google_fonts = array_find($fonts, function ($font) {
-    return str_contains($font, 'fonts.googleapis.com');
+    return isset($font['url']) && str_contains($font['url'], 'fonts.googleapis.com');
   });
 
   // Attach preconnects only once if Google Fonts are present.
@@ -199,22 +199,29 @@ function humsci_basic_page_attachments_alter(&$attachments) {
 
   // Now attach preload + stylesheet for each font.
   foreach ($info['preload_fonts'] as $font) {
+    if (empty($font['url']) || empty($font['type'])) {
+      continue;
+    }
+
     // Preload first.
     $attachments['#attached']['html_head_link'][] = [[
       'rel' => 'preload',
-      'as' => 'style',
-      'href' => $font,
+      'as' => $font['type'],
+      'href' => $font['url'],
+      'crossorigin' => 'anonymous',
     ],
       FALSE,
     ];
 
-    // Then stylesheet.
-    $attachments['#attached']['html_head_link'][] = [[
-      'rel' => 'stylesheet',
-      'href' => $font,
-    ],
-      FALSE,
-    ];
+    // If type is style, add the stylesheet link.
+    if ($font['type'] == 'style') {
+      $attachments['#attached']['html_head_link'][] = [[
+        'rel' => 'stylesheet',
+        'href' => $font['url'],
+      ],
+        FALSE,
+      ];
+    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/fonts/_fonts.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/fonts/_fonts.scss
@@ -8,4 +8,5 @@
     url('https://www-media.stanford.edu/assets/fonts/stanford.ttf')
       format('truetype');
   font-weight: 300;
+  font-display: swap;
 }

--- a/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
+++ b/docroot/themes/humsci/humsci_colorful/humsci_colorful.info.yml
@@ -24,4 +24,7 @@ libraries:
   - humsci_colorful/base
 
 preload_fonts:
-  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap'
+  - url: 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap'
+    type: 'style'
+  - url: 'https://www-media.stanford.edu/assets/fonts/stanford.woff2'
+    type: 'font'

--- a/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
+++ b/docroot/themes/humsci/humsci_traditional/humsci_traditional.info.yml
@@ -24,4 +24,7 @@ libraries:
   - humsci_traditional/base
 
 preload_fonts:
-  - 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap'
+  - url: 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap'
+    type: 'style'
+  - url: 'https://www-media.stanford.edu/assets/fonts/stanford.woff2'
+    type: 'font'


### PR DESCRIPTION
# Summary
- Add `font-display: swap` to Stanford font definition
- Extend font preloading logic added in #1958 to support individual font files

## Backstory
- [ClickUp ticket](https://app.clickup.com/t/36718269/SHS-6339)

## Need Review By (Date)
10/08

## Urgency
medium

## Steps to Test
1. Visit both [Colorful](https://hs-colorful-r9j6oc4w2vgsyyxieodephy5fserumps.tugboatqa.com/) and [Traditional](https://hs-traditional-r9j6oc4w2vgsyyxieodephy5fserumps.tugboatqa.com/) sites
2. Confirm that the "Stanford" logo in the header looks as expected
3. Using the inspect tools, confirm that the Stanford font is being correctly loaded (in Chrome, select the element and then check "Computed > Rendered Fonts" in the "Elements" tab)
4. Inspect the site, go to the `<head>` element and confirm that the Stanford font is being preloaded:
    <img width="829" height="34" alt="Screenshot 2025-10-03 at 4 18 24 PM" src="https://github.com/user-attachments/assets/413debb4-e92c-4389-ab1c-ea25050a7d0d" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211595294398800