### PR TITLE
SHS-6407: Add feeds tamper module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "drupal/fast_404": "^3.2",
         "drupal/fast_404_generator": "^1.0",
         "drupal/feeds": "^3.0",
+        "drupal/feeds_tamper": "^2.0@beta",
         "drupal/field_formatter_class": "^1.4",
         "drupal/field_group": "^3.5",
         "drupal/field_permissions": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18c8484f3ff34bc4204f3bf6af1fdf18",
+    "content-hash": "4afacb10bffc7b8d337ee3e05b50aeea",
     "packages": [
         {
             "name": "acquia/blt",
@@ -6446,6 +6446,77 @@
             }
         },
         {
+            "name": "drupal/feeds_tamper",
+            "version": "2.0.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/feeds_tamper.git",
+                "reference": "8.x-2.0-beta4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/feeds_tamper-8.x-2.0-beta4.zip",
+                "reference": "8.x-2.0-beta4",
+                "shasum": "2d72f372c6a58a1273e26a07dcb906f0fd264b99"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10 || ^11",
+                "drupal/feeds": "^3.0",
+                "drupal/tamper": "^1.0-alpha3"
+            },
+            "require-dev": {
+                "drupal/feeds": "3.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-beta4",
+                    "datestamp": "1725795667",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "franz",
+                    "homepage": "https://www.drupal.org/user/581844"
+                },
+                {
+                    "name": "Honza Pobořil",
+                    "homepage": "https://www.drupal.org/user/123612"
+                },
+                {
+                    "name": "mausolos",
+                    "homepage": "https://www.drupal.org/user/642118"
+                },
+                {
+                    "name": "megachriz",
+                    "homepage": "https://www.drupal.org/user/654114"
+                },
+                {
+                    "name": "twistor",
+                    "homepage": "https://www.drupal.org/user/473738"
+                }
+            ],
+            "description": "Modify feeds data before it gets saved.",
+            "homepage": "http://drupal.org/project/feeds_tamper",
+            "keywords": [
+                "Drupal",
+                "feeds",
+                "tamper"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/feeds_tamper",
+                "issues": "http://drupal.org/project/issues/feeds_tamper"
+            }
+        },
+        {
             "name": "drupal/field_formatter_class",
             "version": "1.8.0",
             "source": {
@@ -11748,6 +11819,67 @@
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
                 "source": "https://git.drupalcode.org/project/stage_file_proxy"
+            }
+        },
+        {
+            "name": "drupal/tamper",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/tamper.git",
+                "reference": "8.x-1.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/tamper-8.x-1.0-beta1.zip",
+                "reference": "8.x-1.0-beta1",
+                "shasum": "57cdf8e00396ea3716c74e3c6b92615b0ac64c62"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta1",
+                    "datestamp": "1740654928",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "ericgsmith",
+                    "homepage": "https://www.drupal.org/user/1649952"
+                },
+                {
+                    "name": "jamesdixon",
+                    "homepage": "https://www.drupal.org/user/762570"
+                },
+                {
+                    "name": "megachriz",
+                    "homepage": "https://www.drupal.org/user/654114"
+                },
+                {
+                    "name": "twistor",
+                    "homepage": "https://www.drupal.org/user/473738"
+                }
+            ],
+            "description": "Generic plugin to modify data.",
+            "homepage": "https://www.drupal.org/project/tamper",
+            "keywords": [
+                "Drupal",
+                "tamper"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/tamper",
+                "issues": "http://drupal.org/project/issues/tamper"
             }
         },
         {
@@ -27305,6 +27437,7 @@
         "drupal/content_access_simple": 10,
         "drupal/empty_fields": 10,
         "drupal/entity_reference_exposed_filters": 15,
+        "drupal/feeds_tamper": 10,
         "drupal/hook_event_dispatcher": 15,
         "drupal/linkit": 5,
         "drupal/markup": 10,

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -48,6 +48,8 @@ ignored_config_entities:
   - 'user.settings:register'
   - 'single_content_sync.settings:allowed_entity_types.node'
   - 'core.extension:module.feeds'
+  - 'core.extension:module.feeds_tamper'
+  - 'core.extension:module.tamper'
   - core.entity_view_mode.feeds_feed.full
   - feeds.settings
   - 'system.action.feeds_feed*'


### PR DESCRIPTION
# Summary
Adds the Feeds Tamper module to provide enhanced data manipulation capabilities during content import processes. This module will be manually enabled only on sites that require its functionality.

## Backstory
The Feeds Tamper module extends the Feeds module by allowing data modifications before content is saved. It provides community-supported plugins for string replacements, case conversions, trimming, and other data transformations. This reduces the need for custom code while providing powerful import processing capabilities. Since most sites don't require this functionality, the module will be manually enabled only where needed.

## Need Review By (Date)
ASAP

## Urgency
High. Getting this to production with simplify current work with the Jasper Ridge website.

## Steps to Test
1. Verify that is module is not enabled on existing multidevs.
