### PR TITLE
Add test default site sync workflow and update all workflows from MySQL 5.7 to 8.0

### DIFF
--- a/.github/workflows/acquia-cleanup.yml
+++ b/.github/workflows/acquia-cleanup.yml
@@ -39,6 +39,5 @@ jobs:
           git config --global user.name "Github Actions" &&
           ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
-          blt blt:telemetry:disable --no-interaction &&
           blt humsci:clean-backups &&
           blt humsci:clean-branches

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -23,7 +23,7 @@ jobs:
       DRUPAL_DATABASE_HOST: mysql
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -4,29 +4,10 @@ on:
     types: [opened, synchronize, reopened]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-env:
-  themePath: docroot/themes/humsci/humsci_basic
+  cancel-in-progress: true 
 jobs:
-  lint_theme:
-    runs-on: ubuntu-latest
-    container:
-      image: pookmish/drupal8ci:php8.3
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node.js from .nvmrc
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: 'npm'
-          cache-dependency-path: ${{ env.themePath }}/package-lock.json
-      - name: Install theme dependencies
-        run: npm ci --prefix $themePath
-      - name: Lint Theme
-        run: npm run lint --prefix $themePath
   test_site_sync:
     runs-on: ubuntu-latest
-    needs: lint_theme
     container:
       image: pookmish/drupal8ci:php8.3
       options: '--network-alias drupal8ci'
@@ -36,6 +17,7 @@ jobs:
       DRUPAL_DATABASE_USERNAME: drupal
       DRUPAL_DATABASE_PASSWORD: drupal
       DRUPAL_DATABASE_HOST: mysql
+      themePath: docroot/themes/humsci/humsci_basic
     services:
       mysql:
         image: mysql:5.7
@@ -55,6 +37,10 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
           cache-dependency-path: ${{ env.themePath }}/package-lock.json
+      - name: Install theme dependencies
+        run: npm ci --prefix $themePath
+      - name: Lint Theme
+        run: npm run lint --prefix $themePath
       - name: Restore Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -63,7 +63,7 @@ jobs:
           mysql -h mysql -P 3306 -u root -pdrupal -e 'SET GLOBAL max_allowed_packet=67108864;' &&
           rm -rf /var/www/html &&
           ln -snf $GITHUB_WORKSPACE /var/www/html &&
-          ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
+          ssh-keyscan -t rsa humscigryphon.ssh.prod.acquia-sites.com >> /root/.ssh/known_hosts &&
           composer install -n &&
           blt settings &&
           mkdir -p docroot/sites/default/files &&

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -63,6 +63,7 @@ jobs:
           mysql -h mysql -P 3306 -u root -pdrupal -e 'SET GLOBAL max_allowed_packet=67108864;' &&
           rm -rf /var/www/html &&
           ln -snf $GITHUB_WORKSPACE /var/www/html &&
+          ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
           blt settings &&
           mkdir -p docroot/sites/default/files &&

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -20,7 +20,7 @@ jobs:
       themePath: docroot/themes/humsci/humsci_basic
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -1,0 +1,77 @@
+name: Test Default Site Sync
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  themePath: docroot/themes/humsci/humsci_basic
+jobs:
+    lint_theme:
+    runs-on: ubuntu-latest
+    container:
+      image: pookmish/drupal8ci:php8.3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+          cache-dependency-path: ${{ env.themePath }}/package-lock.json
+      - name: Install theme dependencies
+        run: npm ci --prefix $themePath
+      - name: Lint Theme
+        run: npm run lint --prefix $themePath
+  test_site_sync:
+    runs-on: ubuntu-latest
+    needs: lint_theme
+    container:
+      image: pookmish/drupal8ci:php8.3
+      options: '--network-alias drupal8ci'
+    env:
+      REAL_AES_ENCRYPTION: ${{secrets.REAL_AES_ENCRYPTION}}
+      DRUPAL_DATABASE_NAME: drupal
+      DRUPAL_DATABASE_USERNAME: drupal
+      DRUPAL_DATABASE_PASSWORD: drupal
+      DRUPAL_DATABASE_HOST: mysql
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: drupal
+          MYSQL_USER: drupal
+          MYSQL_PASSWORD: drupal
+          MYSQL_ROOT_PASSWORD: drupal
+        ports:
+          - 33306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+          cache-dependency-path: ${{ env.themePath }}/package-lock.json
+      - name: Restore Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+            docroot/core
+            docroot/libraries
+            docroot/modules/contrib
+          key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
+      - run: git config --system --add safe.directory '*'
+      - name: Install Site
+        run: |
+          mysql -h mysql -P 3306 -u root -pdrupal -e 'SET GLOBAL max_allowed_packet=67108864;' &&
+          rm -rf /var/www/html &&
+          ln -snf $GITHUB_WORKSPACE /var/www/html &&
+          composer install -n &&
+          blt settings &&
+          mkdir -p docroot/sites/default/files &&
+          chmod -R 777 docroot/sites/default/files/ &&
+          blt drupal:sync --site=default -n

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -8,7 +8,7 @@ concurrency:
 env:
   themePath: docroot/themes/humsci/humsci_basic
 jobs:
-    lint_theme:
+  lint_theme:
     runs-on: ubuntu-latest
     container:
       image: pookmish/drupal8ci:php8.3

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -30,6 +30,13 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          if_key_exists: fail
       - uses: actions/checkout@v4
       - name: Set up Node.js from .nvmrc
         uses: actions/setup-node@v6
@@ -51,7 +58,7 @@ jobs:
             docroot/modules/contrib
           key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
       - run: git config --system --add safe.directory '*'
-      - name: Install Site
+      - name: Sync Default Site
         run: |
           mysql -h mysql -P 3306 -u root -pdrupal -e 'SET GLOBAL max_allowed_packet=67108864;' &&
           rm -rf /var/www/html &&

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -21,7 +21,7 @@ jobs:
       DRUPAL_DATABASE_HOST: mysql
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal
@@ -94,7 +94,7 @@ jobs:
         image: selenium/standalone-chrome:130.0
         options: '--shm-size="2g"'
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal
@@ -164,7 +164,7 @@ jobs:
         image: selenium/standalone-chrome:130.0
         options: '--shm-size="2g"'
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -262,5 +262,4 @@ jobs:
           git config --global user.name "Github Actions" &&
           ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
-          blt blt:telemetry:disable --no-interaction &&
           blt deploy -n


### PR DESCRIPTION
# Summary
Adds a GitHub Actions workflow to test syncing the default Drupal site on every PR. Updates MySQL to 8.0 for all workflows and ensures SSH known_hosts includes the correct Acquia host for Drush site syncs.

## Backstory
Previously, site syncs were not automatically tested on PRs. This PR introduces a workflow to test `blt drupal:sync` for the default site, ensuring database/config updates are validated on every PR. It also updates all workflows to use MySQL 8.0 and adds the correct Acquia SSH host for Drush operations

## Urgency
medium
