### PR TITLE
SHS-6498: Upgrade Metatag Simple Widget module to D11 compatible version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9155,30 +9155,30 @@
         },
         {
             "name": "drupal/metatag_simple_widget",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/metatag_simple_widget.git",
-                "reference": "1.0.0"
+                "reference": "1.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/metatag_simple_widget-1.0.0.zip",
-                "reference": "1.0.0",
-                "shasum": "8f989da9787ce71765da3d1b3730302fb835fde1"
+                "url": "https://ftp.drupal.org/files/projects/metatag_simple_widget-1.1.0.zip",
+                "reference": "1.1.0",
+                "shasum": "940dd6dd28e7ec9dbe6dcd2afa11ae023e811d24"
             },
             "require": {
-                "drupal/core": "^9 || ^10",
+                "drupal/core": "^10 || ^11",
                 "drupal/metatag": "^1.0 || ^2.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.0",
-                    "datestamp": "1751551289",
+                    "version": "1.1.0",
+                    "datestamp": "1766185604",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -9191,6 +9191,10 @@
                     "name": "Jim Vomero (nJim)",
                     "homepage": "https://www.drupal.org/u/nJim",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "njim",
+                    "homepage": "https://www.drupal.org/user/1251088"
                 }
             ],
             "description": "Provides a simple widget for metatag fields",


### PR DESCRIPTION
# Summary
Get this module ready for D11. 

## Backstory
  [SHS-6498](https://app.clickup.com/t/36718269/SHS-6498)

## Need Review By (Date)
before we want to do D11

## Urgency
low

## Steps to Test
1. Create/edit a page
2. change some metatags

Note how the module works the same as it did before (the only thing that's changed is that it now advertises that it's compatible with D11). 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212469990522435