### PR TITLE
SHS-6220: Hide revision-related fields on media

### DIFF
--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -142,6 +142,14 @@ function hs_admin_form_node_form_alter(&$form, FormStateInterface $form_state, $
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function hs_admin_form_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Hide revision related fields on media forms.
+  $form['revision_information']['#access'] = FALSE;
+}
+
+/**
  * After build callback for hs_admin_form_node_form_alter().
  *
  * @param array $form


### PR DESCRIPTION
# Summary
- Hide revision related fields on media forms

## Backstory
- [ClickUp ticket](https://app.clickup.com/t/36718269/SHS-6220)

## Need Review By (Date)
01/14

## Urgency
medium

## Steps to Test
1. On any site, add and edit media items of different types, in the following ways:
    1. Visiting the `/admin/content/media` admin page
    2. Directly into media fields on nodes and components
    3. In the WYSIWYG editor
2. For all cases, confirm that the "Revision Information" section is not present on the forms anymore.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212311329548264