### PR TITLE
SHS-6486: Adjust ddev drush to use the correct URLs

### DIFF
--- a/.ddev/commands/web/drush
+++ b/.ddev/commands/web/drush
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+drush="/var/www/html/vendor/bin/drush"
+
+# If the first argument starts with "@", then we can turn it into a domain
+# and use it as the --uri parameter.
+if [[ $1 == @* ]]; then
+  alias="${1:1}"
+  IFS='.' read -r site _ <<< "$alias"
+  domain="$site.ddev.site"
+  domain="${domain//_/-}"
+  $drush --uri="$domain" ${@:1}
+else
+  $drush ${@:1}
+fi

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 11.21.1
+version: 11.21.0
 core_version_requirement: ^10.3 || ^11
 dependencies:
   - 'drupal:block'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 11.21.0
+version: 11.21.1
 core_version_requirement: ^10.3 || ^11
 dependencies:
   - 'drupal:block'


### PR DESCRIPTION
# Summary
Get Drush commands in DDev to use the correct URL for a site.

## Backstory
Before this change, if I run a command like 
ddev drush @hs_traditional.local user:login
It will give me a URL with a broken domain name like
http://hs-traditional/user/reset/1/1764881899/c9B6a4rUnVhrZmxsPMQntJ_NmLNB7uSnZZROuaKCvro/login
I then need to look up what the correct domain should be

## Need Review By (Date)
New Year's

## Urgency
Low

## Steps to Test
```
ddev drush @hs_traditional.local user:login
```