### PR TITLE
SHS-6501: Fix Inaccurate editorial preview on JRBP Collection

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -185,4 +185,23 @@
   & div:only-child:not(.hb-card__date-tile, .hb-pill) {
     width: 100%;
   }
+
+  // Vertical Linked cards.
+  .hb-vertical-button-card .hs-button {
+    @include hb-traditional {
+      background-color: transparent;
+      border-color: var(--palette--secondary);
+      color: var(--palette--secondary);
+      border-width: 0;
+      border-top-width: 2px;
+      margin-top: auto;
+      margin-left: hb-calculate-rems(-24px);
+      margin-right: hb-calculate-rems(-24px);
+
+      &:hover, &:focus {
+        color: var(--palette--white);
+        background-color: var(--palette--secondary);
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Summary
- Fix incorrect styles for the vertical button card component preview

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6501)

## Need Review By (Date)
02/21

## Urgency
medium

## Steps to Test
1. Log into both [Colorful](https://hs-colorful-si85jbya3natbsffpvmgzzg92yqh35kj.tugboatqa.com/user) and [Traditional](https://hs-traditional-si85jbya3natbsffpvmgzzg92yqh35kj.tugboatqa.com/user) test sites
2. Visit the _Vertical Button Cards with Uniform Height_ test page ([Colorful](https://hs-colorful-si85jbya3natbsffpvmgzzg92yqh35kj.tugboatqa.com/components/collections/collections-postcards/vertical-button-cards-0/vertical-button-cards-0), [Traditional](https://hs-traditional-si85jbya3natbsffpvmgzzg92yqh35kj.tugboatqa.com/components/collections-0/collections-postcards/vertical-button-cards/vertical-button-cards-uniform))
3. Edit the page and confirm that the previews match the final component as close as possible


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212881868621151