### PR TITLE
SHS-6460: Characters not displaying in Color Band when limited width

### DIFF
--- a/config/default/core.entity_view_display.paragraph.hs_clr_bnd.preview.yml
+++ b/config/default/core.entity_view_display.paragraph.hs_clr_bnd.preview.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.paragraph.hs_clr_bnd.field_hs_clr_bnd_wdth
     - paragraphs.paragraphs_type.hs_clr_bnd
   module:
-    - blazy
     - ds
     - empty_fields
     - field_formatter_class
@@ -69,12 +68,10 @@ content:
     weight: 2
     region: color_band_link
   field_hs_clr_bnd_ttl:
-    type: blazy_title
+    type: string
     label: hidden
     settings:
-      delimiter: '|'
-      tag: small
-      break: false
+      link_to_entity: false
     third_party_settings: {  }
     weight: 0
     region: color_band_title


### PR DESCRIPTION
# Summary
- Fix incorrect formatter of colorband title field

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6460)

## Need Review By (Date)
11/12

## Urgency
medium

## Steps to Test
1. Log into a [tugboat test site](https://hs-colorful-y7nap5fm6cqmlvxj0u7vju7tcoviwizy.tugboatqa.com/user/login)
2. Visit the [Colorband test page](https://hs-colorful-y7nap5fm6cqmlvxj0u7vju7tcoviwizy.tugboatqa.com/components/color-bands)
3. Edit the node. Confirm that the first colorband have vertical bar (`|`) characters and that the "Width" field is configured to "Limited width" (if not change it)
4. Save the node. Confirm that the colorband text looks as expected
5. Test other combinations and confirm that the text looks as expected in all cases


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211773773606280