### PR TITLE
HSD8-1797: Adjust Course Tag Table labels and Add Translated Tag Column

### DIFF
--- a/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/CourseTagListBuilder.php
+++ b/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/CourseTagListBuilder.php
@@ -4,6 +4,7 @@ namespace Drupal\hs_courses_importer;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\hs_courses_importer\Entity\CourseTagInterface;
 
 /**
  * Provides a listing of Course Tag Translation entities.
@@ -14,8 +15,9 @@ class CourseTagListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $header['label'] = $this->t('Course Tag Translation');
+    $header['label'] = $this->t('Explore Courses Tag');
     $header['id'] = $this->t('Machine name');
+    $header['tag'] = $this->t('Translated Tag');
     return $header + parent::buildHeader();
   }
 
@@ -25,7 +27,10 @@ class CourseTagListBuilder extends ConfigEntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $entity->label();
     $row['id'] = $entity->id();
-    // You probably want a few more properties here...
+    $row['tag'] = '';
+    if ($entity instanceof CourseTagInterface) {
+      $row['tag'] = $entity->tag();
+    }
     return $row + parent::buildRow($entity);
   }
 


### PR DESCRIPTION
# Summary
This PR updates the Course Tag Translation entities table in the admin UI. It changes the label to "Explore Courses Tag", adds a new column for "Translated Tag", and keeps the "Machine name" column. The new column displays the translated tag value for each entity.

## Backstory
[HSD8-1797](https://stanfordits.atlassian.net/browse/HSD8-1797): Title Column on Course Importer Tagging translation
The request was to improve the clarity and usefulness of the Course Tag Translation admin page. The previous table showed only the course tag and machine name. The machine name column remains for reference, but the label is now clearer, and the translated tag is visible for easier review and management. This change supports better content administration and translation workflows.

## Need Review By (Date)
As soon as possible.

## Urgency
Medium

## Steps to Test
1. Go to the Course Tag Translation entities admin page `/admin/config/importers/course-tag`
2. Confirm the table label is now "Explore Courses Tag".
3. Confirm the "Machine name" column is still present.
4. Confirm a new column "Translated Tag" appears and displays the translated value for each tag.


[HSD8-1797]: https://stanfordits.atlassian.net/browse/HSD8-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ