### PR TITLE
Deprecate and Uninstall block_content_permissions with Role/Config Cleanup

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -866,3 +866,63 @@ function su_humsci_profile_update_9746() {
     ]);
   }
 }
+
+/**
+ * Remove block_content_permissions permissions and dependencies from roles.
+ */
+function su_humsci_profile_update_9747(): string {
+  $role_storage = \Drupal::entityTypeManager()->getStorage('user_role');
+  $roles = $role_storage->loadMultiple();
+  $removed_permissions = [];
+  $removed_dependencies = [];
+
+  // Get all block content types to build the dynamic permission names.
+  $block_content_types = \Drupal::entityTypeManager()->getStorage('block_content_type')->loadMultiple();
+  $permission_patterns = [];
+  foreach ($block_content_types as $type_id => $type) {
+    $permission_patterns[] = "create {$type_id} block content";
+    $permission_patterns[] = "delete any {$type_id} block content";
+    $permission_patterns[] = "update any {$type_id} block content";
+  }
+
+  // Remove permissions from all roles.
+  foreach ($roles as $role) {
+    /** @var \Drupal\user\Entity\Role $role */
+    $role_permissions = $role->getPermissions();
+    $to_remove = array_intersect($role_permissions, $permission_patterns);
+    if (!empty($to_remove)) {
+      foreach ($to_remove as $perm) {
+        $role->revokePermission($perm);
+      }
+      $role->save();
+      $removed_permissions[$role->id()] = $to_remove;
+    }
+
+    // Remove block_content_permissions from config dependencies if present.
+    $config = \Drupal::configFactory()->getEditable('user.role.' . $role->id());
+    $dependencies = (array) ($config->get('dependencies.module') ?: []);
+    if (($key = array_search('block_content_permissions', $dependencies)) !== FALSE) {
+      unset($dependencies[$key]);
+      $config->set('dependencies.module', array_values($dependencies));
+      $config->save();
+      $removed_dependencies[] = $role->id();
+    }
+  }
+
+  return t('Removed block_content_permissions permissions from roles: @roles. Removed config dependency from roles: @deps.', [
+    '@roles' => implode(', ', array_keys($removed_permissions)),
+    '@deps' => implode(', ', $removed_dependencies),
+  ]);
+}
+
+/**
+ * Uninstall the block_content_permissions module.
+ */
+function su_humsci_profile_update_9748(): string {
+  $module = 'block_content_permissions';
+  if (\Drupal::moduleHandler()->moduleExists($module)) {
+    \Drupal::service('module_installer')->uninstall([$module]);
+    return t('Uninstalled the block_content_permissions module.');
+  }
+  return t('block_content_permissions module was already uninstalled.');
+}


### PR DESCRIPTION
# Summary
Deprecate and safely uninstall the `block_content_permissions` module. Adds update hooks to programmatically remove all dynamic permissions and config dependencies from user roles before uninstalling the module, preventing config import failures and permission issues.

## Backstory

The recent 10.5.x update uninstalled the `block_content_permissions` module and updated all role configuration stored in the codebase accordingly. However, sites are allowed to create and customize roles, and those role configs are not tracked in the codebase. As a result, custom role configurations were not being adjusted before uninstalling the module. This led to broken config and config import failures on sites where custom roles still referenced the module or its dynamic permissions. 

This PR introduces update hooks to:
- Remove all permissions supplied by `block_content_permissions` from all roles (including custom roles).
- Remove config dependencies on the module from all roles.
- Uninstall the module only after all dependencies are cleaned up.

This ensures a clean deprecation and uninstallation process, even for sites with custom roles/config not tracked in code.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Sync a site with custom roles
1. Confirm:
   - No config import errors related to user roles or `block_content_permissions`.
   - The module is uninstalled.
   - All user roles (including custom ones) no longer reference the module or its permissions.
   - Site permissions and access behave as expected.