### PR TITLE
HSD8-1776: Remove domain_registration and block_content_permissions modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,6 @@
         "drupal/diff": "^1.0",
         "drupal/display_field_copy": "^2.1",
         "drupal/domain_301_redirect": "^2.0",
-        "drupal/domain_registration": "^1.6",
         "drupal/draggableviews": "^2.0",
         "drupal/ds": "^3.9",
         "drupal/eck": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
         "drupal/better_exposed_filters": "^7.0",
         "drupal/better_normalizers": "^2.0",
         "drupal/block_class": "^4.0",
-        "drupal/block_content_permissions": "^1.10",
         "drupal/cancel_button": "^1.1",
         "drupal/chosen": "^4.0",
         "drupal/ckeditor5_plugin_pack": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "295244a657987dc00ec7e4839164e97b",
+    "content-hash": "6dfc650fa48a6ab2ced1857473fe8035",
     "packages": [
         {
             "name": "accessible360/accessible-slick",
@@ -5100,59 +5100,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/domain_301_redirect",
                 "issues": "http://drupal.org/project/domain_301_redirect"
-            }
-        },
-        {
-            "name": "drupal/domain_registration",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/domain_registration.git",
-                "reference": "8.x-1.9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/domain_registration-8.x-1.9.zip",
-                "reference": "8.x-1.9",
-                "shasum": "dec20070ee4e04bc828a6cee26482923e21ab271"
-            },
-            "require": {
-                "drupal/core": "^9.1 || ^10 || ^11"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.9",
-                    "datestamp": "1749629650",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "arvinsingla",
-                    "homepage": "https://www.drupal.org/user/61137"
-                },
-                {
-                    "name": "pcambra",
-                    "homepage": "https://www.drupal.org/user/122101"
-                }
-            ],
-            "description": "Module Allows or restricts registration on your site based on the persons email address domain.",
-            "homepage": "http://drupal.org/project/domain_registration",
-            "keywords": [
-                "Drupal",
-                "domain_registration"
-            ],
-            "support": {
-                "source": "http://cgit.drupalcode.org/domain_registration",
-                "issues": "http://drupal.org/project/issues/domain_registration"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6dfc650fa48a6ab2ced1857473fe8035",
+    "content-hash": "53c3388695e44cc98b3b406ae933504a",
     "packages": [
         {
             "name": "accessible360/accessible-slick",
@@ -2787,55 +2787,6 @@
                 "source": "https://git.drupalcode.org/project/block_class",
                 "issues": "https://www.drupal.org/project/issues/block_class",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
-            }
-        },
-        {
-            "name": "drupal/block_content_permissions",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/block_content_permissions.git",
-                "reference": "8.x-1.11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/block_content_permissions-8.x-1.11.zip",
-                "reference": "8.x-1.11",
-                "shasum": "1ecb7330f69be30b6cf05f8682d1957c1aaf605e"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9 || ^10"
-            },
-            "suggest": {
-                "drupal/block_region_permissions": "Block Region Permissions adds permissions for administering 'blocks' based on each theme's regions."
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.11",
-                    "datestamp": "1674237116",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Joshua Roberson",
-                    "homepage": "https://www.drupal.org/u/joshuaroberson",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "Block Content Permissions adds permissions for administering 'block content types' and 'block content'.",
-            "homepage": "https://www.drupal.org/project/block_content_permissions",
-            "support": {
-                "source": "https://git.drupalcode.org/project/block_content_permissions",
-                "issues": "https://www.drupal.org/project/issues/block_content_permissions"
             }
         },
         {


### PR DESCRIPTION
# Summary
This PR removes the `drupal/domain_registration` and `drupal/block_content_permissions` modules from the codebase, as both were uninstalled in the previous release and are no longer needed.

## Backstory
Both modules were uninstalled in the 11.9.0 release. This PR follows up by removing their code and references from `composer.json` and `composer.lock`.

[HSD8-1776](https://stanfordits.atlassian.net/browse/HSD8-1776): Uninstall and remove the domain_registration module

## Urgency
Low

## Steps to Test
1. Review `composer.json` and `composer.lock` to confirm `drupal/domain_registration` and `drupal/block_content_permissions` are removed.
2. Confirm no other code references to these modules remain (besides update hooks).
3. Run `composer install` to ensure no dependency errors.


[HSD8-1776]: https://stanfordits.atlassian.net/browse/HSD8-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ