### PR TITLE
SHS-6490: Add JS class to <html> earlier to prevent FOUC issue

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - hs_layouts:hs_layouts
   - fontawesome:fontawesome
 libraries:
+  - humsci_basic/init
   - humsci_basic/main-content-fallback
   - humsci_basic/editoria11y
 

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
@@ -1,3 +1,8 @@
+init:
+  header: true
+  js:
+    dist/js/init.js: { preprocess: false }
+
 accordion:
   js:
     dist/js/accordion.js: {}

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/init/init.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/init/init.js
@@ -1,0 +1,1 @@
+document.documentElement.classList.add('js');

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/init/init.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/init/init.js
@@ -1,1 +1,2 @@
+// Add a `js` class to the html element before page renders, to prevent FOUC.
 document.documentElement.classList.add('js');

--- a/docroot/themes/humsci/humsci_basic/webpack.common.js
+++ b/docroot/themes/humsci/humsci_basic/webpack.common.js
@@ -12,6 +12,7 @@ const jsSrcDir = path.resolve(__dirname, 'src/js/');
 
 // Shared JS files. Used in both traditional and colorful themes.
 const shared = {
+  init: 'shared/init/init.js',
   accordion: 'shared/accordion/accordion-toggle-all.js',
   addtocal: 'shared/addtocal/addtocal.js',
   'page-scroll-animations': 'shared/animation/page-scroll.js',
@@ -38,7 +39,9 @@ const shared = {
 const colorful = {};
 const traditional = {};
 
-const sassFiles = globSync('src/scss/**/*.scss', { exclude: ['src/scss/partials/**/*.scss'] });
+const sassFiles = globSync('src/scss/**/*.scss', {
+  exclude: ['src/scss/partials/**/*.scss'],
+});
 
 export default {
   entry() {


### PR DESCRIPTION
# Summary
- Add a script in the page header that adds a `js` class to the `html` element. Drupal also does this out-of-the-box, but the script is located at the end of the file, which causes a delay that displays an incorrectly styled version of the main navigation. 

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6490)

## Need Review By (Date)
01/21

## Urgency
medium

## Steps to Test
1. Visit different pages on the test sites, both as anonymous and logged user
2. Confirm that in all cases, the main menu looks as expected and that the issue described in [the ticket](https://app.clickup.com/t/36718269/SHS-6490) is not happening anymore

**Note:** The original issue is hard to reproduce, because it was produced by a delay in the execution of a script and that depends on a lot of different conditions: network speed, processing power, size of the page, etc. It didn't happen only for logged in users when navigating to a second level link as described in the ticket, there were other instances where the issue could happen. However, with this fix, the issue shouldn't happen anymore under any conditions. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212365599241238
  - https://app.asana.com/0/0/1212843343328685