### PR TITLE
SHS-6518: Curriculum Maps | Allow Duplicate Year, Quarter and Course

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hs_cmap.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_cmap.default.yml
@@ -103,7 +103,7 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         convert: '0'
-        duplicate: '0'
+        duplicate: duplicate
       expose_drag_drop: 0
     third_party_settings:
       field_formatter_class:

--- a/config/default/core.entity_form_display.paragraph.hs_cmap_qtr.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_cmap_qtr.default.yml
@@ -34,7 +34,7 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         convert: '0'
-        duplicate: '0'
+        duplicate: duplicate
       expose_drag_drop: '1'
     third_party_settings:
       field_formatter_class:

--- a/config/default/core.entity_form_display.paragraph.hs_cmap_year.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hs_cmap_year.default.yml
@@ -34,7 +34,7 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         convert: '0'
-        duplicate: '0'
+        duplicate: duplicate
       expose_drag_drop: 0
     third_party_settings:
       field_formatter_class:


### PR DESCRIPTION
# Summary
Allow users to duplicate Year, Quarter and Course

## Backstory
[ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6518)

## Need Review By (Date)
02/03

## Urgency
medium

## Steps to Test
1. Log in to [Colorful](https://hs-colorful-fxrtsjbgy9ptcsryofppmtbq75ql8fls.tugboatqa.com/user/login) and [Traditional](https://hs-traditional-fxrtsjbgy9ptcsryofppmtbq75ql8fls.tugboatqa.com/user/login)
2. Create a Flexible Page and add a `Curriculum Map` component
3. Confirm that now you can duplicate a `Year`, a `Quarter` and/or a `Course`. Like this:

<img width="450" height="208" alt="Screenshot 2026-01-23 at 4 36 11 PM" src="https://github.com/user-attachments/assets/6bb0edc3-ef3c-4941-8b3c-673a29f6de06" />

4. Save it and confirm everything looks and works as expected


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213094691784993