### PR TITLE
SHS-6521: Fix link text showing instead of arrow in Horizontal Card preview 

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -113,6 +113,11 @@
 
   .field-hs-postcard-link a {
     color: transparent;
+
+    &:hover,
+    &:focus {
+      color: transparent;
+    }
   }
 
   .hb-timeline-item {


### PR DESCRIPTION
# Summary
Fix the link text showing instead of an arrow in the preview of a Horizontal Card

## Backstory
[ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6521)

## Need Review By (Date)
02/03

## Urgency
medium

## Steps to Test
1. Log into the [Colorful test site](https://hs-colorful-gemaqofkyl18vm0kie5bea2fw4ye8z5j.tugboatqa.com/user)
2. Visit the [Horizontal Cards test page](https://hs-colorful-gemaqofkyl18vm0kie5bea2fw4ye8z5j.tugboatqa.com/components/collections/collections-postcards/horizontal-cards)
3. Edit the page and scroll down to a collection that includes cards with links. Try to hover the mouse over the arrow button
7. Confirm the text is not being displayed when hovering on it 
