### PR TITLE
SHS-6467: Bug | Overlapping text image slide indicator on Photo Album Element

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
@@ -83,6 +83,10 @@
 
     // counter for the last slide
     li:last-of-type button {
+      &::before {
+        content: counter(listCounter);
+      }
+
       @include grid-media-min('sm') {
         left: hb-calculate-rems(48px);
       }
@@ -93,6 +97,10 @@
         left: hb-calculate-rems(12px);
         min-width: hb-calculate-rems(32px);
         text-align: right;
+      }
+
+      &::before {
+        content: counter(listCounter);
       }
 
       &::after {
@@ -118,6 +126,21 @@
 
     li:not(:last-of-type):not(.slick-active) button {
       display: none;
+    }
+
+    // Screen reader only content.
+    .slick-sr-only {
+      border: 0 !important;
+      clip: rect(1px, 1px, 1px, 1px) !important;
+      -webkit-clip-path: inset(50%) !important;
+      clip-path: inset(50%) !important;
+      height: 1px !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      padding: 0 !important;
+      position: absolute !important;
+      width: 1px !important;
+      white-space: nowrap !important;
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
@@ -131,8 +131,7 @@
     // Screen reader only content.
     .slick-sr-only {
       border: 0 !important;
-      clip: rect(1px, 1px, 1px, 1px) !important;
-      -webkit-clip-path: inset(50%) !important;
+      clip-path: rect(1px, 1px, 1px, 1px) !important;
       clip-path: inset(50%) !important;
       height: 1px !important;
       margin: -1px !important;


### PR DESCRIPTION
# Summary
- Update Slideshow Photo Album styles to match updated version of slick library.

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6467)

## Need Review By (Date)
11/26

## Urgency
medium

## Steps to Test
1. In both Traditional and Colorful Tugboat sites, visit the Photo Album page ([Colorful](https://hs-colorful-grjof64zh7ribwychjqm09jglhcn75gk.tugboatqa.com/components/photo-album), [Traditional](https://hs-traditional-grjof64zh7ribwychjqm09jglhcn75gk.tugboatqa.com/components/photo-album))
2. Confirm that the slideshow photo album pager at the bottom shows only numbers (e.g. _4 / 12_)
3. Compare with the Live site ([Colorful](https://hs-colorful.stanford.edu/components/photo-album), [Traditional](https://hs-traditional.stanford.edu/components/photo-album)) and confirm that the reported bug is not present anymore.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211880054483576