### PR TITLE
SHS-6442: BUG | width of Vertical Linked Cards with no image are uneven

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.grid.scss
@@ -32,8 +32,6 @@
   }
 
   &__item {
-    display: flex;
-    align-items: flex-start;
     margin-bottom: calc(#{hb-spacing-width('default', false)} / 2);
 
     @include grid-media-min('sm') {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
@@ -52,17 +52,6 @@
     );
   }
 
-  .hb-stretch-vertical-linked-cards & {
-    display: flex;
-    flex-flow: column nowrap;
-  }
-
-  // Stretched vertical linked cards inside a grid.
-  .hb-stretch-vertical-linked-cards .hb-grid__item & {
-    align-self: stretch;
-    width: 100%;
-  }
-
   &__img {
     overflow: hidden;
 
@@ -209,6 +198,24 @@
       @include hb-themes(('colorful', 'airy')) {
         background-image: none;
       }
+    }
+  }
+}
+
+// .hb-stretch-vertical-linked-cards helper class.
+.hb-stretch-vertical-linked-cards {
+  .hb-vertical-linked-card {
+    display: flex;
+    flex-flow: column nowrap;
+  }
+
+  .hb-grid__item {
+    display: flex;
+    align-items: flex-start;
+
+    .hb-vertical-linked-card {
+      align-self: stretch;
+      width: 100%;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_vertical-linked-card.scss
@@ -60,6 +60,7 @@
   // Stretched vertical linked cards inside a grid.
   .hb-stretch-vertical-linked-cards .hb-grid__item & {
     align-self: stretch;
+    width: 100%;
   }
 
   &__img {


### PR DESCRIPTION
# Summary
- Fix uneven width issue in stretched vertical linked cards inside a grid

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6442)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Log into the [Colorful Tugboat test site](https://pr2032-he1v1osoneafm06jk6n48c795rwf7atq.tugboatqa.com/user)
2. Edit the [_Vertical Linked Grid_ display of the _Default Research Area_ view](https://pr2032-he1v1osoneafm06jk6n48c795rwf7atq.tugboatqa.com/admin/structure/views/view/hs_default_research_area/edit/vertical_linked_grid)
3. Confirm that the display has the `hb-stretch-vertical-linked-cards` class assigned (this is necessary to match the Religious Studies view that originally presented he bug)
4. Visit the [Research Areas Vertical Linked Grid](https://pr2032-he1v1osoneafm06jk6n48c795rwf7atq.tugboatqa.com/views/research-areas-horizontal-card-list/research-areas-vertical-linked-grid) page and confirm that the width of the items is consistent.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211734449259736