### PR TITLE
SHS-6548: Get DDev working well with Acquia Cloud next, and other modern versions

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -128,8 +128,8 @@ additional_hostnames:
   - womensleadershipcp
 additional_fqdns: []
 database:
-    type: mysql
-    version: "5.7"
+  type: mysql
+  version: "8.4"
 use_dns_when_possible: true
 disable_settings_management: true
 composer_version: "2.8.2"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -135,7 +135,7 @@ additional_hostnames:
 additional_fqdns: []
 database:
   type: mysql
-  version: "8.4"
+  version: "8.0"
 use_dns_when_possible: true
 disable_settings_management: true
 composer_version: "2.8.2"
@@ -143,6 +143,9 @@ web_environment: []
 corepack_enable: false
 additional_services:
   - selenium
+upload_dirs:
+  - sites/*/files
+  - themes/humsci/humsci_basic/node_modules
 
 hooks:
   post-start:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -5,39 +5,33 @@ php_version: "8.3"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames:
-  - ethicsinsociety
-  - anthropology
-  - archaeology
-  - art
-  - biology
-  - chemistry
-  - classics
-  - economics
-  - english
-  - history
-  - mathematics
-  - philosophy
-  - physics
-  - psychology
-  - sociology
   - aaai
   - aaas
   - aarcs
   - africanstudies
   - amstudies
   - anthrohandbook
+  - anthropology
+  - archaeology
+  - art
   - artexhibitions
+  - artgradguide
   - arthandbook
   - aviditacharya-humsci
   - bingschool
+  - biocapstoneshowcase
+  - biology
   - biologyvirtualshowcase
   - bsurp
   - buddhiststudies
+  - buddhiststudies2026
   - cas
   - ccsre
   - ceas
   - cesta
+  - chemistry
   - clas
+  - classics
   - cmbprogram
   - cmems
   - cqmd
@@ -51,7 +45,11 @@ additional_hostnames:
   - dsresearch
   - duboislab
   - ealc
+  - economics
   - em1060
+  - english
+  - environmentalhumanities
+  - ethicsinsociety
   - facultyaffairs-humsci
   - feminist
   - finance-humsci
@@ -61,6 +59,7 @@ additional_hostnames:
   - globalcurrents
   - grandtour
   - gus-humsci
+  - history
   - hps
   - hs-colorful
   - hs-design
@@ -92,18 +91,23 @@ additional_hostnames:
   - language
   - linguistics
   - lowe
+  - mathematics
   - mcs
   - medicalhumanities
   - memorylab
   - middleeast
   - morrisoninstitute
   - mrc
+  - mrc2025
   - mtl
   - music
   - philit
+  - philosophy
+  - physics
   - planning-humsci
   - politicalscience
   - popstudies
+  - psychology
   - ptarmigan
   - publichumanities
   - publicpolicy
@@ -114,6 +118,7 @@ additional_hostnames:
   - shenlab
   - sitp
   - siw
+  - sociology
   - southasia
   - stanfordsciencefellows
   - statistics
@@ -123,6 +128,7 @@ additional_hostnames:
   - tessier-lavigne-lab
   - texttechnologies
   - urbanstudies
+  - vpnl
   - west
   - womensleadership
   - womensleadershipcp

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Install Chromium for Codeception testing (works on ARM64)
-RUN apt-get update && apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
     chromium \
     chromium-driver \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Summary
- Update ddev MySQL to version 8.0 to match acquia
- Fix issue during `ddev start` when installing chromium
- Update and sort alphabetically to ddev hostnames

## Backstory
- [ClickUp Ticket](https://app.clickup.com/t/36718269/SHS-6548)

## Need Review By (Date)
03/18

## Urgency
medium

## Steps to Test
1. Re-create the ddev containers: `ddev delete--omit-snapshot && ddev start` (this is needed because the db version changed).
3. Setup a few sites using `blt` (E.g. `ddev blt drupal:sync --site=hs_colorful`). Confirm that the sites are installed correctly and that there are no issues when pulling the db from Acquia.
4. **Bonus:** Confirm that local codeception tests work as expected (Follow instructions on the [ddev readme](https://github.com/SU-HSDO/suhumsci/blob/develop/.ddev/DDEV-README.md)).
