### PR TITLE
SHS-6558: Improve environment detection for compile scripts (build-theme); added local override variable (#2144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ CSS assets are built using the Grunt task runner, but are run using npm scripts 
 - `npm run theme-watch` - Compile a CSS build and watch for changes in the existing `.scss` files in all themes based on `humsci_basic`.
 - `npm run theme-visreg` - Run Percy VRT on `hs_colorful` and `hs_traditional` sites (see `docroot/themes/humsci/humsci_basic/README.md` for details.)
 
+The build process will automatically choose whether to run in/out of ddev/lando (if installed).  To override this behavior use one of the following commands:
+
+- `export HSDP_COMPILE_ENVIRONMENT=ddev`
+- `export HSDP_COMPILE_ENVIRONMENT=lando`
+- `export HSDP_COMPILE_ENVIRONMENT=baremetal`
 
 ## Testing
 

--- a/hooks/common/theme/theme-build.sh
+++ b/hooks/common/theme/theme-build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 DIR="$(dirname "$(realpath "$0")")"
-NPM_CMD=$("$DIR/theme-get-command.sh")
+. "$DIR/theme-get-command.sh"
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit
 
 echo "Building theme..." >&2
 ${NPM_CMD} run build

--- a/hooks/common/theme/theme-get-command.sh
+++ b/hooks/common/theme/theme-get-command.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 
+DIR="$(dirname "$(realpath "$0")")"
+
+echo "HSDP_COMPILE_ENVIRONMENT: $HSDP_COMPILE_ENVIRONMENT" >&2
 if [ -n "$DDEV_PROJECT" ] || [ -n "$LANDO_PROJECT" ]; then
-  # If inside a container, use npm directly.
-  echo "npm"
-elif [ -d ".ddev/php" ] && command -v ddev &> /dev/null; then
-  # If outside a DDEV container, use ddev npm.
-  echo "ddev npm"
-elif [ -e .lando.yml ]  && command -v lando &> /dev/null; then
-  # If outside a Lando container, use lando npm.
-  echo "lando npm"
+  echo "Compiling the theme using the npm within ddev/lando..." >&2
+  NPM_CMD="npm"
+elif [ -d "$DIR/../../../.ddev/php" ] && [ "$HSDP_COMPILE_ENVIRONMENT" == "ddev" ] && command -v ddev &> /dev/null; then
+  echo "Compiling the theme by calling 'ddev npm'..." >&2
+  NPM_CMD="ddev npm"
+elif [ -e .lando.yml ]  && [ "$HSDP_COMPILE_ENVIRONMENT" == "lando" ] && command -v lando &> /dev/null; then
+  echo "Compiling the theme by calling 'lando npm'..." >&2
+  NPM_CMD="lando npm"
 else
-  echo "npm"
+  echo "Compiling the theme by using npm on bare metal..." >&2
+  NPM_CMD="npm"
 fi
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit 1
 
 if [ -d "$HOME/.nvm" ] && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && command -v nvm &> /dev/null; then
   echo "Installing correct version of node..." >&2
@@ -23,4 +27,13 @@ fi
 if [ ! -d node_modules ]; then
   echo "Installing npm dependencies..." >&2
   ${NPM_CMD} ci
+  if ! ${NPM_CMD} ci; then
+    echo
+    echo "Installing NPM_CMD dependencies failed.  Some failures may be due to where you are compiling the code.
+    See the root README.md about alternate ways of compiling the theme in/out of ddev/lando."  >&2
+    exit 1
+  fi
 fi
+
+# Callers source this file, so export NPM_CMD for use in the parent shell.
+export NPM_CMD

--- a/hooks/common/theme/theme-get-command.sh
+++ b/hooks/common/theme/theme-get-command.sh
@@ -2,7 +2,12 @@
 
 DIR="$(dirname "$(realpath "$0")")"
 
-echo "HSDP_COMPILE_ENVIRONMENT: $HSDP_COMPILE_ENVIRONMENT" >&2
+if [ -n "$HSDP_COMPILE_ENVIRONMENT" ]; then
+  echo "HSDP_COMPILE_ENVIRONMENT: $HSDP_COMPILE_ENVIRONMENT" >&2
+else
+  echo "HSDP_COMPILE_ENVIRONMENT: <unset>" >&2
+fi
+
 if [ -n "$DDEV_PROJECT" ] || [ -n "$LANDO_PROJECT" ]; then
   echo "Compiling the theme using the npm within ddev/lando..." >&2
   NPM_CMD="npm"

--- a/hooks/common/theme/theme-lint.sh
+++ b/hooks/common/theme/theme-lint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 DIR="$(dirname "$(realpath "$0")")"
-NPM_CMD=$("$DIR/theme-get-command.sh")
+. "$DIR/theme-get-command.sh"
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit
 
 echo "Running linters on the theme..."
 ${NPM_CMD} run lint

--- a/hooks/common/theme/theme-test.sh
+++ b/hooks/common/theme/theme-test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 DIR="$(dirname "$(realpath "$0")")"
-NPM_CMD=$("$DIR/theme-get-command.sh")
+. "$DIR/theme-get-command.sh"
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit
 
 echo "Running theme tests..."
 ${NPM_CMD} run test

--- a/hooks/common/theme/theme-visreg.sh
+++ b/hooks/common/theme/theme-visreg.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 DIR="$(dirname "$(realpath "$0")")"
-NPM_CMD=$("$DIR/theme-get-command.sh")
+. "$DIR/theme-get-command.sh"
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit
 
 # Percy Visual Regression Testing requires a .env file with the Percy Token in the theme folder.
 if [ -e .env ]; then

--- a/hooks/common/theme/theme-watch.sh
+++ b/hooks/common/theme/theme-watch.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 DIR="$(dirname "$(realpath "$0")")"
-NPM_CMD=$("$DIR/theme-get-command.sh")
+. "$DIR/theme-get-command.sh"
 
-cd docroot/themes/humsci/humsci_basic || exit
+cd "$DIR"/../../../docroot/themes/humsci/humsci_basic || exit
 
 echo "Watching for changes in the theme..."
 ${NPM_CMD} start


### PR DESCRIPTION
# Summary
- automatically determine the environment to run in (allow overrides).  
- correctly use the proper version of NPM/node across scripts

## Backstory
Build was not completing on Tugboat.  

## Need Review By (Date)
ASAP

## Urgency
High

## Steps to Test
locally, try
1. `npm run theme-build`
It should automatically figure out how to run without any errors.
2. 
  - `export HSDP_COMPILE_ENVIRONMENT=ddev`
  - `npm run theme-build`
  You should see that it is choosing to run within ddev
3.
  - `unset HSDP_COMPILE_ENVIRONMENT`
  - `nvm use 16
  - `npm run theme-build`
  - You should see that it's now running on bare metal again.  If it was successful that means that it successfully changed the version of npm within the scope of the script(s). 

