### PR TITLE
SHS-6543: Add Curriculum Requirement Types permissions for Site Managers

### DIFF
--- a/config/default/user.role.contributor.yml
+++ b/config/default/user.role.contributor.yml
@@ -6,6 +6,7 @@ dependencies:
     - block_content.type.hs_basic_block
     - dashboard.dashboard.main_dashboard
     - filter.format.basic_html
+    - filter.format.bold_italics_links
     - filter.format.minimal_html
     - filter.format.minimal_html_with_styles
     - media.type.embeddable
@@ -115,6 +116,7 @@ permissions:
   - 'unpublish editable content'
   - 'update media'
   - 'use text format basic_html'
+  - 'use text format bold_italics_links'
   - 'use text format minimal_html'
   - 'use text format minimal_html_with_styles'
   - 'view editoria11y checker'

--- a/config/default/user.role.preparer.yml
+++ b/config/default/user.role.preparer.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - filter.format.basic_html
+    - filter.format.bold_italics_links
     - filter.format.minimal_html
     - filter.format.minimal_html_with_styles
     - media.type.file
@@ -73,6 +74,7 @@ permissions:
   - 'update any media'
   - 'update media'
   - 'use text format basic_html'
+  - 'use text format bold_italics_links'
   - 'use text format minimal_html'
   - 'use text format minimal_html_with_styles'
   - 'view any unpublished hs_basic_page content'

--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -7,6 +7,7 @@ dependencies:
     - dashboard.dashboard.main_dashboard
     - entityqueue.entity_queue.hs_person
     - filter.format.basic_html
+    - filter.format.bold_italics_links
     - filter.format.minimal_html
     - filter.format.minimal_html_with_styles
     - media.type.embeddable
@@ -230,6 +231,7 @@ permissions:
   - 'update hs_person entityqueue'
   - 'update media'
   - 'use text format basic_html'
+  - 'use text format bold_italics_links'
   - 'use text format minimal_html'
   - 'use text format minimal_html_with_styles'
   - 'view 403 reports'

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.install
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.install
@@ -15,4 +15,12 @@ function hs_cmap_update_10001() {
     'edit terms in hs_curriculum_requirement_type',
     'use text format bold_italics_links',
   ]);
+
+  user_role_grant_permissions('preparer', [
+    'use text format bold_italics_links',
+  ]);
+
+  user_role_grant_permissions('contributor', [
+    'use text format bold_italics_links',
+  ]);
 }

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.install
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.install
@@ -13,5 +13,6 @@ function hs_cmap_update_10001() {
     'create terms in hs_curriculum_requirement_type',
     'delete terms in hs_curriculum_requirement_type',
     'edit terms in hs_curriculum_requirement_type',
+    'use text format bold_italics_links',
   ]);
 }

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.install
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update functions for hs_cmap module.
+ */
+
+/**
+ * Grant permissions to site manager role.
+ */
+function hs_cmap_update_10001() {
+  user_role_grant_permissions('site_manager', [
+    'create terms in hs_curriculum_requirement_type',
+    'delete terms in hs_curriculum_requirement_type',
+    'edit terms in hs_curriculum_requirement_type',
+  ]);
+}

--- a/docroot/modules/humsci/hs_cmap/hs_cmap.install
+++ b/docroot/modules/humsci/hs_cmap/hs_cmap.install
@@ -13,6 +13,9 @@ function hs_cmap_update_10001() {
     'create terms in hs_curriculum_requirement_type',
     'delete terms in hs_curriculum_requirement_type',
     'edit terms in hs_curriculum_requirement_type',
+    'delete term revisions in hs_curriculum_requirement_type',
+    'revert term revisions in hs_curriculum_requirement_type',
+    'view term revisions in hs_curriculum_requirement_type',
     'use text format bold_italics_links',
   ]);
 


### PR DESCRIPTION
# Summary
Add Curriculum Requirement Types permissions for Site Managers

## Backstory
[SHS-6543](https://app.clickup.com/t/36718269/SHS-6543)

## Need Review By (Date)
02/03

## Urgency
medium

## Steps to Test
1. Log into any test site (for example [Colorful](https://hs-colorful-xvvexp8lpq3cgdq53okhrvbnirnnik1r.tugboatqa.com/user)), visit the [user list](https://hs-colorful.ddev.site/admin/users) and masquerade as any user with the "Site Manager" role (for example "IT Site Manager"). Alternatively, you can login directly with an user with the "Site Manager" role, if you have the credentials.
2. Visit the [Taxonomy List Page](https://english-xvvexp8lpq3cgdq53okhrvbnirnnik1r.tugboatqa.com/admin/structure/taxonomy/manage/hs_curriculum_requirement_type/overview).
3. Confirm you can add, edit and delete terms of the "Curriculum Requirement Type" vocabulary.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213232272886373