### PR TITLE
HSD8-1828: Add and enable the purge_users module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
         "drupal/pathauto": "^1.8",
         "drupal/publishcontent": "^1.2",
         "drupal/purge": "^3.2",
+        "drupal/purge_users": "^5.0",
         "drupal/rabbit_hole": "^1.0-beta4",
         "drupal/readonly_field_widget": "^1.4",
         "drupal/real_aes": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd2da774c29b26811bfd5376ffcc100f",
+    "content-hash": "5b5c23f4662a0f1d2c1c3b00c7e63bf6",
     "packages": [
         {
             "name": "acquia/blt",
@@ -1639,29 +1639,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -1681,9 +1681,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -10308,6 +10308,59 @@
             "homepage": "https://www.drupal.org/project/purge",
             "support": {
                 "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_users",
+            "version": "5.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/purge_users.git",
+                "reference": "5.0.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/purge_users-5.0.0-beta1.zip",
+                "reference": "5.0.0-beta1",
+                "shasum": "1d6525900402ab5b381de000a000c1ef12371767"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "5.0.0-beta1",
+                    "datestamp": "1768327347",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Er.Sajal",
+                    "homepage": "https://www.drupal.org/user/3418765"
+                },
+                {
+                    "name": "jim.applebee",
+                    "homepage": "https://www.drupal.org/user/2498674"
+                },
+                {
+                    "name": "mably",
+                    "homepage": "https://www.drupal.org/user/3375160"
+                }
+            ],
+            "description": "Purge inactive users after a set interval.",
+            "homepage": "https://drupal.org/project/purge_users",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge_users",
+                "issues": "https://drupal.org/project/issues/purge_users"
             }
         },
         {

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -54,3 +54,5 @@ ignored_config_entities:
   - 'system.action.feeds_feed*'
   - 'ultimate_cron.job.feeds*'
   - views.view.feeds_feed
+  - purge_users.settings
+  - 'purge_users.purge_users_policy.*'

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -199,6 +199,7 @@ module:
   phpass: 0
   preprocess_event_dispatcher: 0
   publishcontent: 0
+  purge_users: 0
   r4032login: 0
   rabbit_hole: 0
   readonly_field_widget: 0

--- a/config/default/purge_users.settings.yml
+++ b/config/default/purge_users.settings.yml
@@ -1,0 +1,30 @@
+_core:
+  default_config_hash: U3htOQFcQLvAkrADhzINubfP0sWXSItgnPmetECBdeY
+langcode: en
+user_never_lastlogin_value: 30
+user_never_lastlogin_period: days
+user_lastlogin_value: 30
+user_lastlogin_period: days
+user_inactive_value: 30
+user_inactive_period: days
+user_blocked_value: 30
+user_blocked_period: days
+enabled_never_loggedin_users: false
+enabled_loggedin_users: false
+enabled_inactive_users: false
+enabled_blocked_users: false
+enabled_do_not_purge_authors: false
+enabled_do_not_purge_commenters: false
+purge_included_users_roles: {  }
+purge_on_cron: false
+inactive_user_notify_subject: 'Your account is deleted'
+inactive_user_notify_text: "Dear User, \r\n\r\nYour account has been deleted due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website.\r\n\r\nThank you"
+send_email_notification: false
+purge_user_cancel_method: user_cancel_block
+disregard_blocked_users: false
+purge_excluded_users_roles: {  }
+user_before_deletion_subject: 'Your account will be deleted'
+user_before_deletion_text: "Dear User, \r\n\r\nYour account will be deleted soon due the website’s policy to automatically remove users who match certain criteria. If you have concerns regarding the deletion, please talk to the administrator of the website.\r\n\r\nThank you"
+send_email_user_before_notification: false
+user_before_notification_value: ''
+user_before_notification_period: days

--- a/config/default/ultimate_cron.job.purge_users_cron.yml
+++ b/config/default/ultimate_cron.job.purge_users_cron.yml
@@ -1,0 +1,17 @@
+uuid: 1046fa67-6af5-4109-9132-c74496afb829
+langcode: en
+status: true
+dependencies:
+  module:
+    - purge_users
+title: 'Default cron handler'
+id: purge_users_cron
+weight: 0
+module: purge_users
+callback: 'purge_users#cron'
+scheduler:
+  id: simple
+launcher:
+  id: serial
+logger:
+  id: database

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.install
@@ -1106,3 +1106,10 @@ function su_humsci_profile_update_9753() {
     'slick',
   ]);
 }
+
+/**
+ * Install the purge_users module.
+ */
+function su_humsci_profile_update_9754() {
+  \Drupal::service('module_installer')->install(['purge_users']);
+}


### PR DESCRIPTION
# Summary
Adds the Auto Purge Users module (`drupal/purge_users`) to the codebase. The module is enabled, but no purge configuration is active by default. Configuration for purging is intentionally ignored via `config_ignore`, so each site can configure and test policies individually before any default configuration or site-wide enablement.

## Backstory
This PR follows the plan to:
- Add the `purge_users` module for future automatic removal of inactive user accounts (e.g., Stanford Staff, Faculty, Student roles).
- Avoid enabling or configuring purging by default; instead, allow manual testing and rollout per site.
- Use `config_ignore` to prevent `purge_users` settings and policies from being overwritten during config sync, so sites can safely test and configure as needed.
- No default purge policies are active; module is only installed and ready for site-by-site configuration.

## Need Review By (Date)
ASAP (to allow testing and site-specific configuration)

## Urgency
Medium

## Steps to Test
1. Confirm `purge_users` module is present and enabled, but not actively purging by default.
2. On a test site, configure purge policies for desired roles and inactivity period.
3. Export config and verify `config_ignore` rules for `purge_users` settings and policies are in place.
4. Test purging by running cron or manually triggering purge; verify only locally configured policies are applied.
5. Confirm excluded roles are not purged and content is reassigned as expected.
6. Ensure no default notification emails are sent unless configured locally.


