### PR TITLE
SHS-6520: Tighten Curriculum Map editorial labels

### DIFF
--- a/config/default/field.field.paragraph.hs_cmap_qtr.field_hs_cmap_qtr_crs.yml
+++ b/config/default/field.field.paragraph.hs_cmap_qtr.field_hs_cmap_qtr_crs.yml
@@ -12,7 +12,7 @@ id: paragraph.hs_cmap_qtr.field_hs_cmap_qtr_crs
 field_name: field_hs_cmap_qtr_crs
 entity_type: paragraph
 bundle: hs_cmap_qtr
-label: Courses
+label: 'Courses or Requirements'
 description: ''
 required: true
 translatable: false

--- a/config/default/paragraphs.paragraphs_type.hs_cmap_qtr_crs.yml
+++ b/config/default/paragraphs.paragraphs_type.hs_cmap_qtr_crs.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: hs_cmap_qtr_crs
-label: 'Required Courses'
+label: 'Course or Requirement'
 icon_uuid: null
 icon_default: null
 description: ''

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.module
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.module
@@ -186,3 +186,35 @@ function _hs_cmap_insert_into_array_after_element(array &$array, int $after_posi
     array_slice($array, $after_position + 1, NULL, TRUE)
   );
 }
+
+/**
+ * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
+ */
+function hs_cmap_field_widget_complete_paragraphs_form_alter(array &$field_widget_form, FormStateInterface $form_state, array $context) {
+  $elements_to_change = [
+    'field_hs_cmap_years',
+    'field_hs_cmap_year_qtr',
+    'field_hs_cmap_qtr_crs',
+  ];
+
+  // We need the field name to alter the correct element.
+  if (
+      empty($field_widget_form['widget']['#field_name']) ||
+      !in_array($field_widget_form['widget']['#field_name'], $elements_to_change)
+    ) {
+    return;
+  }
+
+  foreach (Element::children($field_widget_form['widget']) as $key) {
+    if (!is_int($key)) {
+      continue;
+    }
+    // Remove these elements from from display.
+    if (isset($field_widget_form['widget'][$key]['top']['type'])) {
+      unset($field_widget_form['widget'][$key]['top']['type']);
+    }
+    if (isset($field_widget_form['widget'][$key]['top']['icons'])) {
+      unset($field_widget_form['widget'][$key]['top']['icons']);
+    }
+  }
+}

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.module
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.module
@@ -209,7 +209,7 @@ function hs_cmap_field_widget_complete_paragraphs_form_alter(array &$field_widge
     if (!is_int($key)) {
       continue;
     }
-    // Remove these elements from from display.
+    // Remove these elements from form display.
     if (isset($field_widget_form['widget'][$key]['top']['type'])) {
       unset($field_widget_form['widget'][$key]['top']['type']);
     }

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -290,14 +290,8 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
   color: var(--gin-color-button-text);
 }
 
-/* Remove redundancy in the element labels on the Curriculum Map component */
-.paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .paragraph-top .paragraph-type,
-.paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .paragraph-top .paragraph-info {
-  display: none;
-}
-
 
 .paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .form-wrapper .paragraphs-content:first-child .form-item > .form-item__label {
-    margin-top: -2rem;
+    margin-top: -1.5rem;
     margin-bottom: 0.5rem;
 }

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -289,3 +289,15 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 .ui-dialog .pager__link:hover {
   color: var(--gin-color-button-text);
 }
+
+/* Remove redundancy in the element labels on the Curriculum Map component */
+.paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .paragraph-top .paragraph-type,
+.paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .paragraph-top .paragraph-info {
+  display: none;
+}
+
+
+.paragraphs-tabs-wrapper .paragraph-type--hs-cmap-year .form-wrapper .paragraphs-content:first-child .form-item > .form-item__label {
+    margin-top: -2rem;
+    margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
# Summary
- Remove redundancy in the element labels on the Curriculum Map component
- Update labels name

## Backstory
 [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6520)

## Need Review By (Date)
02/03

## Urgency
medium

## Steps to Test
1. Log in to [Colorful](https://hs-colorful-ilthji7igvu4hs6mjoau6xwz2qcugeex.tugboatqa.com/user/login) and [Traditional](https://hs-traditional-ilthji7igvu4hs6mjoau6xwz2qcugeex.tugboatqa.com/user/login)
2. Create a Flexible Page and add a `Curriculum Map` component
3. Confirm the labels look like this now:

<img width="848" height="683" alt="Screenshot 2026-01-23 at 2 20 10 PM" src="https://github.com/user-attachments/assets/e31f7089-4ff6-45e1-96af-5d785e05fbd4" />

<img width="461" height="216" alt="Screenshot 2026-01-23 at 2 20 20 PM" src="https://github.com/user-attachments/assets/9209fe75-418d-4b8a-81a5-88a8fdfe7463" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212826317903691
  - https://app.asana.com/0/0/1213140388723580