### PR TITLE
HSD8-1776: Uninstall and deprecate domain_registration module

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -44,7 +44,6 @@ ignored_config_entities:
   - content_access.settings
   - hs_capx.settings
   - system.site
-  - 'domain_registration.settings:pattern'
   - 'user.settings:register'
   - 'single_content_sync.settings:allowed_entity_types.node'
   - 'core.extension:module.feeds'

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -53,7 +53,6 @@ module:
   diff: 0
   display_field_copy: 0
   domain_301_redirect: 0
-  domain_registration: 0
   draggableviews: 0
   dropzonejs: 0
   dynamic_page_cache: 0

--- a/config/default/domain_registration.settings.yml
+++ b/config/default/domain_registration.settings.yml
@@ -1,6 +1,0 @@
-_core:
-  default_config_hash: 0xE4emSSHTVKb88WL3yN2IahuH23p8VNAXMZNux6BKs
-langcode: en
-method: 0
-pattern: ''
-message: 'You are not allowed to register for this site.'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -933,3 +933,15 @@ function su_humsci_profile_update_9748(): string {
   }
   return t('block_content_permissions module was already uninstalled.');
 }
+
+/**
+ * Uninstall the domain_registration module.
+ */
+function su_humsci_profile_update_9749(): string {
+  $module = 'domain_registration';
+  if (\Drupal::moduleHandler()->moduleExists($module)) {
+    \Drupal::service('module_installer')->uninstall([$module]);
+    return t('Uninstalled the domain_registration module.');
+  }
+  return t('domain_registration module was already uninstalled.');
+}


### PR DESCRIPTION
# Summary
Uninstalls the `domain_registration` module from the application via a database update hook. This is part 1 of a two-step process; the module will be removed from the codebase in a future release.

## Backstory
The `domain_registration` module is no longer needed. Uninstalling via a database update hook is best practice for this multi-site platform, ensuring safe removal without config import failures. Related config and ignore settings have been updated, and the module's config has been deleted. No other references to the module exist outside its own code and config.

## Need Review By (Date)
10/30/2025

## Urgency
medium

## Steps to Test
1. Run database updates:
   `drush @default.local updatedb -y`
2. Run config import:
   `drush @default.local ci -y`
3. Confirm `domain_registration` is uninstalled and its config is removed.
4. Review config changes:
   - `config_ignore.settings.yml` no longer ignores `domain_registration.settings:pattern`
   - `core.extension.yml` no longer lists `domain_registration`
   - `domain_registration.settings.yml` is deleted
5. Confirm no references to `domain_registration` remain except the module itself (to be removed in part 2).