### PR TITLE
Restore toggle modules configuration for CI environments

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -20,6 +20,11 @@ drush:
     prod: '${project.machine_name}.prod'
   default_alias: '${drush.aliases.local}'
 modules:
+  ci:
+    enable: {  }
+    uninstall:
+      - purge
+      - acquia_connector
   local:
     enable: {  }
     uninstall:


### PR DESCRIPTION
# Summary
The Tugboat preview is broken. This is due to modules not getting uninstalled before config import. This is typically handled by `blt drupal:toggle:modules`. The command is still being triggered, however the configuration for modules to uninstall in `ci` environments was removed in #2106 . This restores it and should fix the Tugboat previews.