### PR TITLE
HSD8-1825: Add and enable Tagify module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -188,6 +188,7 @@
         "drupal/stage_file_proxy": "^3.0",
         "drupal/style_selector": "^2.0@beta",
         "drupal/swiper_formatter": "^2.0",
+        "drupal/tagify": "^1.2",
         "drupal/term_condition": "^2.0",
         "drupal/token_or": "^2.2",
         "drupal/transliterate_filenames": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "091c686675b578b112f4582fa4d1c618",
+    "content-hash": "fd6dca351c92097559fcc225b53ac51d",
     "packages": [
         {
             "name": "accessible360/accessible-slick",
@@ -11869,6 +11869,59 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/swiper_formatter",
                 "issues": "https://www.drupal.org/project/issues/swiper_formatter"
+            }
+        },
+        {
+            "name": "drupal/tagify",
+            "version": "1.2.47",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/tagify.git",
+                "reference": "1.2.47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/tagify-1.2.47.zip",
+                "reference": "1.2.47",
+                "shasum": "75f1608e3d64b6dfc30711ff1bb7a8ba42584425"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/better_exposed_filters": "^7.0",
+                "drupal/facets": "^2.0",
+                "drupal/iconify_icons": "*",
+                "drupal/search_api": "^1.31",
+                "drupal/ui_icons": "*",
+                "drupal/ui_icons_field": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.2.47",
+                    "datestamp": "1768580848",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "David Galeano",
+                    "homepage": "https://www.drupal.org/u/gxleano"
+                }
+            ],
+            "description": "Integration with the Tagify JavaScript library.",
+            "homepage": "https://drupal.org/project/tagify",
+            "support": {
+                "source": "https://git.drupalcode.org/project/tagify",
+                "issues": "https://www.drupal.org/project/issues/tagify"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -233,6 +233,7 @@ module:
   swiper_formatter: 0
   syslog: 0
   system: 0
+  tagify: 0
   taxonomy: 0
   telephone: 0
   term_condition: 0

--- a/config/default/tagify.settings.yml
+++ b/config/default/tagify.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: lOU4meC54_CRItb9BjAhDrlmYIcf4KDHp63E0phoXio
+set_default_widget: false

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1089,3 +1089,10 @@ function su_humsci_profile_update_9751() {
     $logger->notice('Image style cleanup: No styles found to delete.');
   }
 }
+
+/**
+ * Install the tagify module.
+ */
+function su_humsci_profile_update_9752() {
+  \Drupal::service('module_installer')->install(['tagify']);
+}


### PR DESCRIPTION
# Summary
Adds the Drupal Tagify module (via composer) and its default configuration, enables it in core.extension, and provides an update hook for installation. This allows integration with the Tagify JavaScript library for enhanced tagging UI.

## Backstory
Tagify is being added to support improved tagging functionality in content forms. This PR includes all necessary codebase and configuration changes to install and enable the module, as well as a database update hook for existing sites. No custom configuration is set at this time; the default settings are used.

## Need Review By (Date)
_asap_

## Urgency
low

## Steps to Test
1. Run `composer install` to ensure the Tagify module is downloaded.
2. Run `drush updb` to apply the update hook and install the module.
3. Confirm that the Tagify module appears as enabled on the Extend page.
4. Check that the `tagify.settings` configuration is present in config.
5. Optionally, test a form that uses Tagify to verify the widget loads.
