### PR TITLE
HSD8-1815: Restore hidden and disabled roles in access control forms

### DIFF
--- a/config/default/content_access_simple.settings.yml
+++ b/config/default/content_access_simple.settings.yml
@@ -1,12 +1,8 @@
 _core:
   default_config_hash: Rl4OPlnjxboVhLbRQeTtStQRcg8XV4XDFZm8qleYrus
 role_config:
-  hidden_roles:
-    - administrator
-    - search_indexer
-    - anonymous
-  disabled_roles:
-    - site_manager
+  hidden_roles: {  }
+  disabled_roles: {  }
 debug: false
 help_text_view: 'Only the chosen roles will be able to view this content (when published). <i>Site Managers</i> can always view all content.'
 unpublished_message: 'These settings only take effect once this page is published. Only <i>Site Managers</i> and <i>Contributors</i> can view unpublished private pages.'

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -1019,18 +1019,26 @@ function su_humsci_profile_form_stanford_samlauth_add_user_alter(&$form, FormSta
  *   The processed form element.
  */
 function _su_humsci_profile_process_per_role_field(&$element, FormStateInterface $form_state, &$complete_form) {
-  if (isset($element['search_indexer'])) {
-    $element['search_indexer']['#access'] = FALSE;
-  }
-  if (isset($element['anonymous'])) {
-    $element['anonymous']['#access'] = FALSE;
-  }
-  if (isset($element['authenticated'])) {
-    $element['authenticated']['#title'] = 'All logged in users';
-  }
-  if (isset($element['site_manager'])) {
-    $element['site_manager']['#default_value'] = 'site_manager';
-    $element['site_manager']['#disabled'] = TRUE;
-  }
+  // 2026-02-23: Commenting this out for now. Hiding these roles from the
+  // content access control form using #access = FALSE resulted in the fields
+  // for these roles to not be rendered in the form. This caused all permissions
+  // to be set to FALSE for these roles when the form was saved. The largest
+  // consequence of this was anonymous users losing access to all content of the
+  // type configured. Hiding the roles also prevented access from being restored
+  // to these roles through the site UI, and required drush to delete or modify
+  // the configuration directly. See HSD8-1815 for more details.
+  // if (isset($element['search_indexer'])) {
+  //   $element['search_indexer']['#access'] = FALSE;
+  // }
+  // if (isset($element['anonymous'])) {
+  //   $element['anonymous']['#access'] = FALSE;
+  // }
+  // if (isset($element['authenticated'])) {
+  //   $element['authenticated']['#title'] = 'All logged in users';
+  // }
+  // if (isset($element['site_manager'])) {
+  //   $element['site_manager']['#default_value'] = 'site_manager';
+  //   $element['site_manager']['#disabled'] = TRUE;
+  // }
   return $element;
 }

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -1027,18 +1027,20 @@ function _su_humsci_profile_process_per_role_field(&$element, FormStateInterface
   // type configured. Hiding the roles also prevented access from being restored
   // to these roles through the site UI, and required drush to delete or modify
   // the configuration directly. See HSD8-1815 for more details.
-  // if (isset($element['search_indexer'])) {
-  //   $element['search_indexer']['#access'] = FALSE;
-  // }
-  // if (isset($element['anonymous'])) {
-  //   $element['anonymous']['#access'] = FALSE;
-  // }
-  // if (isset($element['authenticated'])) {
-  //   $element['authenticated']['#title'] = 'All logged in users';
-  // }
-  // if (isset($element['site_manager'])) {
-  //   $element['site_manager']['#default_value'] = 'site_manager';
-  //   $element['site_manager']['#disabled'] = TRUE;
-  // }
+  /*
+  if (isset($element['search_indexer'])) {
+    $element['search_indexer']['#access'] = FALSE;
+  }
+  if (isset($element['anonymous'])) {
+    $element['anonymous']['#access'] = FALSE;
+  }
+  if (isset($element['authenticated'])) {
+    $element['authenticated']['#title'] = 'All logged in users';
+  }
+  if (isset($element['site_manager'])) {
+    $element['site_manager']['#default_value'] = 'site_manager';
+    $element['site_manager']['#disabled'] = TRUE;
+  }
+  */
   return $element;
 }

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.profile
@@ -1027,20 +1027,20 @@ function _su_humsci_profile_process_per_role_field(&$element, FormStateInterface
   // type configured. Hiding the roles also prevented access from being restored
   // to these roles through the site UI, and required drush to delete or modify
   // the configuration directly. See HSD8-1815 for more details.
-  /*
-  if (isset($element['search_indexer'])) {
-    $element['search_indexer']['#access'] = FALSE;
-  }
-  if (isset($element['anonymous'])) {
-    $element['anonymous']['#access'] = FALSE;
-  }
-  if (isset($element['authenticated'])) {
-    $element['authenticated']['#title'] = 'All logged in users';
-  }
-  if (isset($element['site_manager'])) {
-    $element['site_manager']['#default_value'] = 'site_manager';
-    $element['site_manager']['#disabled'] = TRUE;
-  }
-  */
+  // phpcs:disable
+  // if (isset($element['search_indexer'])) {
+  //   $element['search_indexer']['#access'] = FALSE;
+  // }
+  // if (isset($element['anonymous'])) {
+  //   $element['anonymous']['#access'] = FALSE;
+  // }
+  // if (isset($element['authenticated'])) {
+  //   $element['authenticated']['#title'] = 'All logged in users';
+  // }
+  // if (isset($element['site_manager'])) {
+  //   $element['site_manager']['#default_value'] = 'site_manager';
+  //   $element['site_manager']['#disabled'] = TRUE;
+  // }
+  // phpcs:enable
   return $element;
 }


### PR DESCRIPTION
# Summary
This PR restores hidden and disabled roles in the access control forms. It comments out the code that hides/disables roles and updates the configuration to remove hidden/disabled roles.

## Backstory
[HSD8-1815](https://stanfordits.atlassian.net/browse/HSD8-1815): Person node with non anonymous author permissions issue
Hiding roles from access control forms caused permissions for those roles (especially anonymous) to be set to FALSE when the forms were saved, resulting in loss of access for anonymous users. Once access control was enabled for a content type, anonymous access could not be restored via the UI.

## Need Review By (Date)
02/25/2026

## Urgency
high

## Steps to Test
1. Confirm that hidden/disabled roles are now visible in access control forms.
2. Save access control settings for a content type and verify anonymous access is not lost.


[HSD8-1815]: https://stanfordits.atlassian.net/browse/HSD8-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ