### PR TITLE
HSD8-1799: Grant hs_basic_block edit permission via update hook

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -945,3 +945,42 @@ function su_humsci_profile_update_9749(): string {
   }
   return t('domain_registration module was already uninstalled.');
 }
+
+/**
+ * Grant hs_basic_block edit permission to contributor and site_manager roles.
+ */
+function su_humsci_profile_update_9750(): string {
+  $permission = 'edit any hs_basic_block block content';
+  $roles = ['contributor', 'site_manager'];
+  $granted = [];
+
+  /** @var \Drupal\user\RoleStorageInterface $role_storage */
+  $role_storage = \Drupal::entityTypeManager()->getStorage('user_role');
+
+  foreach ($roles as $rid) {
+    /** @var \Drupal\user\Entity\Role|null $role */
+    $role = $role_storage->load($rid);
+    if (!$role) {
+      // Skip silently; roles can vary by site.
+      continue;
+    }
+    if (!$role->hasPermission($permission)) {
+      $role->grantPermission($permission);
+      $role->save();
+      $granted[] = $rid;
+    }
+  }
+
+  if ($granted) {
+    \Drupal::logger('su_humsci_profile')->notice('Granted @perm to roles: @roles.', [
+      '@perm' => $permission,
+      '@roles' => implode(', ', $granted),
+    ]);
+    return t('Granted @perm to: @roles.', [
+      '@perm' => $permission,
+      '@roles' => implode(', ', $granted),
+    ]);
+  }
+
+  return t('No changes: roles already had @perm or were missing.', ['@perm' => $permission]);
+}


### PR DESCRIPTION
# Summary
Add update hook to grant the core custom block permission `edit any hs_basic_block block content` to the `contributor` and `site_manager` roles. This restores editing capability lost after removing the `block_content_permissions` module and migrating to Drupal core custom block permissions (which were previously ignored due to `config_ignore` on role config).

## Backstory
During the Drupal 10.5 upgrade and the 11.19.0 release, the `block_content_permissions` module was uninstalled and its granular permissions were intended to be replaced by Drupal core's custom block permissions. However, role configuration (`user.role.*permissions`) is excluded from config imports via `config_ignore`, so the permissions that should have continued allowing editing of the `hs_basic_block` were never applied. Prior follow-up update hooks removed old permissions and dependencies, but did not re-add per-type edit permissions under the core model. This PR introduces a targeted update hook to directly grant the missing permission in the database, bypassing config ignore.

References:
- Removal & dependency cleanup: PRs #2017 and #2019
- Uninstall and config changes in Drupal 10.5 upgrade PR: #2012 
- Historical permissions cleanup: Update hooks `su_humsci_profile_update_9747`–`9749`

## Urgency
high – Important to restore expected editorial access

## Steps to Test
1. Checkout branch
2. Run database updates:
   ```bash
   drush updb -y
   ```
3. Verify permission presence:
   ```bash
   drush role:perm:list contributor | grep 'edit any hs_basic_block block content' || echo 'Missing on contributor'
   drush role:perm:list site_manager | grep 'edit any hs_basic_block block content' || echo 'Missing on site_manager'
   ```
4. (Optional) As a user with one of those roles, confirm you can edit an existing `hs_basic_block` custom block.

