### PR TITLE
SHS-6593: Resolve hidden focusable content in caption toggle

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
@@ -42,11 +42,18 @@
 
             if (collapsible) {
               caption.classList.add('collapsible-caption');
+
+              // Keep the button focusable and accessible.
+              toggleButton.removeAttribute('tabindex');
+
               if (!toggleButton.classList.contains('is-open')) {
                 content.classList.add('visually-hidden');
               } else {
                 caption.classList.add('is-open');
               }
+            } else {
+              // Remove from keyboard navigation when not collapsible.
+              toggleButton.setAttribute('tabindex', '-1');
             }
           });
         };

--- a/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
@@ -45,6 +45,7 @@
       type="button"
       class="toggle-caption__toggle"
       aria-hidden="true"
+      tabindex="-1"
     >
     </button>
     <div class="toggle-caption__content">


### PR DESCRIPTION
# Summary
Resolve hidden focusable content in caption toggle

## Backstory
[SHS-6593](https://app.clickup.com/t/36718269/SHS-6593)

## Steps to Test

1. Log in to the Tugboat test site ([Colorful](https://hs-colorful-znbbpfnrkjtv4a8rn1dwzyffvrwohypr.tugboatqa.com/user), [Traditional](https://hs-traditional-znbbpfnrkjtv4a8rn1dwzyffvrwohypr.tugboatqa.com/user)).
2. Navigate to Components in the main menu and select a Collection item.
3. In the sidebar, go to `Collections with Postcards` → `Vertical Cards`.
4. Scroll to the `Image, Body & Link` section and locate a card without the info icon in the bottom-right corner.
5. Inspect the element and verify that the hidden button has tabindex="-1".
6. Confirm that the button is not reachable via keyboard navigation (e.g., using the Tab key).
7. Repeat the validation on a card with the info icon to ensure the button is focusable and behaves as expected.

<img width="1728" height="910" alt="image" src="https://github.com/user-attachments/assets/7e5bf055-ec38-40ad-8ed6-7a27909ae999" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213706922452355