### PR TITLE
Prevent unnecessary cache clearing in content_access_simple node submit handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -241,6 +241,9 @@
                 "https://www.drupal.org/project/config_ignore/issues/2857247": "https://www.drupal.org/files/issues/2020-01-11/support-for-export-2857247-44.patch",
                 "https://www.drupal.org/project/config_ignore/issues/2865419": "https://www.drupal.org/files/issues/2020-07-20/config_ignore-wildcard_force_import.patch"
             },
+            "drupal/content_access_simple": {
+                "https://www.drupal.org/project/content_access_simple/issues/3575304: Check for permission changes before running any actions on node submit": "patches/contrib/content_access_simple-3575304-mr-1.patch"
+            },
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/2999491": "https://www.drupal.org/files/issues/2024-07-17/drupal-2999491-162.patch",
                 "https://www.drupal.org/project/drupal/issues/2981837": "https://www.drupal.org/files/issues/2019-05-22/findMigrationDependencies-null-process-value-2981837-5.patch",

--- a/patches/contrib/content_access_simple-3575304-mr-1.patch
+++ b/patches/contrib/content_access_simple-3575304-mr-1.patch
@@ -1,0 +1,22 @@
+diff --git a/content_access_simple.module b/content_access_simple.module
+index 9c9ecdc2ef992e6c745f19808ca451196f1036ef..2bcfdcf44e76a269394327022ca2aa4d481ff53f 100644
+--- a/content_access_simple.module
++++ b/content_access_simple.module
+@@ -120,6 +120,17 @@ function content_access_simple_node_form_submit($form, FormStateInterface $form_
+     }
+   }
+ 
++  // Compare view settings, ignoring order and duplicates.
++  $origView = array_unique(array_diff($origSettings['view'], $hiddenRoles));
++  $newView = array_unique(array_diff($newViewSettings, $hiddenRoles));
++  sort($origView);
++  sort($newView);
++
++  // If view settings are unchanged, skip grant/cache update.
++  if ($origView === $newView) {
++    return;
++  }
++
+   $origSettings['view'] = $newViewSettings;
+ 
+   // Update Content Access settings.


### PR DESCRIPTION
# Summary
This PR adds a patch to the `content_access_simple` module to prevent unnecessary cache clearing and access grant updates when node permissions have not changed. The patch compares the original and new view settings (ignoring order and duplicates, and excluding hidden roles) and skips grant/cache updates if they are unchanged.

## Backstory
Aggressive cache deletion in `content_access_simple` can cause performance issues, as the cache was cleared every time a node was saved, regardless of whether permissions changed. This can be especially problematic for simple edits unrelated to permissions. The fix ensures that cache clearing and grant updates only occur when permission settings actually change, improving efficiency and reducing unnecessary operations.

See issue: [content_access_simple #3575304](https://www.drupal.org/project/content_access_simple/issues/3575304)
Merge request: [MR 1](https://git.drupalcode.org/project/content_access_simple/-/merge_requests/1)

## Need Review By (Date)
ASAP

## Urgency
Medium

## Steps to Test
1. Apply the patch and run `composer install`.
2. Edit a node with `content_access_simple` enabled and save without changing permissions.
3. Verify that cache is not cleared and grants are not updated if permissions are unchanged.
4. Change permissions and save; verify that cache and grants update as expected.
5. Review logs and performance for improvements.