### PR TITLE
HSD8-1849: Restore environment-specific config locking and prefixing logic

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -35,6 +35,8 @@ ignored_config_entities:
   - 'menu_position.menu_position_rule.*'
   - 'migrate_plus.migration.*:status'
   - 'migrate_plus.migration.custm*'
+  - 'purge_users.purge_users_policy.*'
+  - purge_users.settings
   - 'samlauth.authentication:map_users_roles'
   - 'single_content_sync.settings:allowed_entity_types.node'
   - stanford_samlauth.settings
@@ -47,5 +49,3 @@ ignored_config_entities:
   - 'user.settings:register'
   - views.view.feeds_feed
   - 'views.view.hs_*:status'
-  - purge_users.settings
-  - 'purge_users.purge_users_policy.*'

--- a/config/default/hs_config_prefix.settings.yml
+++ b/config/default/hs_config_prefix.settings.yml
@@ -1,3 +1,3 @@
 _core:
   default_config_hash: 7IIiZ2X-1vn8TFP1bP1PccDc7QgdYCxO2Kbi62fyzPU
-prefix: custm_
+prefix: ''

--- a/config/envs/prod/config_split.patch.hs_config_prefix.settings.yml
+++ b/config/envs/prod/config_split.patch.hs_config_prefix.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  prefix: custm_
+removing:
+  prefix: ''

--- a/docroot/modules/humsci/hs_config_readonly/hs_config_readonly.services.yml
+++ b/docroot/modules/humsci/hs_config_readonly/hs_config_readonly.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\hs_config_readonly\EventSubscriber\ConfigReadOnlyEventSubscriber
     decorates: config_readonly_form_subscriber
     public: false
-    arguments: ['@module_handler', '@config.factory', '@entity_type.manager']
+    arguments: ['@module_handler', '@config.factory', '@config.storage.sync', '@entity_type.manager']

--- a/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriber.php
+++ b/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriber.php
@@ -183,17 +183,27 @@ class ConfigReadOnlyEventSubscriber extends ConfigReadOnlyEventSubscriberBase {
    */
   protected function configIsLocked($config) {
     $config = is_array($config) ? $config : [$config];
+
     $config_ignore_settings = $this->configFactory->get('config_ignore.settings');
     $config_ignore = ConfigIgnoreConfig::fromConfig($config_ignore_settings);
 
     foreach ($config as $config_name) {
-      // If isIgnored returns FALSE, the config is NOT ignored and should be
-      // locked.
-      if ($config_ignore->isIgnored('', $config_name, 'import', 'update') === FALSE) {
-        return TRUE;
+      // If the configuration does not exist in the config storage, do not lock
+      // the form. This allows configuration in the active storage, which only
+      // exists on the current site and has not been exported, to be edited. It
+      // also unlocks creation forms because no configuration exists yet in the
+      // storage.
+      if (!$this->configStorage->exists($config_name)) {
+        return FALSE;
+      }
+      // If the config is ignored it should be editable and not locked.
+      if ($config_ignore->isIgnored('', $config_name, 'import', 'update')) {
+        return FALSE;
       }
     }
-    return FALSE;
+    // If something is not unlocked deliberately with the conditions above, then
+    // lock it.
+    return TRUE;
   }
 
   /**

--- a/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriberBase.php
+++ b/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriberBase.php
@@ -3,9 +3,10 @@
 namespace Drupal\hs_config_readonly\EventSubscriber;
 
 use Drupal\config_readonly\ConfigReadonlyWhitelistTrait;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\config_readonly\ReadOnlyFormEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
@@ -31,6 +32,13 @@ abstract class ConfigReadOnlyEventSubscriberBase implements EventSubscriberInter
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $configFactory;
+
+  /**
+  * Config filter storage service.
+  *
+  * @var \Drupal\Core\Config\StorageInterface
+  */
+  protected $configStorage;
 
   /**
    * Ignore the configurations form these modules.
@@ -65,8 +73,9 @@ abstract class ConfigReadOnlyEventSubscriberBase implements EventSubscriberInter
   /**
    * {@inheritdoc}
    */
-  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, StorageInterface $config_storage, EntityTypeManagerInterface $entity_type_manager) {
     $this->moduleHandler = $module_handler;
+    $this->configStorage = $config_storage;
     $config = $config_factory->get('hs_config_readonly.settings');
     $this->excludedModules = $config->get('excluded_modules') ?: $this->excludedModules;
     $this->readOnlyFormIds = $config->get('form_ids') ?: $this->readOnlyFormIds;

--- a/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriberBase.php
+++ b/docroot/modules/humsci/hs_config_readonly/src/EventSubscriber/ConfigReadOnlyEventSubscriberBase.php
@@ -34,10 +34,10 @@ abstract class ConfigReadOnlyEventSubscriberBase implements EventSubscriberInter
   protected $configFactory;
 
   /**
-  * Config filter storage service.
-  *
-  * @var \Drupal\Core\Config\StorageInterface
-  */
+   * Config filter storage service.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
   protected $configStorage;
 
   /**

--- a/docroot/modules/humsci/hs_config_readonly/tests/src/Unit/EventSubscriber/ConfigReadOnlyEventSubscriberTest.php
+++ b/docroot/modules/humsci/hs_config_readonly/tests/src/Unit/EventSubscriber/ConfigReadOnlyEventSubscriberTest.php
@@ -47,6 +47,10 @@ class ConfigReadOnlyEventSubscriberTest extends UnitTestCase {
       ->willReturn($config);
 
     $config_storage = $this->createMock(StorageInterface::class);
+    $config_storage->method('exists')
+      ->willReturnCallback(function ($name) {
+        return $name !== 'nonexistent.config';
+    });
 
     $wizard_config = $this->createMock(ConfigEntityInterface::class);
     $wizard_config->method('getConfigDependencyName')
@@ -147,6 +151,11 @@ class ConfigReadOnlyEventSubscriberTest extends UnitTestCase {
     $event = new ReadOnlyFormEvent($form_state, $form);
     $this->eventSubscriber->onFormAlter($event);
     $this->assertFalse($event->isFormReadOnly());
+
+    $form_state->setBuildInfo(['callback_object' => new TestConfigFormCallbackObject('nonexistent.config')]);
+    $event = new ReadOnlyFormEvent($form_state, $form);
+    $this->eventSubscriber->onFormAlter($event);
+    $this->assertFalse($event->isFormReadOnly());    
   }
 
   /**

--- a/docroot/modules/humsci/hs_config_readonly/tests/src/Unit/EventSubscriber/ConfigReadOnlyEventSubscriberTest.php
+++ b/docroot/modules/humsci/hs_config_readonly/tests/src/Unit/EventSubscriber/ConfigReadOnlyEventSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\hs_config_readonly\Unit\EventSubscriber;
 use Drupal\config_readonly\ReadOnlyFormEvent;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityStorageBase;
@@ -45,6 +46,8 @@ class ConfigReadOnlyEventSubscriberTest extends UnitTestCase {
     $config_factory->method('get')
       ->willReturn($config);
 
+    $config_storage = $this->createMock(StorageInterface::class);
+
     $wizard_config = $this->createMock(ConfigEntityInterface::class);
     $wizard_config->method('getConfigDependencyName')
       ->willReturn('locked.config.test');
@@ -55,7 +58,7 @@ class ConfigReadOnlyEventSubscriberTest extends UnitTestCase {
     $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
     $entity_type_manager->method('getStorage')->willReturn($entity_storage);
 
-    $event_subscriber = new ConfigReadOnlyEventSubscriber($module_handler, $config_factory, $entity_type_manager);
+    $event_subscriber = new ConfigReadOnlyEventSubscriber($module_handler, $config_factory, $config_storage, $entity_type_manager);
 
     $this->eventSubscriber = $event_subscriber;
   }


### PR DESCRIPTION
# Summary
This PR restores correct `hs_config_readonly` and config prefixing behavior after the config module updates made in #2106. It ensures that only production sites use the `custm_` prefix for content types and views, and restores the previous behavior for unlocking forms for new and custom configuration entities.

## Backstory
After the recent release and deployment, custom forms that should be editable became read-only on production H&S sites. The refactor of the `hs_config_readonly` module to use `config_ignore`'s `ConfigIgnoreConfig` class removed the previous logic that allowed creation and editing of new/custom configs. The previous logic only locked forms for configuration that existed in the config sync storage; if a config did not exist in the sync storage (such as new or custom configs created on the site), the form was editable. The new logic did not check for the existence of the config in the sync storage, causing all forms to be locked unless explicitly ignored by `config_ignore`, which is only part of the `hs_config_readonly` intended behavior. 

Additionally, the `custm_` prefix was being applied everywhere due to a change in default config, rather than just on production. The changes here limit the prefix to only production, as it was previously.

## Need Review By (Date)
ASAP

## Urgency
High

## Steps to Test
1. On a local or non-prod site, create a new content type and add fields. Confirm no `custm_` prefix is applied and forms are editable.
2. On a production or prod-split-enabled site, create a new content type and add fields. Confirm `custm_` prefix is applied and forms are editable for new/custom configs.
3. Confirm that existing configs not ignored by `config_ignore` are locked/read-only.
4. Confirm that configs ignored by `config_ignore` are editable.
5. Confirm that creation forms (for new content types, fields, views) are always editable.
6. Confirm that the config prefixing and readonly logic matches the intended environment-specific behavior.
