### PR TITLE
Update Tugboat to Install Node.js Major Version in .nvmrc

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -26,9 +26,8 @@ services:
 
       # Commands that set up the basic preview infrastructure
       init:
-        # Add nodeJS to build theme assets after composer install
-        - curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-        - apt-get install -y nodejs
+        # Install Node.js system-wide based on .nvmrc major version for consistent builds
+        - export NODE_VERSION=$(cat .nvmrc | cut -d. -f1) && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && apt-get install -y nodejs
         # Symlink the tugboat directory to the docker image expected path.
         - rm -rf /var/www/localhost
         - ln -snf ${TUGBOAT_ROOT} /var/www/localhost


### PR DESCRIPTION
Cherry pick of #2042 to merge into the `develop` branch.