### PR TITLE
SHS-6501: Fix Inaccurate editorial preview on JRBP Collection

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/preview/_preview.scss
@@ -174,17 +174,6 @@
     --link-base-current-color: var(--palette--white);
     --link-base-hover-current-color: var(--palette--white);
   }
-}
-
-.hb-raised-cards--uniform-height
-  .field-hs-collection-items
-  .ptype-hs-postcard
-  .paragraph-admin-preview {
-  display: flex;
-
-  & div:only-child:not(.hb-card__date-tile, .hb-pill) {
-    width: 100%;
-  }
 
   // Vertical Linked cards.
   .hb-vertical-button-card .hs-button {
@@ -203,5 +192,16 @@
         background-color: var(--palette--secondary);
       }
     }
+  }
+}
+
+.hb-raised-cards--uniform-height
+  .field-hs-collection-items
+  .ptype-hs-postcard
+  .paragraph-admin-preview {
+  display: flex;
+
+  & div:only-child:not(.hb-card__date-tile, .hb-pill) {
+    width: 100%;
   }
 }


### PR DESCRIPTION
# Summary
- Fix Vertical Button Card preview styles.
- Follow up to #2100, the original fix didn't cover all cases.

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6501)
- [Comment](https://app.clickup.com/t/36718269/SHS-6501?comment=90130215343669)

## Need Review By (Date)
02/04

## Urgency
medium

## Steps to Test
1. Log into both [Colorful](https://hs-colorful-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/user) and [Traditional](https://hs-traditional-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/user) test sites
2. Visit the _Vertical Button Cards with Uniform Height_ ([Colorful](https://hs-colorful-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/components/collections/collections-postcards/vertical-button-cards-0/vertical-button-cards-0), [Traditional](https://hs-traditional-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/components/collections-0/collections-postcards/vertical-button-cards/vertical-button-cards-uniform)) and the _Vertical Button Card_ ([Colorful](https://hs-colorful-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/components/collections/collections-postcards/vertical-button-cards-0), [Traditional](https://hs-traditional-fadhv9ymgnqq9hlui1xcj2puzwfmpjiq.tugboatqa.com/components/collections-0/collections-postcards/vertical-button-cards)) test pages
3. Edit the page and confirm that the previews match the final component as close as possible
4. Edit some of the individual collections and confirm that the previews for the individual cards match the final component as close as possible


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213137870516404
  - https://app.asana.com/0/0/1213142308437361