### PR TITLE
SHS-6481: Fix the Short Line length text style so that the font can be centered

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -43,9 +43,6 @@ services:
       update:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
-        # Ensure this packet size persists even if MySQL restarts.
-        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
         # Sync to hs_colorful, hs_colorful database & files and create user.
         - blt drupal:sync:files --site=hs_colorful
         - drush @hs_colorful.local user:create tugboat --password=pushcar || true
@@ -67,9 +64,6 @@ services:
       build:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
-        # Ensure this packet size persists even if MySQL restarts.
-        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
 
         - drush @hs_colorful.local cr
         - drush @hs_colorful.local eval '\Drupal::moduleHandler()->loadInclude("user", "install");user_update_10000();'
@@ -126,8 +120,12 @@ services:
     # Use the latest available 5.x version of MySQL
     image: tugboatqa/mysql:5
     commands:
+      init:
+        # Increase the allowed packet size to 512MB.
+        - mysql -e "SET GLOBAL max_allowed_packet=536870912;"
+        # Ensure this packet size persists even if MySQL restarts.
+        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
       update:
-        - mysql -e 'SET GLOBAL max_allowed_packet=536870912;'
         # Delete and recreate the database for each site.
         - mysql -e "DROP DATABASE IF EXISTS hs_colorful; CREATE DATABASE hs_colorful;"
         - mysql -e "DROP DATABASE IF EXISTS hs_traditional; CREATE DATABASE hs_traditional;"

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/ckeditor/_imports.scss
@@ -113,7 +113,7 @@
 
   .hs-font-splash {
     @include grid-media-min('md') {
-      margin: 48px 0 16px;
+      margin-block: 48px 16px;
     }
 
     @include hb-themes(('colorful', 'airy')) {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -251,6 +251,12 @@ $credits: (hs-credits, credits);
   max-width: hb-calculate-rems(700px);
 }
 
+// When short line length is applied and the text is also centered, we need to
+// center the container itself within the text area.
+.hs-short-line-length.text-align-center {
+  margin-inline: auto;
+}
+
 .hs-table--borderless {
   thead {
     th {
@@ -367,7 +373,11 @@ $credits: (hs-credits, credits);
     box-sizing: border-box;
     color: var(--palette--white) !important;
     border: none;
-    background: linear-gradient(to top, var(--palette--black), transparent) !important;
+    background: linear-gradient(
+      to top,
+      var(--palette--black),
+      transparent
+    ) !important;
     z-index: 1;
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_wysiwyg-text-area.scss
@@ -257,6 +257,12 @@ $credits: (hs-credits, credits);
   margin-inline: auto;
 }
 
+// When short line length is applied and the text is also right-aligned, we need to
+// push the container itself to the right.
+.hs-short-line-length.text-align-right {
+  margin-inline: auto 0;
+}
+
 .hs-table--borderless {
   thead {
     th {


### PR DESCRIPTION
# Summary
- Fix centering and right-alignment of elements with "Short Line Length" wysiwyg style applied
- **Update the tugboat configuration to fix a [recurrent memory issue in mysql](https://docs.tugboatqa.com/troubleshooting/fix-problem-x/index.html#mysql-server-has-gone-away)**

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6481)

## Need Review By (Date)
12/17

## Urgency
medium

## Steps to Test
1. Log into the [Colorful tugboat site](https://hs-colorful-5c5erdjvelrtvoldv684blabo06vx4d2.tugboatqa.com/user)
2. Create a flexible page. Add some text into the Text Area, apply the "Short Line Length" style and then center the text
3. Save the page and confirm that text is fully centered in the content area.
4. Repeat the test in the [Traditional tugboat site](https://hs-traditional-5c5erdjvelrtvoldv684blabo06vx4d2.tugboatqa.com/user)
5. Repeat the previous tests, but aligning the text to the right instead of centering.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211986462145127