### PR TITLE
Update Tugboat to Install Node.js Major Version in .nvmrc 

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -26,9 +26,10 @@ services:
 
       # Commands that set up the basic preview infrastructure
       init:
-        # Add nodeJS to build theme assets after composer install
-        - curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-        - apt-get install -y nodejs
+        # Install nvm (Node Version Manager)
+        - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+        # Load nvm and install Node.js version from repo root .nvmrc
+        - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm install && nvm use
         # Symlink the tugboat directory to the docker image expected path.
         - rm -rf /var/www/localhost
         - ln -snf ${TUGBOAT_ROOT} /var/www/localhost

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -26,10 +26,10 @@ services:
 
       # Commands that set up the basic preview infrastructure
       init:
-        # Install nvm (Node Version Manager)
-        - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-        # Load nvm and install Node.js version from repo root .nvmrc
-        - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm install && nvm use
+        # Install Node.js system-wide based on .nvmrc major version for consistent builds
+        - export NODE_VERSION=$(cat .nvmrc | cut -d. -f1) && \
+          curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && \
+          apt-get install -y nodejs
         # Symlink the tugboat directory to the docker image expected path.
         - rm -rf /var/www/localhost
         - ln -snf ${TUGBOAT_ROOT} /var/www/localhost

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -27,9 +27,7 @@ services:
       # Commands that set up the basic preview infrastructure
       init:
         # Install Node.js system-wide based on .nvmrc major version for consistent builds
-        - export NODE_VERSION=$(cat .nvmrc | cut -d. -f1) && \
-          curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && \
-          apt-get install -y nodejs
+        - export NODE_VERSION=$(cat .nvmrc | cut -d. -f1) && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && apt-get install -y nodejs
         # Symlink the tugboat directory to the docker image expected path.
         - rm -rf /var/www/localhost
         - ln -snf ${TUGBOAT_ROOT} /var/www/localhost


### PR DESCRIPTION
# Summary
This PR updates the Tugboat configuration to install the Node.js version specified by the major version in the project's .nvmrc file, ensuring consistency between local development and Tugboat preview environments. The previous approach installed the latest Node.js version, which could cause incompatibilities with dependencies and local builds.

## Backstory
Recent build failures and inconsistencies were traced to a mismatch between the Node.js version used locally (managed by nvm and .nvmrc) and the version installed in Tugboat (which defaulted to the latest release). Node.js 25.x introduced breaking changes that affected the build, while local development was using 24.x. This change ensures Tugboat always uses the correct major version, reducing the risk of future incompatibilities.

In Tugboat CI, each command runs in a new shell session, so nvm and its environment do not persist between commands. For this reason, we read the .nvmrc file and install the matching major version system-wide, rather than using nvm directly, to ensure Node.js is available everywhere in the build process.

## Need Review By (Date)
ASAP (to prevent further Tugboat build failures and ensure environment consistency)

## Urgency
High

## Steps to Test
1. Push this branch to Tugboat and trigger a preview build.
2. Confirm that the Node.js version installed in the Tugboat container matches the major version in .nvmrc (e.g., 24.x if .nvmrc contains 24).
3. Run `npm ci` and `npm run theme-build` in the Tugboat preview; confirm there are no Node.js version errors or watcher issues.
4. Confirm that the preview site builds and loads as expected.

