### PR TITLE
SHS-6439: Implement | Heading solution for accordions

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
@@ -138,3 +138,13 @@
     }
   }
 }
+
+// Special title spacing for collections with an accordion as first child.
+.paragraph--type--hs-collection
+  > h2:has(+ .field-hs-collection-items > .ptype-hs-accordion:first-child),
+.paragraph--type--hs-collection
+  > h2:has(
+    + .contextual + .field-hs-collection-items > .ptype-hs-accordion:first-child
+  ) {
+  margin-block-end: hb-calculate-rems(16px);
+}

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
@@ -149,6 +149,9 @@
   margin-block-end: hb-calculate-rems(16px);
 }
 
-.field-hs-collection-items > .ptype-hs-accordion details {
+.paragraph--type--hs-collection:has(> h2)
+  .field-hs-collection-items
+  > .ptype-hs-accordion
+  details {
   margin-top: 0;
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/objects/_layouts.row.scss
@@ -148,3 +148,7 @@
   ) {
   margin-block-end: hb-calculate-rems(16px);
 }
+
+.field-hs-collection-items > .ptype-hs-accordion details {
+  margin-top: 0;
+}


### PR DESCRIPTION
# Summary
- Reduce collection 

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6439)

## Need Review By (Date)
11/12

## Urgency
medium

## Steps to Test
1. Visit the following links:
    1. https://hs-colorful-levnfeq976pgxgyhgqgdjjqu6mk5k4ut.tugboatqa.com/accordions-collections-test
    2. https://hs-traditional-levnfeq976pgxgyhgqgdjjqu6mk5k4ut.tugboatqa.com/accordions-collections-test
2. For both cases, confirm that the bottom margin of the collections that have an accordion as the first element is smaller (16px) than the ones that have a different component as the first element.
3. In the same page, confirm that the space under the title is also smaller when the collection have multiple columns.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211779502931137