### PR TITLE
SHS-6448: Restructure course importers block on the dashboard to use importer URL's

### DIFF
--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\hs_dashboard\Plugin\ImporterInfo;
 
+use Drupal\Core\GeneratedLink;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
-use Drupal\hs_dashboard\Plugin\ImporterInfoInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 10,
  * )
  */
-class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {
+class CourseImporterInfo extends ImporterInfoBase {
 
   use StringTranslationTrait;
 
@@ -45,6 +45,8 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    *   The KeyValue factory.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The DateFormatter.
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   The migration manager interface.
    */
   public function __construct(
     array $configuration,
@@ -53,8 +55,9 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
     EntityTypeManagerInterface $entity_type_manager,
     KeyValueFactoryInterface $key_value_factory,
     DateFormatterInterface $date_formatter,
+    MigrationPluginManagerInterface $migration_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter, $migration_manager);
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -69,6 +72,7 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
       $container->get('entity_type.manager'),
       $container->get('keyvalue'),
       $container->get('date.formatter'),
+      $container->get('plugin.manager.migration'),
     );
   }
 
@@ -77,8 +81,7 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    */
   public function getTableHeaders(): array {
     return [
-      $this->t('Course tag'),
-      $this->t('Catalog'),
+      $this->t('Courses'),
       $this->t('Last Imported'),
     ];
   }
@@ -87,20 +90,15 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    * {@inheritDoc}
    */
   public function getTableRows(): array {
-    $storage = $this->entityTypeManager->getStorage('hs_course_tag');
-    $query = $storage->getQuery();
-    $query->sort('label');
-    $query->accessCheck(TRUE);
-    /** @var \Drupal\hs_courses_importer\Entity\CourseTagInterface[] $tags */
-    $tags = $storage->loadMultiple($query->execute());
+    $course_importer = $this->migrationManager->getDefinition('hs_courses');
+    $urls = $course_importer['source']['urls'] ?? [];
 
     $table_rows = [];
 
-    foreach ($tags as $tag) {
+    foreach ($urls as $url) {
       $table_rows[] = [
         'data' => [
-          ['data' => $tag->label()],
-          ['data' => $this->buildCourseLink($this->t('Explore courses'), 'catalog', $tag->label())],
+          ['data' => $this->buildCourseLink($url)],
           ['data' => $this->lastImportTime('hs_courses')],
         ],
       ];
@@ -118,20 +116,18 @@ class CourseImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
   /**
    * Create a course link to display in the dashboard.
    *
-   * @param string $text
-   *   The link text to display.
-   * @param string $format
-   *   The display format as 'catalog' or 'xml-20200810'.
-   * @param string $course_tag
-   *   The course tag.
+   * @param string $url
+   *   The https://explorecourses.stanford.edu XML feed that we're importing.
    *
-   * @return string
+   * @return \Drupal\Core\GeneratedLink
    *   A renderable course link.
    */
-  protected function buildCourseLink($text, $format, $course_tag) {
-    $tag = htmlspecialchars($course_tag, ENT_QUOTES, 'UTF-8');
-    $uri = "https://explorecourses.stanford.edu/search?view={$format}&filter-coursestatus-Active=on&page=0&catalog=&academicYear=&q={$tag}&collapse=";
-    return Link::fromTextAndUrl($text, Url::fromUri($uri))->toString();
+  protected function buildCourseLink(string $url): GeneratedLink {
+    $query = parse_url($url, PHP_URL_QUERY);
+    parse_str($query, $params);
+    $query = $params['q'] ?? 'unknown';
+    $human_url = str_replace('view=xml-', 'view=', $url);
+    return Link::fromTextAndUrl($query, Url::fromUri($human_url))->toString();
   }
 
 }

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/CourseImporterInfo.php
@@ -91,6 +91,9 @@ class CourseImporterInfo extends ImporterInfoBase {
    */
   public function getTableRows(): array {
     $course_importer = $this->migrationManager->getDefinition('hs_courses');
+
+    // This list of URLs is controlled at:
+    // @url /admin/config/importers/courses-importer
     $urls = $course_importer['source']['urls'] ?? [];
 
     $table_rows = [];
@@ -125,9 +128,14 @@ class CourseImporterInfo extends ImporterInfoBase {
   protected function buildCourseLink(string $url): GeneratedLink {
     $query = parse_url($url, PHP_URL_QUERY);
     parse_str($query, $params);
-    $query = $params['q'] ?? 'unknown';
+    $text = $params['q'] ?? 'unknown';
+    // Oddly, there are some non-printable characters in many of these URLs.
+    $text = preg_replace('/[^[:print:]]/', '', $text);
+    // There is a query param that controls the output format.  Something like:
+    // `view=xml-20200810`
+    // We just need to remove the 'xml-' portion.
     $human_url = str_replace('view=xml-', 'view=', $url);
-    return Link::fromTextAndUrl($query, Url::fromUri($human_url))->toString();
+    return Link::fromTextAndUrl($text, Url::fromUri($human_url))->toString();
   }
 
 }

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
@@ -14,6 +14,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
 use Drupal\hs_dashboard\Plugin\ImporterInfoInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -84,6 +85,8 @@ class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
    *   The widget manager.
    * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager.
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   The migration manager interface.
    */
   public function __construct(
     array $configuration,
@@ -94,8 +97,9 @@ class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
     DateFormatterInterface $date_formatter,
     WidgetPluginManager $widget_manager,
     EntityFieldManagerInterface $entity_field_manager,
+    MigrationPluginManagerInterface $migration_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter, $migration_manager);
     $this->entityTypeManager = $entity_type_manager;
     $this->widgetManager = $widget_manager;
     $this->entityFieldManager = $entity_field_manager;
@@ -116,6 +120,7 @@ class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
       $container->get('date.formatter'),
       $container->get('plugin.manager.field.widget'),
       $container->get('entity_field.manager'),
+      $container->get('plugin.manager.migration'),
     );
   }
 

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
@@ -4,7 +4,6 @@ namespace Drupal\hs_dashboard\Plugin\ImporterInfo;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides information about other importers.
@@ -21,26 +20,11 @@ class OtherImporterInfo extends ImporterInfoBase {
   /**
    * A list of migration IDs already represented in other ImporterInfo blocks.
    */
-  const SKIP_IMPORTERS = [
+  private const SKIP_IMPORTERS = [
     'hs_courses',
     'hs_localist_scheduled',
     'hs_capx',
   ];
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('keyvalue'),
-      $container->get('date.formatter'),
-      $container->get('plugin.manager.migration')
-    );
-  }
 
   /**
    * {@inheritDoc}

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
@@ -34,13 +34,6 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
   ];
 
   /**
-   * Migration plugin manager service.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
-   */
-  protected $migrationManager;
-
-  /**
    * Constructs a new OtherImporterInfo object.
    *
    * @param array $configuration
@@ -67,8 +60,7 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
     DateFormatterInterface $date_formatter,
     MigrationPluginManagerInterface $migration_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter);
-    $this->migrationManager = $migration_manager;
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter, $migration_manager);
   }
 
   /**

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/OtherImporterInfo.php
@@ -2,14 +2,8 @@
 
 namespace Drupal\hs_dashboard\Plugin\ImporterInfo;
 
-use Drupal\Core\Datetime\DateFormatterInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
-use Drupal\hs_dashboard\Plugin\ImporterInfoInterface;
-use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -22,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   weight = 100,
  * )
  */
-class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterface, ContainerFactoryPluginInterface {
+class OtherImporterInfo extends ImporterInfoBase {
 
   /**
    * A list of migration IDs already represented in other ImporterInfo blocks.
@@ -32,36 +26,6 @@ class OtherImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
     'hs_localist_scheduled',
     'hs_capx',
   ];
-
-  /**
-   * Constructs a new OtherImporterInfo object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value_factory
-   *   The KeyValue factory interface.
-   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
-   *   The DateFormatter.
-   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
-   *   The migration manager interface.
-   */
-  public function __construct(
-    array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    EntityTypeManagerInterface $entity_type_manager,
-    KeyValueFactoryInterface $key_value_factory,
-    DateFormatterInterface $date_formatter,
-    MigrationPluginManagerInterface $migration_manager,
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter, $migration_manager);
-  }
 
   /**
    * {@inheritdoc}

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/PeopleImporterInfo.php
@@ -10,6 +10,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\hs_dashboard\Plugin\ImporterInfoBase;
 use Drupal\hs_dashboard\Plugin\ImporterInfoInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Drupal\stanford_migrate\EventSubscriber\EventsSubscriber;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -49,6 +50,8 @@ class PeopleImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
    *   The DateFormatter.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory interface.
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   The migration manager interface.
    */
   public function __construct(
     array $configuration,
@@ -58,8 +61,9 @@ class PeopleImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
     KeyValueFactoryInterface $key_value_factory,
     DateFormatterInterface $date_formatter,
     ConfigFactoryInterface $config_factory,
+    MigrationPluginManagerInterface $migration_manager,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $key_value_factory, $date_formatter, $migration_manager);
     $this->capxConfig = $config_factory->getEditable('hs_capx.settings');
   }
 
@@ -75,6 +79,7 @@ class PeopleImporterInfo extends ImporterInfoBase implements ImporterInfoInterfa
       $container->get('keyvalue'),
       $container->get('date.formatter'),
       $container->get('config.factory'),
+      $container->get('plugin.manager.migration'),
     );
   }
 

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoBase.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoBase.php
@@ -10,6 +10,7 @@ use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -41,6 +42,13 @@ abstract class ImporterInfoBase extends PluginBase implements ImporterInfoInterf
   protected DateFormatterInterface $dateFormatter;
 
   /**
+   * Migration plugin manager service.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected MigrationPluginManagerInterface $migrationManager;
+
+  /**
    * Constructs a new ViewsBasicManager object.
    *
    * @param array $configuration
@@ -55,6 +63,8 @@ abstract class ImporterInfoBase extends PluginBase implements ImporterInfoInterf
    *   The KeyValue factory.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The DateFormatter.
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_manager
+   *   The migration manager interface.
    */
   public function __construct(
     array $configuration,
@@ -63,11 +73,13 @@ abstract class ImporterInfoBase extends PluginBase implements ImporterInfoInterf
     EntityTypeManagerInterface $entity_type_manager,
     KeyValueFactoryInterface $key_value_factory,
     DateFormatterInterface $date_formatter,
+    MigrationPluginManagerInterface $migration_manager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->lastImportedStore = $key_value_factory->get('migrate_last_imported');
     $this->dateFormatter = $date_formatter;
+    $this->migrationManager = $migration_manager;
   }
 
   /**
@@ -81,6 +93,7 @@ abstract class ImporterInfoBase extends PluginBase implements ImporterInfoInterf
       $container->get('entity_type.manager'),
       $container->get('keyvalue'),
       $container->get('date.formatter'),
+      $container->get('plugin.manager.migration'),
     );
   }
 

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfoManager.php
@@ -132,7 +132,24 @@ class ImporterInfoManager extends DefaultPluginManager {
 
     }
 
-    $this->cache->set('hs_dashboard_importer_info_tables', $tables, time() + 900);
+    // There's some caching issues.  If the underlying data in these tables
+    // changes, you need to do a full cache clear in order to see the change.
+    // The code below _should_ cover it, but it's being cached somewhere higher
+    // in the stack. We'll create a ticket in ClickUp to investigate further.
+    //
+    // Collect cache tags for all migrations.
+    $cache_tags = [
+      'config:migrate_plus.migration_list',
+      'config:migrate.migration_list',
+    ];
+    $migration_storage = \Drupal::entityTypeManager()->getStorage('migration');
+    foreach ($migration_storage->loadMultiple() as $migration) {
+      $cache_tags[] = 'config:' . $migration->getConfigDependencyName();
+    }
+
+    $this->cache->set('hs_dashboard_importer_info_tables', $tables, time() + 900, $cache_tags);
+    $tables['#cache']['tags'] = $cache_tags;
+
     return $tables;
 
   }


### PR DESCRIPTION
# Summary
The dashboard block for course importers was not showing a list of courses being imported. Rather it was a list of which tags from the external system were being processed (but an imported item might not have any of those tags).  

This PR changes the list to show the source URLs (in a human-readable format).

To do this, this PHP class needed the `migrationManager` service which was already in use by one of the sibling classes.  So the parent class was refactored to include this service.   That's why all the classes in this family have diffs. 

## Backstory
  [SHS-6448](https://app.clickup.com/t/36718269/SHS-6448)

## Need Review By (Date)
normal review time to get into the next release

## Urgency
medium

## Steps to Test
1. On any site visit `/admin/dashboard`
2. compare to the list of URLs at `/admin/config/importers/courses-importer`
3. make a change to that list
4. clear the site-wide cache (known bug.  there's a ClickUp ticket to fix).
5. review the dashboard and see your changes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211513502735944