### PR TITLE
Revoke non-dynamic block_content_permissions

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -885,6 +885,13 @@ function su_humsci_profile_update_9747(): string {
     $permission_patterns[] = "update any {$type_id} block content";
   }
 
+  // Add static permissions from block_content_permissions.permissions.yml.
+  $static_permissions = [
+    'administer block content types',
+    'view restricted block content',
+  ];
+  $permission_patterns = array_merge($permission_patterns, $static_permissions);
+
   // Remove permissions from all roles.
   foreach ($roles as $role) {
     /** @var \Drupal\user\Entity\Role $role */


### PR DESCRIPTION
# Summary
Follow up to #2017. Also need to remove the two non-dynamic permissions defined in the module.

## Backstory
See #2017 