### PR TITLE
SHS-6400: Stretched vertical linked cards in Accordion can bleed outside the accordion boundaries

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
@@ -33,6 +33,7 @@
 
   &__item {
     display: flex;
+    align-items: flex-start;
     margin-bottom: calc(#{hb-spacing-width('default', false)} / 2);
 
     @include grid-media-min('sm') {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
@@ -32,6 +32,7 @@
   }
 
   &__item {
+    display: flex;
     margin-bottom: calc(#{hb-spacing-width('default', false)} / 2);
 
     @include grid-media-min('sm') {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
@@ -55,7 +55,6 @@
   .hb-stretch-vertical-linked-cards & {
     display: flex;
     flex-flow: column nowrap;
-    height: 100%;
   }
 
   &__img {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
@@ -57,6 +57,11 @@
     flex-flow: column nowrap;
   }
 
+  // Stretched vertical linked cards inside a grid.
+  .hb-stretch-vertical-linked-cards .hb-grid__item & {
+    align-self: stretch;
+  }
+
   &__img {
     overflow: hidden;
 


### PR DESCRIPTION
# Summary
- Fix issue that was causing vertical linked cards to overflow their container when inside a grid and stretched.

## Backstory
- [ClickUp ticket](https://app.clickup.com/t/36718269/SHS-6400)

## Need Review By (Date)
10/08

## Urgency
medium

## Steps to Test
1. Visit the [Accordions page](https://hs-colorful-awepjlcmfzwoqepo3lejqncbre8cosbm.tugboatqa.com/accordions) in the Colorful test site
2. Open the "Accordion with a News view" accordion. Confirm the following:
    1. You can see a news view of Vertical Linked Cards
    2. The cards are stretched
    3. There's no overflow at the bottom of the accordion

**NOTE:** This bug isn't present in any of the Tugboat test sites, so a similar view was created for testing purposes in the colorful test site. For reference, you can visit https://music.stanford.edu/musicstanford and check the accordions in that page to see the bug that was fixed and compare with the test setup. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211595294398794