### PR TITLE
SHS-6398: Fix javascript error triggered when editing components with text areas

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/js/shared/tables/wrap.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/tables/wrap.js
@@ -12,7 +12,7 @@
        */
       function wrapElement(element) {
         // Create a new div with a special class name
-        const wrapper = context.createElement('div');
+        const wrapper = document.createElement('div');
         wrapper.className = 'hb-table-wrap';
 
         element.parentNode.insertBefore(wrapper, element);


### PR DESCRIPTION
# Summary
- Fix javascript error that was being triggered when editing components with text areas

## Backstory
- [ClickUp ticket](https://app.clickup.com/t/36718269/SHS-6398)

## Need Review By (Date)
10/08

## Urgency
medium

## Steps to Test
1. Log into either [colorful](https://hs-colorful-inbui13ypjezuzt5mcquqlvn0ri2b4uq.tugboatqa.com/user) or [traditional](https://hs-traditional-inbui13ypjezuzt5mcquqlvn0ri2b4uq.tugboatqa.com/user) test sites (no need to test both, javascript is shared by both themes)
2. Visit the Horizontal Cards page ([colorful](https://hs-colorful-inbui13ypjezuzt5mcquqlvn0ri2b4uq.tugboatqa.com/components/collections/collections-postcards/horizontal-cards), [traditional](https://hs-traditional-inbui13ypjezuzt5mcquqlvn0ri2b4uq.tugboatqa.com/components/collections-0/collections-postcards/horizontal-cards)).
3. Open the javascript console and edit the node. Then edit any component. Confirm that the following error is not present anymore:
    <img width="995" height="159" alt="Screenshot 2025-09-11 at 12 37 57 PM" src="https://github.com/user-attachments/assets/c601122e-3f3d-473a-a130-5bb6205f88df" />

**NOTE:** In some case, there'll be a different error in the console: `Uncaught TypeError: $action.next(...).textContent is not a function`. It can be ignored, it's a non-critical [issue in the Rabbit Hole module](https://www.drupal.org/project/rabbit_hole/issues/3463826) that's already fixed in the dev version and will be included in the module's next release.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211595294398797
  - https://app.asana.com/0/0/1211712285628670