### PR TITLE
Remove extra dump parameters from blt sync

### DIFF
--- a/blt/src/Blt/Plugin/Commands/HsCommands.php
+++ b/blt/src/Blt/Plugin/Commands/HsCommands.php
@@ -315,7 +315,6 @@ class HsCommands extends BltTasks {
       ->drush('sql-sync')
       ->arg($remote_alias)
       ->arg($local_alias)
-      ->option('extra-dump', '--no-tablespaces --insert-ignore', '=')
       ->option('--target-dump', sys_get_temp_dir() . '/tmp.target.sql.gz')
       ->option('structure-tables-key', 'lightweight')
       ->option('create-db');


### PR DESCRIPTION
# Summary
The `extra-dump` steps in the `drush sql-sync` command triggered in `blt drupal:sync` were causing syncing errors after the upgrade to MySQL 8 and/or Acquia Cloud Next. These steps are not necessary and can be removed.

