### PR TITLE
HSD8-1789: Grant hs_basic_block edit/create permissions via update hook

### DIFF
--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -91,6 +91,7 @@ permissions:
   - 'assign site_manager role'
   - 'create embeddable media'
   - 'create file media'
+  - 'create hs_basic_block block content'
   - 'create hs_basic_page content'
   - 'create hs_course content'
   - 'create hs_event content'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -950,37 +950,59 @@ function su_humsci_profile_update_9749(): string {
  * Grant hs_basic_block edit permission to contributor and site_manager roles.
  */
 function su_humsci_profile_update_9750(): string {
-  $permission = 'edit any hs_basic_block block content';
-  $roles = ['contributor', 'site_manager'];
-  $granted = [];
+  // Define a role => permissions map so each role is loaded once and only
+  // receives the specific permissions intended for that role.
+  $role_permissions = [
+    'contributor' => [
+      'edit any hs_basic_block block content',
+    ],
+    'site_manager' => [
+      'edit any hs_basic_block block content',
+      'create hs_basic_block block content',
+    ],
+  ];
 
   /** @var \Drupal\user\RoleStorageInterface $role_storage */
   $role_storage = \Drupal::entityTypeManager()->getStorage('user_role');
 
-  foreach ($roles as $rid) {
+  $changed = [];
+
+  foreach ($role_permissions as $rid => $perms) {
     /** @var \Drupal\user\Entity\Role|null $role */
     $role = $role_storage->load($rid);
     if (!$role) {
-      // Skip silently; roles can vary by site.
       continue;
     }
-    if (!$role->hasPermission($permission)) {
-      $role->grantPermission($permission);
+
+    $granted_for_role = [];
+    foreach ($perms as $perm) {
+      if (!$role->hasPermission($perm)) {
+        $role->grantPermission($perm);
+        $granted_for_role[] = $perm;
+      }
+    }
+
+    if ($granted_for_role) {
       $role->save();
-      $granted[] = $rid;
+      $changed[$rid] = $granted_for_role;
     }
   }
 
-  if ($granted) {
-    \Drupal::logger('su_humsci_profile')->notice('Granted @perm to roles: @roles.', [
-      '@perm' => $permission,
-      '@roles' => implode(', ', $granted),
+  if ($changed) {
+    // Log a compact summary for auditing without spamming individual lines.
+    $summaries = [];
+    foreach ($changed as $rid => $perms) {
+      $summaries[] = $rid . ': ' . implode(', ', $perms);
+    }
+    \Drupal::logger('su_humsci_profile')->notice('Granted hs_basic_block permissions => @summary', [
+      '@summary' => implode(' | ', $summaries),
     ]);
-    return t('Granted @perm to: @roles.', [
-      '@perm' => $permission,
-      '@roles' => implode(', ', $granted),
+    return t('Granted hs_basic_block permissions for: @summary', [
+      '@summary' => implode(' | ', $summaries),
     ]);
   }
 
-  return t('No changes: roles already had @perm or were missing.', ['@perm' => $permission]);
+  return t('No changes: roles already had the required hs_basic_block permissions or were missing.');
 }
+
+

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1004,5 +1004,3 @@ function su_humsci_profile_update_9750(): string {
 
   return t('No changes: roles already had the required hs_basic_block permissions or were missing.');
 }
-
-

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -945,3 +945,42 @@ function su_humsci_profile_update_9749(): string {
   }
   return t('domain_registration module was already uninstalled.');
 }
+
+/**
+ * Grant hs_basic_block edit permission to contributor and site_manager roles.
+ */
+function su_humsci_profile_update_9750(): string {
+  $permission = 'edit any hs_basic_block block content';
+  $roles = ['contributor', 'site_manager'];
+  $granted = [];
+
+  /** @var \Drupal\user\RoleStorageInterface $role_storage */
+  $role_storage = \Drupal::entityTypeManager()->getStorage('user_role');
+
+  foreach ($roles as $rid) {
+    /** @var \Drupal\user\Entity\Role|null $role */
+    $role = $role_storage->load($rid);
+    if (!$role) {
+      // Skip silently; roles can vary by site.
+      continue;
+    }
+    if (!$role->hasPermission($permission)) {
+      $role->grantPermission($permission);
+      $role->save();
+      $granted[] = $rid;
+    }
+  }
+
+  if ($granted) {
+    \Drupal::logger('su_humsci_profile')->notice('Granted @perm to roles: @roles.', [
+      '@perm' => $permission,
+      '@roles' => implode(', ', $granted),
+    ]);
+    return t('Granted @perm to: @roles.', [
+      '@perm' => $permission,
+      '@roles' => implode(', ', $granted),
+    ]);
+  }
+
+  return t('No changes: roles already had @perm or were missing.', ['@perm' => $permission]);
+}


### PR DESCRIPTION
# Summary
**This is an amendment to the update hook in the previous PR.** An additional permission was needed for the Site Manager role. See #2049 

Add update hook to grant core custom block permissions for `hs_basic_block`:
- `edit any hs_basic_block block content` to `contributor` and `site_manager`
- `create hs_basic_block block content` to `site_manager`

This restores expected editing/creation capabilities lost after removing the `block_content_permissions` module and migrating to Drupal core custom block permissions (which were previously ignored due to `config_ignore` on role config).

## Backstory
During the Drupal 10.5 upgrade and the 11.19.0 release, the `block_content_permissions` module was uninstalled and its granular permissions were intended to be replaced by Drupal core's custom block permissions. However, role configuration (`user.role.*permissions`) is excluded from config imports via `config_ignore`, so the permissions that should have continued allowing editing of the `hs_basic_block` were never applied. Prior follow-up update hooks removed old permissions and dependencies, but did not re-add per-type edit permissions under the core model. This PR introduces a targeted update hook to directly grant the missing permission in the database, bypassing config ignore.

References:
- Removal & dependency cleanup: PRs #2017 and #2019
- Uninstall and config changes in Drupal 10.5 upgrade PR: #2012 
- Historical permissions cleanup: Update hooks `su_humsci_profile_update_9747`–`9749`

## Need Review By (Date)
11/14 (flexible—earlier is fine)

## Urgency
medium – Important to restore expected editorial access but not blocking deployments.

## Steps to Test
1. Checkout branch `HSD8-1799--add-custom-block-permissions`.
2. Run database updates:
   ```bash
   drush updb -y
   ```
3. Verify permission presence:
   ```bash
   drush role:perm:list contributor | grep 'edit any hs_basic_block block content' || echo 'Missing on contributor'
   drush role:perm:list site_manager | grep 'edit any hs_basic_block block content' || echo 'Missing on site_manager'
   drush role:perm:list site_manager | grep 'create hs_basic_block block content' || echo 'Missing create on site_manager'
   ```
4. (Optional) As a user with one of those roles, confirm you can edit (and for Site Manager, create) an `hs_basic_block` custom block.

