### PR TITLE
SHS-6441: BUG | Image of "Banner Image" element became large

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -493,10 +493,12 @@ function humsci_basic_update_view_mode_full_width_image(array &$variables) {
     $parent_field_name = $paragraph->get('parent_field_name')->value;
 
     if ($parent_field_name == 'field_hs_page_hero') {
-      $entity = $variables['items'][0]['content']['#media'];
-      $view_builder = \Drupal::entityTypeManager()->getViewBuilder('media');
-      $render_array = $view_builder->view($entity, 'caption_credit_eager');
-      $variables['items'][0]['content'] = $render_array;
+      $variables['items'][0]['content']['#view_mode'] = 'caption_credit_eager';
+      // Update cache key to reflect new view mode.
+      $view_mode_cache_key = array_search('caption_credit', $variables['items'][0]['content']['#cache']['keys']);
+      if ($view_mode_cache_key !== FALSE) {
+        $variables['items'][0]['content']['#cache']['keys'][$view_mode_cache_key] = 'caption_credit_eager';
+      }
     }
     else {
       _humsci_basic_update_view_mode_slides_image($paragraph, $variables);
@@ -551,10 +553,12 @@ function _humsci_basic_update_view_mode_slides_image(ParagraphInterface $paragra
     return;
   }
 
-  $entity = $variables['items'][0]['content']['#media'];
-  $view_builder = \Drupal::entityTypeManager()->getViewBuilder('media');
-  $render_array = $view_builder->view($entity, 'caption_credit_eager');
-  $variables['items'][0]['content'] = $render_array;
+  $variables['items'][0]['content']['#view_mode'] = 'caption_credit_eager';
+  // Update cache key to reflect new view mode.
+  $view_mode_cache_key = array_search('caption_credit', $variables['items'][0]['content']['#cache']['keys']);
+  if ($view_mode_cache_key !== FALSE) {
+    $variables['items'][0]['content']['#cache']['keys'][$view_mode_cache_key] = 'caption_credit_eager';
+  }
 }
 
 /**


### PR DESCRIPTION
# Summary
- Fix how the image eager loading view mode is assigned to the full width region banner images, to ensure that the original image style is used

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6441)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test

### Tugboat
1. Visit https://pr2031-glyjdct2jwmyufwj8enpbmm54sxzlhzk.tugboatqa.com/components/hero-images-full-width-region-and-main-region/banner-image. Confirm that the banner image dimensions match the [live site](https://hs-colorful.stanford.edu/components/hero-images-full-width-region-and-main-region/banner-image) (you can also compare with the [stage site](https://hs-colorful-stage.stanford.edu/components/hero-images-full-width-region-and-main-region/banner-image), which has the bug).
2. Repeat the test for the other full width region banner types listed here: https://pr2031-glyjdct2jwmyufwj8enpbmm54sxzlhzk.tugboatqa.com/components/hero-images-full-width-region-and-main-region

### Local testing
1. Create a flexible page
3. In the full width region, add a "Banner image(s) with partial overlay and text" with at least 2 slides
4. Save the node and confirm the following:
    1. The first image has a `loading="eager"` attribute, the others have `loading="lazy"`
    3. The image style being used for the images is the correct one
5. Repeat the previous steps with the other banner types available for the full width region:
    1. Banner image(s) with text box
    2. Banner image
    4. Banner image with full overlay and text


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211734445948641