### PR TITLE
HSD8-1852: Enable Curriculum Map Paragraph for Private Pages by Default

### DIFF
--- a/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
+++ b/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
@@ -32,6 +32,7 @@ settings:
       hs_priv_text_area: hs_priv_text_area
       hs_accordion: hs_accordion
       hs_clr_bnd: hs_clr_bnd
+      hs_cmap: hs_cmap
       hs_postcard: hs_postcard
       hs_priv_collection: hs_priv_collection
       hs_sptlght_slder: hs_sptlght_slder
@@ -39,63 +40,75 @@ settings:
     negate: 0
     target_bundles_drag_drop:
       hs_accordion:
-        weight: -44
+        weight: -48
         enabled: true
       hs_banner:
-        weight: -36
+        weight: -39
         enabled: false
       hs_callout_box:
-        weight: -32
+        weight: -36
         enabled: false
       hs_carousel:
-        weight: -38
+        weight: -41
         enabled: false
       hs_clr_bnd:
-        weight: -43
+        weight: -47
         enabled: true
-      hs_collection:
-        weight: -31
-        enabled: false
-      hs_gradient_hero:
-        weight: -30
-        enabled: false
-      hs_gradient_hero_slider:
-        weight: -29
-        enabled: false
-      hs_hero_image:
-        weight: -37
-        enabled: false
-      hs_postcard:
-        weight: -42
+      hs_cmap:
+        weight: -46
         enabled: true
-      hs_priv_collection:
-        weight: -41
-        enabled: true
-      hs_priv_text_area:
-        weight: -45
-        enabled: true
-      hs_spotlight:
-        weight: -26
-        enabled: false
-      hs_sptlght_slder:
-        weight: -40
-        enabled: true
-      hs_testimonial:
+      hs_cmap_qtr:
         weight: -28
         enabled: false
-      hs_text_area:
+      hs_cmap_qtr_crs:
+        weight: -27
+        enabled: false
+      hs_cmap_year:
+        weight: -26
+        enabled: false
+      hs_collection:
         weight: -35
         enabled: false
-      hs_timeline:
-        weight: -39
-        enabled: true
-      hs_timeline_item:
-        weight: -25
-        enabled: false
-      hs_view:
+      hs_gradient_hero:
         weight: -34
         enabled: false
+      hs_gradient_hero_slider:
+        weight: -33
+        enabled: false
+      hs_hero_image:
+        weight: -40
+        enabled: false
+      hs_postcard:
+        weight: -45
+        enabled: true
+      hs_priv_collection:
+        weight: -44
+        enabled: true
+      hs_priv_text_area:
+        weight: -49
+        enabled: true
+      hs_spotlight:
+        weight: -31
+        enabled: false
+      hs_sptlght_slder:
+        weight: -43
+        enabled: true
+      hs_testimonial:
+        weight: -32
+        enabled: false
+      hs_text_area:
+        weight: -38
+        enabled: false
+      hs_timeline:
+        weight: -42
+        enabled: true
+      hs_timeline_item:
+        weight: -30
+        enabled: false
+      hs_view:
+        weight: -37
+        enabled: false
       stanford_gallery:
-        weight: -24
+        weight: -29
         enabled: false
 field_type: entity_reference_revisions

--- a/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
+++ b/config/default/field.field.node.hs_private_page.field_hs_priv_page_components.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.hs_private_page
     - paragraphs.paragraphs_type.hs_accordion
     - paragraphs.paragraphs_type.hs_clr_bnd
+    - paragraphs.paragraphs_type.hs_cmap
     - paragraphs.paragraphs_type.hs_postcard
     - paragraphs.paragraphs_type.hs_priv_collection
     - paragraphs.paragraphs_type.hs_priv_text_area


### PR DESCRIPTION
# Summary
This PR updates the default configuration to enable the Curriculum Map (`hs_cmap`) component as an option on Private Pages. This allows site builders to add Curriculum Maps to Private Pages by default on new sites.

## Backstory
[HSD8-1852](https://stanfordits.atlassian.net/browse/HSD8-1852): Update Defaults to include Curriculum Map component as an option on Private Pages
Previously, the Curriculum Map component was not available for Private Pages. There were no blockers to enabling it, and it was requested to make this component available by default for new sites. Existing sites will need to be updated manually as needed. This change updates the field configuration to include Curriculum Maps and adjusts the available components and their weights accordingly.

## Urgency
medium

## Steps to Test
1. Create or edit a Private Page (node type: hs_private_page).
2. In the "Components" field, verify that "Curriculum Map" is now available as an option.
3. Add a Curriculum Map component to the page and save.
4. Confirm that the Curriculum Map displays as expected on the Private Page.



[HSD8-1852]: https://stanfordits.atlassian.net/browse/HSD8-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ