### PR TITLE
SHS-6573: Remove Mailing Address field from default Person layout

### DIFF
--- a/config/default/core.entity_view_display.node.hs_person.default.yml
+++ b/config/default/core.entity_view_display.node.hs_person.default.yml
@@ -479,23 +479,6 @@ third_party_settings:
                   context_mapping:
                     entity: layout_builder.entity
                     view_mode: view_mode
-                6ab54890-a14b-4b0c-b2f1-640f2ab6dcfc:
-                  id: 'field_block:node:hs_person:field_hs_person_mail'
-                  label: 'Mailing Address'
-                  provider: layout_builder
-                  label_display: ''
-                  formatter:
-                    label: above
-                    type: address_default
-                    settings: {  }
-                    third_party_settings:
-                      field_formatter_class:
-                        class: ''
-                      hs_field_helpers:
-                        inline_contents: 0
-                  context_mapping:
-                    entity: layout_builder.entity
-                    view_mode: view_mode
                 2605fdc0-9b10-4a5b-86ed-161e8853abe7:
                   id: 'field_block:node:hs_person:field_hs_person_cv_link'
                   label: 'CV Link'


### PR DESCRIPTION
# Summary
Remove Mailing Address field from default Person layout

## Backstory
[SHS-6573](https://app.clickup.com/t/36718269/SHS-6573)

## Need Review By (Date)
03/17

## Urgency
low

## Steps to Test
1. If you create a new site
2. And you go to `/admin/structure/types/manage/hs_person/display/default/layout`, you should not see `field_hs_person_mail`  in the sidebar

<img width="1628" height="768" alt="image (1)" src="https://github.com/user-attachments/assets/7fbaea10-594c-4b1f-8cd3-dbbdac9f1f88" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213378974783062