### PR TITLE
HSD8-1834: Remove mysql56 module to resolve site install issues on Acquia

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,6 @@
         "drupal/metatag_simple_widget": "^1.0",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_source_csv": "^3.4",
-        "drupal/mysql56": "^1.1",
         "drupal/nobots": "^1.0",
         "drupal/node_in_menu": "^1.0",
         "drupal/node_revision_delete": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c68571f0ee1b1afb47e9552ef5c57dee",
+    "content-hash": "88225c5ccd7f587e8d0df6bafdfdc637",
     "packages": [
         {
             "name": "accessible360/accessible-slick",
@@ -9416,66 +9416,6 @@
                 "source": "https://git.drupalcode.org/project/migrate_tools",
                 "issues": "https://www.drupal.org/project/issues/migrate_tools",
                 "slack": "#migrate"
-            }
-        },
-        {
-            "name": "drupal/mysql56",
-            "version": "dev-1.x",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/mysql56.git",
-                "reference": "f1c1275e0385fd5f080c559e7ca33a5ea36106f4"
-            },
-            "require": {
-                "drupal/core": "^9.4 || ^10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev",
-                    "dev-8.x-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.7+1-dev",
-                    "datestamp": "1727468950",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Drupal\\Driver\\Database\\mysql\\": "",
-                    "Drupal\\mysql56\\": "src"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
-                },
-                {
-                    "name": "balsama",
-                    "homepage": "https://www.drupal.org/user/223087"
-                },
-                {
-                    "name": "effulgentsia",
-                    "homepage": "https://www.drupal.org/user/78040"
-                },
-                {
-                    "name": "traviscarden",
-                    "homepage": "https://www.drupal.org/user/236758"
-                }
-            ],
-            "description": "MySQL 5.6 Driver.",
-            "homepage": "https://www.drupal.org/project/mysql56",
-            "support": {
-                "source": "https://git.drupalcode.org/project/mysql56"
             }
         },
         {


### PR DESCRIPTION
# Summary
Removes the `drupal/mysql56` module from the codebase to resolve site installation failures on Acquia.

## Backstory
[HSD8-1834](https://stanfordits.atlassian.net/browse/HSD8-1834): Site installs failing on Acquia

Recent site provisions on Acquia Cloud Next began failing with errors indicating that `settings.php` was not writable and that MySQL was not supported. Drupal only attempts to write to the `settings.php` file when it cannot successfully connect to the database on install. After extensive investigation it was discovered that the `drupal/mysql56` module was causing the issue, despite the module not being enabled or used. Removing this module from the codebase allowed site installation to proceed successfully.

## Need Review By (Date)
As soon as possible (ASAP) – site provisioning is currently blocked.

## Urgency
High

## Steps to Test
Issue is not reproducible on local, no steps to test.


[HSD8-1834]: https://stanfordits.atlassian.net/browse/HSD8-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ