### PR TITLE
SHS-6540: Dashboard | Cast TranslatableMarkup to string for table row sorting

### DIFF
--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/ImporterInfo/EventImporterInfo.php
@@ -405,7 +405,9 @@ class EventImporterInfo extends ImporterInfoBase implements ImporterInfoInterfac
    */
   private function sortTableRows() {
     usort($this->eventTableRows, function ($a, $b) {
-      return strcasecmp($a['data'][0]['data'], $b['data'][0]['data']);
+      // These may be string objects (with placeholders), so cast to a string to
+      // determine alphabetical order.
+      return strcasecmp((string) $a['data'][0]['data'], (string) $b['data'][0]['data']);
     });
   }
 


### PR DESCRIPTION
# Summary
Due to string comparison of strings that could sometimes be a string _object_ there was a fatal error. 

## Backstory
  [SHS-6540](https://app.clickup.com/t/36718269/SHS-6540)

## Need Review By (Date)
ASAP.  Would love to get this fix into the next release

## Urgency
high

## Steps to Test
1. Log into a [tugboat test site](https://hs-colorful-s2crdhxcebyz4n4w3ntvohb836od8u9h.tugboatqa.com/user).
2. Visit the [Localist Events Importer config page](https://hs-colorful-s2crdhxcebyz4n4w3ntvohb836od8u9h.tugboatqa.com/admin/config/importers/localist-events) (`/admin/config/importers/localist-events`). At the bottom, add a "Multiple Schedules Bookmark URL" with the following URL:
    ```
    https://events-legacy.stanford.edu/bookmark/feed.php?slug=ethics-in-society
    ```
    <img width="1456" height="822" alt="Screenshot 2026-02-18 at 12 15 08 PM" src="https://github.com/user-attachments/assets/2e09fd66-f4f4-4bd4-9a1b-d8d5df1d1d3c" />
3. Visit [the Dashboard](https://hs-colorful-s2crdhxcebyz4n4w3ntvohb836od8u9h.tugboatqa.com/admin/dashboard) (`/admin/dashboard`).  There should be no fatal error, and the event importer section should look something like
    <img width="1344" height="319" alt="Screenshot 2026-02-18 at 12 16 13 PM" src="https://github.com/user-attachments/assets/121cf12f-bb54-4468-97f2-8cbc7fbf0d8b" />
