### PR TITLE
SHS-6588: Padding removed on Spotlight text in Full Width

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.spotlight.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.spotlight.scss
@@ -194,21 +194,20 @@ $container-small: 576px;
 
   // Adjustments for expanded full width spotlights in traditional theme.
   @include hb-traditional {
-    .hs-full-width &,
+    .hs-full-width .hb-spotlight--expanded.hb-spotlight--image-default &,
     .hb-three-column--no-sidebar
       .paragraph--type--hs-sptlght-slder.paragraph--style--full-width
-      .hb-spotlight--expanded
+      .hb-spotlight--expanded.hb-spotlight--image-default
       & {
       @container spotlight (width > #{$container-xlarge}) {
         padding-inline-start: 0;
       }
     }
 
-    .hs-full-width .hb-spotlight--image-left &,
+    .hs-full-width .hb-spotlight--expanded.hb-spotlight--image-left &,
     .hb-three-column--no-sidebar
       .paragraph--type--hs-sptlght-slder.paragraph--style--full-width
-      .hb-splotlight--image-left
-      .hb-spotlight--expanded
+      .hb-spotlight--expanded.hb-spotlight--image-left
       & {
       @container spotlight (width > #{$container-xlarge}) {
         padding-inline-end: 0;
@@ -293,6 +292,17 @@ $container-small: 576px;
     @include hb-themes(('colorful', 'airy')) {
       @container spotlight (width > #{$container-xlarge}) {
         width: calc(100% + #{hb-calculate-rems(32px)});
+      }
+    }
+  }
+
+  .hs-full-width .hb-spotlight--expanded.hb-spotlight--image-default &,
+  .hb-three-column--no-sidebar
+    .paragraph--type--hs-sptlght-slder.paragraph--style--full-width
+    .hb-spotlight--expanded.hb-spotlight--image-default
+    & {
+    @include hb-themes(('colorful', 'airy')) {
+      @container spotlight (width > #{$container-xlarge}) {
         margin: 0;
       }
     }


### PR DESCRIPTION
# Summary
- Fix padding in expanded full width spotlights

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6588)

## Need Review By (Date)
03/18

## Urgency
high

## Steps to Test

For both Colorful and Traditional:
(If you want to skip the content creation steps, visit the following pages: [Colorful](https://hs-colorful-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/full-width-spotlight-test), [Traditional](https://hs-traditional-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/full-width-spotlight-test))

1. Log into the site ([Colorful](https://hs-colorful-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/user), [Traditional](https://hs-traditional-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/user))
2. Create a Flexible Page ([Colorful](https://hs-colorful-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/node/add/hs_basic_page), [Traditional](https://hs-traditional-hzf5fmqhrgctorextyvqy9plcaivlekh.tugboatqa.com/node/add/hs_basic_page))
3. In the Full-width region, add a "Spotlight(s)" component. Inside, add 2 expanded spotlights, one right aligned and the other one left aligned.
4. Repeat the previous step in the Main Content region. Set the value of the "Background Color Width" field to "Full Width"
5. Save the page and confirm that paddings and alignment for the the left and right image spotlights, in both regions, looks as expected

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213552482133328