### PR TITLE
SHS-6449: Orphaned pages | Add filter/column for "Published"

### DIFF
--- a/config/default/views.view.content_orphaned.yml
+++ b/config/default/views.view.content_orphaned.yml
@@ -154,6 +154,73 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Unpublished
+            format_custom_true: Published
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         changed:
           id: changed
           table: node_field_data
@@ -338,17 +405,6 @@ display:
       sorts: {  }
       arguments: {  }
       filters:
-        status:
-          id: status
-          table: node_field_data
-          field: status
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
-          value: '1'
-          group: 1
-          expose:
-            operator: ''
         in_menu:
           id: in_menu
           table: node_field_data
@@ -525,6 +581,66 @@ display:
                   hs_person: '0'
                   hs_publications: '0'
                   hs_research: '0'
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              administrator: '0'
+              site_manager: '0'
+              contributor: '0'
+              author: '0'
+              preparer: '0'
+              reviewer: '0'
+              intranet_viewer: '0'
+              search_indexer: '0'
+              stanford_faculty: '0'
+              stanford_staff: '0'
+              stanford_student: '0'
+              anonymous: '0'
+          is_grouped: true
+          group_info:
+            label: 'Published status'
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
# Summary
- Add "Published" column and filter to the "Orphaned pages" view

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6449)

## Need Review By (Date)
11/12

## Urgency
medium

## Steps to Test
1. Log into a [Tugboat test site](https://hs-traditional-lxkhv28o7vykijwrk7nj4ya63dotsgm6.tugboatqa.com/user/login)
2. Visit the [Orphaned Pages view](https://hs-traditional-lxkhv28o7vykijwrk7nj4ya63dotsgm6.tugboatqa.com/admin/content/orphaned-pages). Confirm that:
    1. There's a "Status" column that shows if a node is published or unpublished
    2. There's  "Published Status" that allows to filter the results based on the status of the nodes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211734748621857
  - https://app.asana.com/0/0/1211855235087439