### PR TITLE
SHS-6422: BUGFIX | Load fonts on admin preview page

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -107,7 +107,7 @@ function su_humsci_gin_admin_page_attachments_alter(&$attachments) {
     return;
   }
 
- $fonts = $info['preload_fonts'];
+  $fonts = $info['preload_fonts'];
 
   // Check if any of the font URLs are Google Fonts.
   $has_google_fonts = array_find($fonts, function ($font) {

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -94,3 +94,60 @@ function su_humsci_gin_admin_preprocess_block(&$variables) {
   }
 
 }
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function su_humsci_gin_admin_page_attachments_alter(&$attachments) {
+  // Preload fonts based on what's in info.yml.
+  $theme = \Drupal::theme()->getActiveTheme();
+  $info = $theme->getExtension()->info;
+
+  if (empty($info['preload_fonts'])) {
+    return;
+  }
+
+ $fonts = $info['preload_fonts'];
+
+  // Check if any of the font URLs are Google Fonts.
+  $has_google_fonts = array_find($fonts, function ($font) {
+    return str_contains($font, 'fonts.googleapis.com');
+  });
+
+  // Attach preconnects only once if Google Fonts are present.
+  if (!empty($has_google_fonts)) {
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'preconnect',
+      'href' => 'https://fonts.googleapis.com',
+    ],
+      FALSE,
+    ];
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'preconnect',
+      'href' => 'https://fonts.gstatic.com',
+      'crossorigin' => 'anonymous',
+    ],
+      FALSE,
+    ];
+  }
+
+  // Now attach preload + stylesheet for each font.
+  foreach ($info['preload_fonts'] as $font) {
+    // Preload first.
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'preload',
+      'as' => 'style',
+      'href' => $font,
+    ],
+      FALSE,
+    ];
+
+    // Then stylesheet.
+    $attachments['#attached']['html_head_link'][] = [[
+      'rel' => 'stylesheet',
+      'href' => $font,
+    ],
+      FALSE,
+    ];
+  }
+}


### PR DESCRIPTION
# Summary
Load fonts on admin preview page

## Backstory
[ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6422)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Visit both Colorful and Traditional sites
2. Log in
3. Edit any public or private page
4. Confirm now that both fonts Source Sans 3 and Source Serif 4 are being loaded
5. Confirm everything looks as expected in the Admin Paragraph Preview (Admin forms)
