### PR TITLE
SHS-6525: Dashboard | Implement 2-col styles with show more/less toggle

### DIFF
--- a/config/default/dashboard.dashboard.main_dashboard.yml
+++ b/config/default/dashboard.dashboard.main_dashboard.yml
@@ -61,7 +61,7 @@ layout:
   -
     layout_id: layout_twocol_section
     layout_settings:
-      label: 'Pages with the most accessibility issues/SiteImprove Broken Links Section'
+      label: 'Pages with the most accessibility issues / SiteImprove Broken Links Section'
       context_mapping: {  }
       column_widths: 50-50
     components:
@@ -94,7 +94,7 @@ layout:
   -
     layout_id: layout_twocol_section
     layout_settings:
-      label: 'Duplicate Profile/Content Sorting Section'
+      label: 'Duplicate Profile / Content Sorting Section'
       context_mapping: {  }
       column_widths: 50-50
     components:
@@ -130,7 +130,7 @@ layout:
   -
     layout_id: layout_twocol_section
     layout_settings:
-      label: 'Importers/Active Site Editors Section'
+      label: 'Importers / Active Site Editors Section'
       context_mapping: {  }
       column_widths: 50-50
     components:

--- a/config/default/dashboard.dashboard.main_dashboard.yml
+++ b/config/default/dashboard.dashboard.main_dashboard.yml
@@ -59,14 +59,15 @@ layout:
         additional: {  }
     third_party_settings: {  }
   -
-    layout_id: layout_onecol
+    layout_id: layout_twocol_section
     layout_settings:
-      label: 'Pages with the most accessibility issues Section'
+      label: 'Pages with the most accessibility issues/SiteImprove Broken Links Section'
       context_mapping: {  }
+      column_widths: 50-50
     components:
       4ec36b0a-20e8-4b96-b9d2-cf40f9438a27:
         uuid: 4ec36b0a-20e8-4b96-b9d2-cf40f9438a27
-        region: content
+        region: first
         configuration:
           id: 'views_block:editoria11y_results-block_top_results'
           label: ''
@@ -78,16 +79,9 @@ layout:
           exposed: {  }
         weight: 0
         additional: {  }
-    third_party_settings: {  }
-  -
-    layout_id: layout_onecol
-    layout_settings:
-      label: 'SiteImprove Broken Links Section'
-      context_mapping: {  }
-    components:
       5abbe598-4aa6-4f17-a593-45c27378f502:
         uuid: 5abbe598-4aa6-4f17-a593-45c27378f502
-        region: content
+        region: second
         configuration:
           id: hs_siteimprove_broken_links
           label: 'Pages with Broken Links'
@@ -98,14 +92,15 @@ layout:
         additional: {  }
     third_party_settings: {  }
   -
-    layout_id: layout_onecol
+    layout_id: layout_twocol_section
     layout_settings:
-      label: 'Duplicate Profiles Section'
+      label: 'Duplicate Profile/Content Sorting Section'
       context_mapping: {  }
+      column_widths: 50-50
     components:
       11de9985-525e-4dd4-b5ce-c8789d008462:
         uuid: 11de9985-525e-4dd4-b5ce-c8789d008462
-        region: content
+        region: first
         configuration:
           id: 'views_block:duplicate_people-block_1'
           label: ''
@@ -117,16 +112,9 @@ layout:
           exposed: {  }
         weight: 0
         additional: {  }
-    third_party_settings: {  }
-  -
-    layout_id: layout_onecol
-    layout_settings:
-      label: 'Content Sorting Section'
-      context_mapping: {  }
-    components:
       36857474-0fa2-48b0-8b32-b129e92cefa6:
         uuid: 36857474-0fa2-48b0-8b32-b129e92cefa6
-        region: content
+        region: second
         configuration:
           id: 'views_block:dashboard_entityqueue-block_sorting'
           label: ''
@@ -140,14 +128,26 @@ layout:
         additional: {  }
     third_party_settings: {  }
   -
-    layout_id: layout_onecol
+    layout_id: layout_twocol_section
     layout_settings:
-      label: 'Active Site Editors Section'
+      label: 'Importers/Active Site Editors Section'
       context_mapping: {  }
+      column_widths: 50-50
     components:
+      fd1a16b1-6039-40c4-848f-c96aa72b84e0:
+        uuid: fd1a16b1-6039-40c4-848f-c96aa72b84e0
+        region: first
+        configuration:
+          id: hs_dashboard_importers
+          label: Importers
+          label_display: visible
+          provider: hs_dashboard
+          context_mapping: {  }
+        weight: 0
+        additional: {  }
       f9927c52-346e-4010-964b-4e368eeb9cc2:
         uuid: f9927c52-346e-4010-964b-4e368eeb9cc2
-        region: content
+        region: second
         configuration:
           id: 'views_block:site_dashboard_active_site_editors-block_1'
           label: ''
@@ -157,24 +157,6 @@ layout:
           views_label: ''
           items_per_page: none
           exposed: {  }
-        weight: 0
-        additional: {  }
-    third_party_settings: {  }
-  -
-    layout_id: layout_onecol
-    layout_settings:
-      label: 'Importers Section'
-      context_mapping: {  }
-    components:
-      fd1a16b1-6039-40c4-848f-c96aa72b84e0:
-        uuid: fd1a16b1-6039-40c4-848f-c96aa72b84e0
-        region: content
-        configuration:
-          id: hs_dashboard_importers
-          label: Importers
-          label_display: visible
-          provider: hs_dashboard
-          context_mapping: {  }
         weight: 0
         additional: {  }
     third_party_settings: {  }

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -130,10 +130,24 @@ html .dashboard-content.user-logged-in {
     transition:
       max-height 550ms ease-out;
     will-change: max-height;
+    height: 100%;
 
     &.is-collapsed {
       max-height: 34.375rem;
-      height: 100%;
+    }
+
+    /* When expanded */
+    &:not(.is-collapsed) {
+      max-height: 100%;
+
+      /* Add space at the bottom when there's a toggle to avoid the toggle hide any content or button */
+      &:has(.show-toggle) {
+        padding-bottom: 2.625rem;
+      }
+
+      .show-toggle::after {
+        transform: rotate(180deg);
+      }
     }
 
     /* Toggle button spacing */
@@ -171,11 +185,6 @@ html .dashboard-content.user-logged-in {
         background-color: #5D5656;
         color: #ffff;
       }
-    }
-
-    /* When expanded */
-    &:not(.is-collapsed) .show-toggle::after {
-      transform: rotate(180deg);
     }
   }
 }

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -124,42 +124,44 @@ html .dashboard-content.user-logged-in {
 }
 
 .dashboard--main-dashboard .layout {
-  .block.is-collapsed {
-    max-height: 550px;
-    overflow: hidden;
+  .block {
     position: relative;
+    overflow: hidden;
+    transition:
+      max-height 550ms ease-out;
+    will-change: max-height;
 
-    /* Optional fade effect */
-    &::after {
-      content: "";
+    &.is-collapsed {
+      max-height: 550px;
+    }
+
+    /* Toggle button spacing */
+    .show-toggle {
+      z-index: 999;
+      display: block;
       position: absolute;
       bottom: 0;
+      border-radius: 0 0 8px 8px;
+      background: #E7E5E4;
+      box-shadow: 0 -1px 4px 0 rgba(0, 0, 0, 0.07), 0 -2px 12.7px 0 rgba(0, 0, 0, 0.29);
       left: 0;
-      width: 100%;
-      height: 60px;
-      background: linear-gradient(to bottom, transparent, white);
+      right: 0;
+      text-align: center;
+      margin: 0;
+      color: #000000;
+      border: none !important;
+      font-weight: semibold;
+      font-size: 1rem;
+
+      &:hover,
+      &:focus {
+        background-color: #5D5656;
+        color: #ffff;
+      }
     }
   }
 
 
-  /* Toggle button spacing */
-  .block .show-toggle {
-    z-index: 999;
-    display: block;
-    position: absolute;
-    bottom: 0;
-    border-radius: 0 0 10px 10px;
-    background: #E7E5E4;
-    box-shadow: 0 -1px 4px 0 rgba(0, 0, 0, 0.07), 0 -2px 12.7px 0 rgba(0, 0, 0, 0.29);
-    left: 0;
-    right: 0;
-    text-align: center;
-    margin: 0;
-    color: #000000;
-    border: none !important;
-    font-weight: semibold;
-    font-size: 1rem;
-  }
 }
 
 

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -107,6 +107,62 @@ html .dashboard-content.user-logged-in {
   margin-inline: var(--space-s);
 }
 
+.dashboard-content .layout--twocol-section {
+  display: flex;
+  flex-wrap: wrap;
+
+  &.layout--twocol-section--50-50 > .layout__region--first,
+  &.layout--twocol-section--50-50 > .layout__region--second {
+    flex: 1 1 550px;
+    min-width: 550px;
+
+    .block {
+      margin-inline-end: 36px;
+      margin-block-end: 36px;
+    }
+  }
+}
+
+.dashboard--main-dashboard .layout {
+  .block.is-collapsed {
+    max-height: 550px;
+    overflow: hidden;
+    position: relative;
+
+    /* Optional fade effect */
+    &::after {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom, transparent, white);
+    }
+  }
+
+
+  /* Toggle button spacing */
+  .block .show-toggle {
+    z-index: 999;
+    display: block;
+    position: absolute;
+    bottom: 0;
+    border-radius: 0 0 10px 10px;
+    background: #E7E5E4;
+    box-shadow: 0 -1px 4px 0 rgba(0, 0, 0, 0.07), 0 -2px 12.7px 0 rgba(0, 0, 0, 0.29);
+    left: 0;
+    right: 0;
+    text-align: center;
+    margin: 0;
+    color: #000000;
+    border: none !important;
+    font-weight: semibold;
+    font-size: 1rem;
+  }
+}
+
+
 /* Hide external link arrow in more links. */
 .dashboard-content .layout .layout__region .block .more-link a.button--primary.ext span.extlink {
   display: none;

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -113,12 +113,12 @@ html .dashboard-content.user-logged-in {
 
   &.layout--twocol-section--50-50 > .layout__region--first,
   &.layout--twocol-section--50-50 > .layout__region--second {
-    flex: 1 1 550px;
-    min-width: 550px;
+    flex: 1 1 34.375rem;
+    min-width: 34.375rem;
 
     .block {
-      margin-inline-end: 36px;
-      margin-block-end: 36px;
+      margin-inline-end: 2.25rem;
+      margin-block-end: 2.25rem;
     }
   }
 }
@@ -132,7 +132,7 @@ html .dashboard-content.user-logged-in {
     will-change: max-height;
 
     &.is-collapsed {
-      max-height: 550px;
+      max-height: 34.375rem;
     }
 
     /* Toggle button spacing */
@@ -141,7 +141,8 @@ html .dashboard-content.user-logged-in {
       display: block;
       position: absolute;
       bottom: 0;
-      border-radius: 0 0 8px 8px;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding-block: 0.75rem;
       background: #E7E5E4;
       box-shadow: 0 -1px 4px 0 rgba(0, 0, 0, 0.07), 0 -2px 12.7px 0 rgba(0, 0, 0, 0.29);
       left: 0;
@@ -153,15 +154,29 @@ html .dashboard-content.user-logged-in {
       font-weight: semibold;
       font-size: 1rem;
 
+      /* Arrow base */
+      &::after {
+        content: "\2193";
+        display: inline-block;
+        font-size: 1.125rem;
+        line-height: 1;
+        margin-left: 0.75rem;
+        transition: transform 300ms ease;
+      }
+
+
       &:hover,
       &:focus {
         background-color: #5D5656;
         color: #ffff;
       }
     }
+
+    /* When expanded */
+    &:not(.is-collapsed) .show-toggle::after {
+      transform: rotate(180deg);
+    }
   }
-
-
 }
 
 

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -133,6 +133,7 @@ html .dashboard-content.user-logged-in {
 
     &.is-collapsed {
       max-height: 34.375rem;
+      height: 100%;
     }
 
     /* Toggle button spacing */

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -61,10 +61,6 @@ html .dashboard-content.user-logged-in {
   flex-direction: column;
 }
 
-.dashboard-content .layout .layout__region .block {
-  flex-grow: 1;
-}
-
 .dashboard-content .layout .layout__region .block a,
 .dashboard-content .layout .layout__region .block li::marker {
   color: var(--color-dashboard-brick-red);
@@ -129,11 +125,13 @@ html .dashboard-content.user-logged-in {
     overflow: hidden;
     transition:
       max-height 550ms ease-out;
-    will-change: max-height;
-    height: 100%;
 
     &.is-collapsed {
       max-height: 34.375rem;
+    }
+
+    &.is-static {
+      height: 100%;
     }
 
     /* When expanded */

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_dashboard.css
@@ -59,6 +59,7 @@ html .dashboard-content.user-logged-in {
 .dashboard-content .layout .layout__region {
   display: flex;
   flex-direction: column;
+  container-type: normal;
 }
 
 .dashboard-content .layout .layout__region .block a,
@@ -105,18 +106,37 @@ html .dashboard-content.user-logged-in {
 
 .dashboard-content .layout--twocol-section {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
 
   &.layout--twocol-section--50-50 > .layout__region--first,
   &.layout--twocol-section--50-50 > .layout__region--second {
-    flex: 1 1 34.375rem;
-    min-width: 34.375rem;
-
     .block {
-      margin-inline-end: 2.25rem;
-      margin-block-end: 2.25rem;
+      margin-inline-end: 0;
     }
   }
+
+  @media (min-width: 1100px) {
+    flex-wrap: wrap;
+    flex-direction: row;
+
+    &.layout--twocol-section--50-50 > .layout__region--first,
+    &.layout--twocol-section--50-50 > .layout__region--second {
+      flex: 1 1 34.375rem;
+      min-width: 34.375rem;
+
+      .block {
+        margin-block-end: 2.25rem;
+      }
+    }
+
+    &.layout--twocol-section--50-50 > .layout__region--first {
+      .block {
+        margin-inline-end: 2.25rem;
+      }
+    }
+  }
+
+
 }
 
 .dashboard--main-dashboard .layout {
@@ -150,7 +170,8 @@ html .dashboard-content.user-logged-in {
 
     /* Toggle button spacing */
     .show-toggle {
-      z-index: 999;
+      z-index: 10;
+      cursor: pointer;
       display: block;
       position: absolute;
       bottom: 0;

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
@@ -13,7 +13,7 @@
         const maxHeight = 550;
 
         // Only apply if taller than 550px
-        if (block.offsetHeight <= maxHeight) {
+        if (block.scrollHeight <= maxHeight) {
           continue;
         }
 
@@ -29,13 +29,34 @@
         block.appendChild(button);
 
         button.addEventListener('click', () => {
-          const isCollapsed = block.classList.toggle('is-collapsed');
+          const isCollapsed = block.classList.contains('is-collapsed');
 
-          button.textContent = isCollapsed ? 'Show More' : 'Show Less';
-          button.setAttribute('aria-expanded', !isCollapsed);
+          if (isCollapsed) {
+            // EXPAND
+            const fullHeight = block.scrollHeight;
+
+            block.style.maxHeight = fullHeight + 'px';
+            block.classList.remove('is-collapsed');
+
+            button.textContent = 'Show Less';
+            button.setAttribute('aria-expanded', 'true');
+
+          } else {
+            // COLLAPSE
+            const currentHeight = block.scrollHeight;
+
+            block.style.maxHeight = currentHeight + 'px';
+
+            requestAnimationFrame(() => {
+              block.style.maxHeight = '550px';
+            });
+
+            block.classList.add('is-collapsed');
+
+            button.textContent = 'Show More';
+            button.setAttribute('aria-expanded', 'false');
+          }
         });
-
-        button.setAttribute('aria-expanded', 'false');
       }
     },
   };

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
@@ -1,0 +1,42 @@
+((Drupal) => {
+  Drupal.behaviors.showToggle = {
+    attach(context) {
+      const blocks = context.querySelectorAll(
+        '.dashboard--main-dashboard .block'
+      );
+
+      if (!blocks.length) {
+        return;
+      }
+
+      for (const block of blocks) {
+        const maxHeight = 550;
+
+        // Only apply if taller than 550px
+        if (block.offsetHeight <= maxHeight) {
+          continue;
+        }
+
+        block.setAttribute('data-show-more-processed', '');
+        block.classList.add('is-collapsed');
+
+        // Create toggle button
+        const button = document.createElement('button');
+        button.className = 'button button--secondary show-toggle';
+        button.type = 'button';
+        button.textContent = 'Show More';
+
+        block.appendChild(button);
+
+        button.addEventListener('click', () => {
+          const isCollapsed = block.classList.toggle('is-collapsed');
+
+          button.textContent = isCollapsed ? 'Show More' : 'Show Less';
+          button.setAttribute('aria-expanded', !isCollapsed);
+        });
+
+        button.setAttribute('aria-expanded', 'false');
+      }
+    },
+  };
+})(Drupal);

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
@@ -1,10 +1,7 @@
 ((Drupal, once) => {
   Drupal.behaviors.showToggle = {
     attach(context) {
-      const blocks = once(
-        'show-toggle',
-        context.querySelectorAll('.dashboard--main-dashboard .block')
-      );
+      const blocks = once('show-toggle', '.dashboard--main-dashboard .block', context);
 
       if (!blocks.length) {
         return;
@@ -15,6 +12,7 @@
 
         // Only apply if taller than 550px
         if (block.scrollHeight <= maxHeight) {
+          block.classList.add('is-static');
           continue;
         }
 

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
@@ -1,8 +1,9 @@
-((Drupal) => {
+((Drupal, once) => {
   Drupal.behaviors.showToggle = {
     attach(context) {
-      const blocks = context.querySelectorAll(
-        '.dashboard--main-dashboard .block'
+      const blocks = once(
+        'show-toggle',
+        context.querySelectorAll('.dashboard--main-dashboard .block')
       );
 
       if (!blocks.length) {
@@ -17,47 +18,23 @@
           continue;
         }
 
-        block.setAttribute('data-show-more-processed', '');
         block.classList.add('is-collapsed');
 
-        // Create toggle button
         const button = document.createElement('button');
-        button.className = 'button button--secondary show-toggle';
+        button.className = 'show-toggle';
         button.type = 'button';
         button.textContent = 'Show More';
+        button.setAttribute('aria-expanded', 'false');
 
         block.appendChild(button);
 
         button.addEventListener('click', () => {
-          const isCollapsed = block.classList.contains('is-collapsed');
+          const isCollapsed = block.classList.toggle('is-collapsed');
 
-          if (isCollapsed) {
-            // EXPAND
-            const fullHeight = block.scrollHeight;
-            const buttonHeight = button.offsetHeight;
-
-            block.style.maxHeight = fullHeight + buttonHeight + 'px';
-            block.style.height = fullHeight + buttonHeight + 'px';
-            block.classList.remove('is-collapsed');
-
-            button.textContent = 'Show Less';
-            button.setAttribute('aria-expanded', 'true');
-
-          } else {
-            // COLLAPSE
-            block.style.height = '100%';
-
-            requestAnimationFrame(() => {
-              block.style.maxHeight = '550px';
-            });
-
-            block.classList.add('is-collapsed');
-
-            button.textContent = 'Show More';
-            button.setAttribute('aria-expanded', 'false');
-          }
+          button.textContent = isCollapsed ? 'Show More' : 'Show Less';
+          button.setAttribute('aria-expanded', String(!isCollapsed));
         });
       }
     },
   };
-})(Drupal);
+})(Drupal, once);

--- a/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
+++ b/docroot/themes/humsci/su_humsci_gin_admin/js/show-toggle.js
@@ -34,8 +34,10 @@
           if (isCollapsed) {
             // EXPAND
             const fullHeight = block.scrollHeight;
+            const buttonHeight = button.offsetHeight;
 
-            block.style.maxHeight = fullHeight + 'px';
+            block.style.maxHeight = fullHeight + buttonHeight + 'px';
+            block.style.height = fullHeight + buttonHeight + 'px';
             block.classList.remove('is-collapsed');
 
             button.textContent = 'Show Less';
@@ -43,9 +45,7 @@
 
           } else {
             // COLLAPSE
-            const currentHeight = block.scrollHeight;
-
-            block.style.maxHeight = currentHeight + 'px';
+            block.style.height = '100%';
 
             requestAnimationFrame(() => {
               block.style.maxHeight = '550px';

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
@@ -31,6 +31,7 @@ show-toggle:
     js/show-toggle.js: {}
   dependencies:
     - core/drupal
+    - core/once
 
 su_humsci_dashboard:
   css:

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.libraries.yml
@@ -26,6 +26,12 @@ paragraph-previews-slideshow-width:
   dependencies:
     - core/drupal
 
+show-toggle:
+  js:
+    js/show-toggle.js: {}
+  dependencies:
+    - core/drupal
+
 su_humsci_dashboard:
   css:
     theme:

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -85,6 +85,7 @@ function su_humsci_gin_admin_preprocess_html(&$variables, $hook) {
     $variables['attributes']['class'][] = 'dashboard-content';
     $variables['#attached']['library'][] = 'su_humsci_gin_admin/su_humsci_dashboard';
     $variables['#attached']['library'][] = 'su_humsci_gin_admin/ajax-scroll-fix';
+    $variables['#attached']['library'][] = 'su_humsci_gin_admin/show-toggle';
   }
 }
 


### PR DESCRIPTION
# Summary
Implement 2 col styles in Dashboard and a show more/less toggle when block height is more than 550px

## Backstory
[SHS-6525](https://app.clickup.com/t/36718269/SHS-6525)


## Need Review By (Date)
03/02

## Urgency
medium

## Steps to Test
1. Log into a [tugboat test site](https://pr2141-ogh2l8btyatzrac7sugfu5n7qvvjsn4c.tugboatqa.com/user/login) (both Colorful and Traditional share the same code, you can use any).
2. In the [Dashboard](https://pr2141-ogh2l8btyatzrac7sugfu5n7qvvjsn4c.tugboatqa.com/admin/dashboard), check the following:
   -  Announcements and My Edits are full-width, but everything below is 2/row
   - Every column has a min-width of 550px, so all information is visible
   - Each row is equal height
   - If a block is taller than 550px, there should be a "Show More/Less" toggle
   - Confirm everything looks as proposed in the [design](https://www.figma.com/proto/hOtD5MStjFIavUrWapHKHN/UX-Design-Tickets-Work?node-id=8017-5862&t=Q74YrkfvgiBRVkoB-0&scaling=min-zoom&content-scaling=fixed&page-id=7757%3A10&starting-point-node-id=7759%3A305&show-proto-sidebar=1&hide-ui=1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213321891069249