### PR TITLE
Add release tag conditional to recent Node step additions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
       - name: Set up Node.js from .nvmrc
+        if: ${{ steps.tag.outputs.tag }}
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -61,6 +62,7 @@ jobs:
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       - name: Install theme dependencies
+        if: ${{ steps.tag.outputs.tag }}
         run: npm ci --prefix docroot/themes/humsci/humsci_basic
       - name: Deploy Tag
         if: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
# Summary
This PR updates the release workflow to add a conditional to recently added steps, ensuring they only run when a release tag is present. This prevents these steps from failing when they should be skipped.

## Backstory
Previously, the Node.js setup step ran unconditionally and failed if the .nvmrc file was not present. The workflow logic was improved to match other steps that depend on the release tag output.