### PR TITLE
CI | Always run npm install after restoring node_modules from cache

### DIFF
--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -75,8 +75,7 @@ jobs:
         with:
           path: ${{ env.themePath }}/node_modules
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', env.themePath)) }}
-      - name: Install theme node_modules
-        if: steps.cache-theme-node-modules.outputs.cache-hit != 'true'
+      - name: Install theme dependencies
         run: npm install --prefix $themePath
       - name: Lint Theme
         run: npm run lint --prefix $themePath
@@ -133,13 +132,12 @@ jobs:
           mkdir -p docroot/sites/default/files &&
           chmod -R 777 docroot/sites/default/files/ &&
           blt drupal:install -n
-      # - name: Restore theme node_modules
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ${{ env.themePath }}/node_modules
-      #     key: ${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', env.themePath)) }}
-      - name: Install theme node_modules
-        # if: steps.cache-theme-node-modules.outputs.cache-hit != 'true'
+      - name: Restore theme node_modules
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.themePath }}/node_modules
+          key: ${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', env.themePath)) }}
+      - name: Install theme dependencies
         run: npm install --prefix $themePath
       - name: Compile theme assets
         run: npm run build --prefix $themePath
@@ -212,6 +210,8 @@ jobs:
         with:
           path: ${{ env.themePath }}/node_modules
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', env.themePath)) }}
+      - name: Install theme dependencies
+        run: npm install --prefix $themePath
       - name: Compile theme assets
         run: npm run build --prefix $themePath
       - name: Codeception Acceptance Tests
@@ -265,6 +265,8 @@ jobs:
         with:
           path: ${{ env.themePath }}/node_modules
           key: ${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', env.themePath)) }}
+      - name: Install theme dependencies
+        run: npm install --prefix $themePath
       - name: Deploy Branch
         run: |
           git config --global user.email "sws-developers@lists.stanford.edu" &&


### PR DESCRIPTION
# Summary
This PR updates the CI workflow to always run `npm install` after restoring theme `node_modules` from cache in all jobs. This not only ensures fresh, correct dependencies for every test and build, resolving issues with stale or mismatched node_modules, but also guarantees that any required install scripts or post-install steps are executed. This prevents subtle build failures caused by missing setup steps that may not be handled by cache restoration alone.

## Backstory
Recently, functional tests began failing after a migration from Grunt to Webpack (#1995) and changes to theme dependencies. Investigation revealed that restoring node_modules from cache without always running `npm install` led to stale or incomplete dependencies, especially after changes to `package-lock.json` or build scripts. Running `npm install` every time is best practice and matches how Composer dependencies are handled in CI. This change was tested directly in the functional test job and resolved the test failures.

## Urgency
High (blocks reliable CI and functional test coverage)

## Steps to Test
This is a CI job -- no tests to step.
