### PR TITLE
HSD8-1823: Grant Author Role Access to Minimal HTML Text Format

### DIFF
--- a/config/default/user.role.author.yml
+++ b/config/default/user.role.author.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.minimal_html
     - media.type.embeddable
     - media.type.file
     - media.type.google_form
@@ -15,6 +16,7 @@ dependencies:
   module:
     - dropzonejs
     - file
+    - filter
     - hs_entities
     - media
     - node
@@ -46,4 +48,5 @@ permissions:
   - 'edit own hs_person content'
   - 'edit own hs_publications content'
   - 'update media'
+  - 'use text format minimal_html'
   - 'view own unpublished media'


### PR DESCRIPTION
# Summary
This PR updates the Author role to grant permission to use the "Minimal HTML" text format. This resolves an issue where Authors were unable to edit the caption/credit field on image media due to lack of access to the required text format.

## Backstory
[HSD8-1823](https://stanfordits.atlassian.net/browse/HSD8-1823): The Author role doesn't have the ability to edit or add Caption/Credit on media

Authors were unable to edit the caption/credit field on image media entities. Investigation revealed that the field uses the "Minimal HTML" text format, but the Author role did not have permission to use it. This change adds the necessary permission so Authors can edit all expected fields. 

## Need Review By (Date)
ASAP

## Urgency
Medium

## Steps to Test
1. Log in as a user with only the Author role.
2. Edit an image media entity.
3. Confirm that the caption/credit field is now editable and no longer disabled.
4. Confirm that the Author role can use the Minimal HTML text format in other fields where it is available.


[HSD8-1823]: https://stanfordits.atlassian.net/browse/HSD8-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212931370067519