### PR TITLE
Update Tugboat config for Acquia Cloud Next changes

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -36,40 +36,45 @@ services:
         # Install/update packages managed by composer, including drush
         - rm -rf vendor
         - composer install --no-ansi
-        - blt blt:telemetry:disable --no-interaction
 
         # Init the settings files.
         - blt blt:init:settings
       update:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
-        # Ensure this packet size persists even if MySQL restarts.
-        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
         # Sync to hs_colorful, hs_colorful database & files and create user.
-        - blt drupal:sync:files --site=hs_colorful
+        - drush sql-sync @hs_colorful.prod @hs_colorful.local --create-db --structure-tables-key=lightweight --no-interaction --ansi
+        - drush @hs_colorful.local sql-sanitize --no-interaction --ansi
+        - drush rsync @hs_colorful.prod:%files @hs_colorful.local:%files --ansi --no-interaction
         - drush @hs_colorful.local user:create tugboat --password=pushcar || true
         - drush @hs_colorful.local user:role:add administrator tugboat || true
 
-        - blt drupal:sync:files --site=hs_traditional
+        # Sync to hs_traditional, hs_traditional database & files and create user.
+        - drush sql-sync @hs_traditional.prod @hs_traditional.local --create-db --structure-tables-key=lightweight --no-interaction --ansi
+        - drush @hs_traditional.local sql-sanitize --no-interaction --ansi
+        - drush rsync @hs_traditional.prod:%files @hs_traditional.local:%files --ansi --no-interaction
         - drush @hs_traditional.local user:create tugboat --password=pushcar || true
         - drush @hs_traditional.local user:role:add administrator tugboat || true
 
-        # Sync to english, history, and west database & files, does not create a user.
-        - blt drupal:sync:files --site=english
+        # Sync to english, english database & files, does not create a user.
+        - drush sql-sync @english.prod @english.local --create-db --structure-tables-key=lightweight --no-interaction --ansi
+        - drush @english.local sql-sanitize --no-interaction --ansi
+        - drush rsync @english.prod:%files @english.local:%files --ansi --no-interaction
 
-        - blt drupal:sync:files --site=history
+        # Sync to history, history database & files, does not create a user.
+        - drush sql-sync @history.prod @history.local --create-db --structure-tables-key=lightweight --no-interaction --ansi
+        - drush @history.local sql-sanitize --no-interaction --ansi
+        - drush rsync @history.prod:%files @history.local:%files --ansi --no-interaction
 
-        - blt drupal:sync:files --site=west
-
+        # Sync to west, west database & files, does not create a user.
+        - drush sql-sync @west.prod @west.local --create-db --structure-tables-key=lightweight --no-interaction --ansi
+        - drush @west.local sql-sanitize --no-interaction --ansi
+        - drush rsync @west.prod:%files @west.local:%files --ansi --no-interaction
 
         - chown -R www-data:www-data ${TUGBOAT_ROOT}/docroot/sites/*/files
       build:
         - rm -rf vendor
         - composer install --no-ansi
-        - mysql -h mysql -P 3306 -u tugboat -ptugboat -e 'SET GLOBAL max_allowed_packet=536870912;'
-        # Ensure this packet size persists even if MySQL restarts.
-        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
 
         - drush @hs_colorful.local cr
         - drush @hs_colorful.local eval '\Drupal::moduleHandler()->loadInclude("user", "install");user_update_10000();'
@@ -91,6 +96,7 @@ services:
         - drush @west.local eval '\Drupal::moduleHandler()->loadInclude("user", "install");user_update_10000();'
         - blt drupal:update --site=west
 
+        # Build frontend assets.
         - npm run theme-build
 
     # Collection of urls to compare visual results.
@@ -123,34 +129,14 @@ services:
   # hostname to access the service by from the php service.
   mysql:
 
-    # Use the latest available 5.x version of MySQL
-    image: tugboatqa/mysql:5
+    # Use the latest available 8.x version of MySQL
+    image: tugboatqa/mysql:8
     commands:
+      init:
+        # Increase the allowed packet size to 512MB.
+        - mysql -e "SET GLOBAL max_allowed_packet=536870912;"
+        # Ensure this packet size persists even if MySQL restarts.
+        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
       update:
-        - mysql -e 'SET GLOBAL max_allowed_packet=536870912;'
-        # Delete and recreate the database for each site.
-        - mysql -e "DROP DATABASE IF EXISTS hs_colorful; CREATE DATABASE hs_colorful;"
-        - mysql -e "DROP DATABASE IF EXISTS hs_traditional; CREATE DATABASE hs_traditional;"
-        - mysql -e "DROP DATABASE IF EXISTS english; CREATE DATABASE english;"
-        - mysql -e "DROP DATABASE IF EXISTS history; CREATE DATABASE history;"
-        - mysql -e "DROP DATABASE IF EXISTS west; CREATE DATABASE west;"
-
         # Give the tugboat user access to the new databases.
         - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'tugboat'; FLUSH PRIVILEGES;"
-
-        # Download each database dump.
-        - scp humscigryphon.prod@web-42199.prod.hosting.acquia.com:/mnt/gfs/humscigryphon.prod/backups/prod-hs_colorful-humscigrydb423120-`date -d '8 hours ago' +%Y-%m-%d`.sql.gz /tmp/hs_colorful.sql.gz
-        - scp humscigryphon.prod@web-42199.prod.hosting.acquia.com:/mnt/gfs/humscigryphon.prod/backups/prod-hs_traditional-humscigrydb423132-`date -d '8 hours ago' +%Y-%m-%d`.sql.gz /tmp/hs_traditional.sql.gz
-        - scp humscigryphon.prod@web-42199.prod.hosting.acquia.com:/mnt/gfs/humscigryphon.prod/backups/prod-english-humscigrydb423084-`date -d '8 hours ago' +%Y-%m-%d`.sql.gz /tmp/english.sql.gz
-        - scp humscigryphon.prod@web-42199.prod.hosting.acquia.com:/mnt/gfs/humscigryphon.prod/backups/prod-history-humscigrydb423116-`date -d '8 hours ago' +%Y-%m-%d`.sql.gz /tmp/history.sql.gz
-        - scp humscigryphon.prod@web-42199.prod.hosting.acquia.com:/mnt/gfs/humscigryphon.prod/backups/prod-west-humscigrydb423301-`date -d '8 hours ago' +%Y-%m-%d`.sql.gz /tmp/west.sql.gz
-
-        # Import each database dump into the associated table.
-        - zcat /tmp/hs_colorful.sql.gz | mysql hs_colorful
-        - zcat /tmp/hs_traditional.sql.gz | mysql hs_traditional
-        - zcat /tmp/english.sql.gz | mysql english
-        - zcat /tmp/history.sql.gz | mysql history
-        - zcat /tmp/west.sql.gz | mysql west
-
-        # Clean up after ourselves to keep the Preview size small.
-        - rm /tmp/*.sql.gz


### PR DESCRIPTION
# Summary
Switches database and file sync in Tugboat from SCP/manual import to Drush-based sync from production, and upgrades MySQL to 8.x for compatibility with Acquia Cloud Next.

## Backstory
Acquia Cloud Next removed SCP access to database backups and now requires Acquia API for sync. MySQL 8.x is required due to new collation in production dumps.

## Need Review By (Date)
ASAP

## Urgency
High

## Steps to Test
1. Create a Tugboat preview.
2. Confirm database and files sync from production using Drush.
3. Verify preview works and MySQL errors are resolved.
