### PR TITLE
SHS-6485: Fix Contrast issue on pagination links in Media Library

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -276,3 +276,8 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 .gin--edit-form[data-once*="ginAccent"] .paragraphs-add-dialog .paragraphs-ee-buttons .paragraphs-button--add-more:focus {
   background-color: var(--color-white);
 }
+
+/* Fix incorrect color in dialog pager links hover */
+.ui-dialog .pager__link:hover {
+  color: var(--gin-color-button-text);
+}


### PR DESCRIPTION
# Summary
- Fix incorrect color in pager hover links when inside a dialog in admin theme

## Backstory
- [ClickUp ticket](https://app.clickup.com/t/36718269/SHS-6485)

## Need Review By (Date)
01/14

## Urgency
medium

## Steps to Test
1. Log into a [tugboat test site](https://hs-colorful-n7xrjwhfils8uvwsgjw0pl3dej5sleg5.tugboatqa.com/user)
3. Edit or create any piece of content that has a media field. For example:
    * "News Image" field in News node
    * "Media" field in the Spotlight component in a Flexible page
    * Media button inside any wysiwyg field
4. Try adding a new media item, to open the "Add or select media" dialog
5. Scroll down to the media library until you see the pager (will only be visible if there are more than 25 media items in the library). Hover your mouse on the pager items and confirm that the text color is white and can be read correctly

<img width="774" height="327" alt="Screenshot 2025-12-24 at 5 09 59 PM" src="https://github.com/user-attachments/assets/1f57f7c6-5d0f-449d-8d0d-510a0b52a4e9" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212274658737047