### PR TITLE
HSD8-1797: Remove machine_name column from Course Tag Form

### DIFF
--- a/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/CourseTagListBuilder.php
+++ b/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/CourseTagListBuilder.php
@@ -16,7 +16,6 @@ class CourseTagListBuilder extends ConfigEntityListBuilder {
    */
   public function buildHeader() {
     $header['label'] = $this->t('Explore Courses Tag');
-    $header['id'] = $this->t('Machine name');
     $header['tag'] = $this->t('Translated Tag');
     return $header + parent::buildHeader();
   }
@@ -26,7 +25,6 @@ class CourseTagListBuilder extends ConfigEntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $entity->label();
-    $row['id'] = $entity->id();
     $row['tag'] = '';
     if ($entity instanceof CourseTagInterface) {
       $row['tag'] = $entity->tag();

--- a/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/tests/Kernel/CourseTagListBuilderTest.php
+++ b/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/tests/Kernel/CourseTagListBuilderTest.php
@@ -40,7 +40,7 @@ class CourseTagListBuilderTest extends EntityKernelTestBase {
   public function testListBuilder() {
     $header = $this->listBuilder->buildHeader();
     $this->assertArrayHasKey('label', $header);
-    $this->assertArrayHasKey('id', $header);
+    $this->assertArrayHasKey('tag', $header);
     $entity = $this->entityTypeManager->createInstance('hs_course_tag', [
       'id' => $this->randomMachineName(),
       'label' => $this->randomString(),
@@ -50,7 +50,7 @@ class CourseTagListBuilderTest extends EntityKernelTestBase {
 
     $row = $this->listBuilder->buildRow($entity);
     $this->assertArrayHasKey('label', $row);
-    $this->assertArrayHasKey('id', $row);
+    $this->assertArrayHasKey('tag', $row);
   }
 
 }

--- a/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/tests/Kernel/Form/CourseTagFormTest.php
+++ b/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/tests/Kernel/Form/CourseTagFormTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\hs_courses_importer\Kernel\Form;
 
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\hs_courses_importer\Entity\CourseTag;
 use Drupal\Tests\hs_courses_importer\Kernel\HsCoursesImporterTestBase;
 
 /**


### PR DESCRIPTION
# Summary
Follow up to #2054 
- Removes the `machine_name` column from the Course Tag Form table data.

## Backstory
[HSD8-1797](https://stanfordits.atlassian.net/browse/HSD8-1797): Title Column on Course Importer Tagging translation


[HSD8-1797]: https://stanfordits.atlassian.net/browse/HSD8-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ