### PR TITLE
SHS-6532: Unable to select text in Spotlight

### DIFF
--- a/config/default/swiper_formatter.swiper_formatter.hs_slideshow.yml
+++ b/config/default/swiper_formatter.swiper_formatter.hs_slideshow.yml
@@ -25,7 +25,7 @@ swiper_options:
   spaceBetween: 0
   slidesPerGroup: 1
   loopedSlides: 1
-  noSwipingSelector: '.no-swipe, button, input'
+  noSwipingSelector: '.hb-spotlight__text, .hb-gradient-hero__text, .hb-hero-overlay__text, .field-media-image-caption'
   mousewheel: false
   grabCursor: false
   cssMode: false

--- a/config/default/swiper_formatter.swiper_formatter.hs_slideshow_counter.yml
+++ b/config/default/swiper_formatter.swiper_formatter.hs_slideshow_counter.yml
@@ -25,7 +25,7 @@ swiper_options:
   spaceBetween: 0
   slidesPerGroup: 1
   loopedSlides: 1
-  noSwipingSelector: '.no-swipe, button, input'
+  noSwipingSelector: '.hb-spotlight__text, .hb-gradient-hero__text, .hb-hero-overlay__text, .field-media-image-caption'
   mousewheel: false
   grabCursor: false
   cssMode: false

--- a/config/default/swiper_formatter.swiper_formatter.slideshow_no_dots.yml
+++ b/config/default/swiper_formatter.swiper_formatter.slideshow_no_dots.yml
@@ -25,7 +25,7 @@ swiper_options:
   spaceBetween: 0
   slidesPerGroup: 1
   loopedSlides: 1
-  noSwipingSelector: '.no-swipe, button, input'
+  noSwipingSelector: '.hb-spotlight__text, .hb-gradient-hero__text, .hb-hero-overlay__text, .field-media-image-caption'
   mousewheel: false
   grabCursor: false
   cssMode: false

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_photo-album-slideshow.scss
@@ -63,6 +63,7 @@
 
     @include grid-media-min('sm') {
       display: block;
+      width: auto;
       text-align: left;
       color: color('white', 'global');
       font-weight: hb-theme-font-weight(bold);


### PR DESCRIPTION
# Summary
- Update swipper settings to allow selecting text inside the slideshow (by default mouse events are hijacked by swipper for for using swipe motion to change the slides, it's necessary to list the selectors that will be excluded).

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6532)

## Need Review By (Date)
02/18

## Urgency
medium

## Steps to Test
**Note:** The ticket only mentioned Spotlights, however the issue was related to a missing configuration in the Swipper settings, so all slideshow were affected.
1. Visit the following pages:
    - Banner image(s) with text box ([Colorful](https://pr2126-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-main-region/banner-images-text-box), [Traditional](https://hs-traditional-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-full-width-region-and-main-region/banner-images-text-box))
    - Banner image with full overlay and text ([Colorful](https://pr2126-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-main-region/banner-image-full-overlay-and-text), [Traditional](https://hs-traditional-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-main-region/banner-images-partial-overlay-and-text))
    - Tall Spotlight(s) - Classic ([Colorful](https://pr2126-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-full-width-region-and-main-region/tall-spotlights-classic), [Traditional](https://hs-traditional-dctxnxedxn97yshipnpdzwnntfr8h0w9.tugboatqa.com/components/hero-images-full-width-region-and-main-region/tall-spotlights-classic)) (All the spotlights share the same Swipper configuration, but if needed check the other Spotlight test pages.)
2. For all slideshows, confirm that you can select the text in each of the slides.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213034441244831