### PR TITLE
SHS-6411: For mailing address, allow all countries, and make all subfields optional

### DIFF
--- a/config/default/field.field.node.hs_person.field_hs_person_mail.yml
+++ b/config/default/field.field.node.hs_person.field_hs_person_mail.yml
@@ -17,23 +17,50 @@ label: 'Mailing Address'
 description: ''
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    langcode: null
+    country_code: US
+    administrative_area: ''
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    address_line3: null
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
-  available_countries:
-    US: US
+  available_countries: {  }
   langcode_override: ''
-  field_overrides: {  }
-  fields:
-    administrativeArea: administrativeArea
-    locality: locality
-    dependentLocality: dependentLocality
-    postalCode: postalCode
-    sortingCode: sortingCode
-    addressLine1: addressLine1
-    addressLine2: addressLine2
-    organization: '0'
-    givenName: '0'
-    additionalName: '0'
-    familyName: '0'
+  field_overrides:
+    givenName:
+      override: hidden
+    additionalName:
+      override: hidden
+    familyName:
+      override: hidden
+    organization:
+      override: hidden
+    addressLine1:
+      override: optional
+    addressLine2:
+      override: optional
+    addressLine3:
+      override: hidden
+    postalCode:
+      override: optional
+    sortingCode:
+      override: optional
+    dependentLocality:
+      override: optional
+    locality:
+      override: optional
+    administrativeArea:
+      override: optional
+  fields: {  }
 field_type: address


### PR DESCRIPTION
# Summary
* Allow addresses from any country, but default to the U.S.
* Make all address sub-fields optional.

This is only a change to how the address is input.  Display remains the same.  I couldn't find any code (other than config) that uses `field_hs_person_mail`. 

## Backstory
Jasper Ridge has many non-US based people.  There's also several profiles to be imported from D7 that have only partial addresses (perhaps just the city, state, country).  
[SHS-SHS-6411](https://app.clickup.com/t/36718269/SHS-SHS-6411)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. create some user profiles.  
2. Try non-US addresses, or partial addresses.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211210952045894