### PR TITLE
SHS-6603: Remove Quarter, Course/Requirement, and Academic Year from components available in Collections

### DIFF
--- a/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
+++ b/config/default/field.field.paragraph.hs_collection.field_hs_collection_items.yml
@@ -7,6 +7,9 @@ dependencies:
     - paragraphs.paragraphs_type.hs_callout_box
     - paragraphs.paragraphs_type.hs_carousel
     - paragraphs.paragraphs_type.hs_clr_bnd
+    - paragraphs.paragraphs_type.hs_cmap_qtr
+    - paragraphs.paragraphs_type.hs_cmap_qtr_crs
+    - paragraphs.paragraphs_type.hs_cmap_year
     - paragraphs.paragraphs_type.hs_collection
     - paragraphs.paragraphs_type.hs_gradient_hero
     - paragraphs.paragraphs_type.hs_priv_collection
@@ -40,6 +43,9 @@ settings:
       hs_priv_text_area: hs_priv_text_area
       hs_sptlght_slder: hs_sptlght_slder
       hs_timeline_item: hs_timeline_item
+      hs_cmap_qtr: hs_cmap_qtr
+      hs_cmap_qtr_crs: hs_cmap_qtr_crs
+      hs_cmap_year: hs_cmap_year
     negate: 1
     target_bundles_drag_drop:
       hs_accordion:
@@ -56,6 +62,18 @@ settings:
         enabled: true
       hs_clr_bnd:
         weight: -42
+        enabled: true
+      hs_cmap:
+        weight: 30
+        enabled: false
+      hs_cmap_qtr:
+        weight: 31
+        enabled: true
+      hs_cmap_qtr_crs:
+        weight: 32
+        enabled: true
+      hs_cmap_year:
+        weight: 33
         enabled: true
       hs_collection:
         weight: -41

--- a/config/envs/local/config_split.patch.dblog.settings.yml
+++ b/config/envs/local/config_split.patch.dblog.settings.yml
@@ -1,0 +1,4 @@
+adding:
+  row_limit: 1000
+removing:
+  row_limit: 100

--- a/config/envs/local/config_split.patch.dblog.settings.yml
+++ b/config/envs/local/config_split.patch.dblog.settings.yml
@@ -1,4 +1,0 @@
-adding:
-  row_limit: 1000
-removing:
-  row_limit: 100

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -708,8 +708,7 @@ function hs_paragraph_types_update_10019(&$sandbox) {
 }
 
 /**
- * Disable Quarter, Course/Requirement, and Academic Year
- * from collections and private collections.
+ * Disable Quarter, Course, and Academic Year from collections and private collections.
  */
 function hs_paragraph_types_update_10020() {
   $bundles_to_hide = ['hs_cmap_qtr', 'hs_cmap_qtr_crs', 'hs_cmap_year'];

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -706,3 +706,20 @@ function hs_paragraph_types_update_10019(&$sandbox) {
 
   $sandbox['#finished'] = count($sandbox['ids']) ? 1 - count($sandbox['ids']) / $sandbox['total'] : 1;
 }
+
+/**
+ * Disable Quarter, Course/Requirement, and Academic Year from collections and private collections.
+ */
+function hs_paragraph_types_update_10020() {
+  $bundles_to_hide = ['hs_cmap_qtr', 'hs_cmap_qtr_crs', 'hs_cmap_year'];
+
+  // Hide cmap quarter/year bundles from collections.
+  _hs_paragraph_types_exclude_bundles_from_field('paragraph', 'hs_collection', 'field_hs_collection_items', $bundles_to_hide);
+  $result = t('Excluded bundles from hs_collection field_hs_collection_items: @bundles.', ['@bundles' => implode(', ', $bundles_to_hide)]);
+
+  // Hide cmap quarter/year bundles from private collections.
+  _hs_paragraph_types_exclude_bundles_from_field('paragraph', 'hs_priv_collection', 'field_hs_collection_items', $bundles_to_hide);
+  $result .= t('Excluded bundles from hs_priv_collection field_hs_collection_items: @bundles.', ['@bundles' => implode(', ', $bundles_to_hide)]);
+
+  return $result;
+}

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -708,7 +708,9 @@ function hs_paragraph_types_update_10019(&$sandbox) {
 }
 
 /**
- * Disable Quarter, Course, and Academic Year from collections and private collections.
+ * Disable Quarter, Course/Requirement, and Academic Year from collections.
+ *
+ * Also applies to private collections.
  */
 function hs_paragraph_types_update_10020() {
   $bundles_to_hide = ['hs_cmap_qtr', 'hs_cmap_qtr_crs', 'hs_cmap_year'];

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -590,10 +590,15 @@ function hs_paragraph_types_update_10016() {
  * Excludes specific bundles from a field in a given entity type and bundle.
  *
  * This function modifies the field configuration to hide selected paragraph
- * bundles for a specific field. It handles cases where fields are ignored
+ * bundles for a specific field. Only to be used on fields that are ignored
  * from configuration exports.
  *
  * Assumes that the field is set up to list the bundles that are _hidden_.
+ *
+ * @todo Make this smarter so that it detects whether the field is configured to
+ *   hide or show bundles.
+ * @todo Make this smarter to detect when being called on a field that is _not_
+ *   ignored from config.
  *
  * @param string $entity_type
  *   The entity type that owns the field (e.g., 'paragraph', 'node').
@@ -705,23 +710,4 @@ function hs_paragraph_types_update_10019(&$sandbox) {
   }
 
   $sandbox['#finished'] = count($sandbox['ids']) ? 1 - count($sandbox['ids']) / $sandbox['total'] : 1;
-}
-
-/**
- * Disable Quarter, Course/Requirement, and Academic Year from collections.
- *
- * Also applies to private collections.
- */
-function hs_paragraph_types_update_10020() {
-  $bundles_to_hide = ['hs_cmap_qtr', 'hs_cmap_qtr_crs', 'hs_cmap_year'];
-
-  // Hide cmap quarter/year bundles from collections.
-  _hs_paragraph_types_exclude_bundles_from_field('paragraph', 'hs_collection', 'field_hs_collection_items', $bundles_to_hide);
-  $result = t('Excluded bundles from hs_collection field_hs_collection_items: @bundles.', ['@bundles' => implode(', ', $bundles_to_hide)]);
-
-  // Hide cmap quarter/year bundles from private collections.
-  _hs_paragraph_types_exclude_bundles_from_field('paragraph', 'hs_priv_collection', 'field_hs_collection_items', $bundles_to_hide);
-  $result .= t('Excluded bundles from hs_priv_collection field_hs_collection_items: @bundles.', ['@bundles' => implode(', ', $bundles_to_hide)]);
-
-  return $result;
 }

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.install
@@ -708,7 +708,8 @@ function hs_paragraph_types_update_10019(&$sandbox) {
 }
 
 /**
- * Disable Quarter, Course/Requirement, and Academic Year from collections and private collections.
+ * Disable Quarter, Course/Requirement, and Academic Year
+ * from collections and private collections.
  */
 function hs_paragraph_types_update_10020() {
   $bundles_to_hide = ['hs_cmap_qtr', 'hs_cmap_qtr_crs', 'hs_cmap_year'];


### PR DESCRIPTION
# Summary
Remove Quarter, Course/Requirement, and Academic Year from components available in Collections

## Backstory
[SHS-6603](https://app.clickup.com/t/36718269/SHS-6603)

## Need Review By (Date)
14/04

## Urgency
medium

## Steps to Test
1. Log in to [Colorful](https://hs-colorful-u3s8ewfl7ayx9w6acemsm9merhmytjtq.tugboatqa.com/user/login) and [Traditional](https://hs-traditional-u3s8ewfl7ayx9w6acemsm9merhmytjtq.tugboatqa.com/user/login)
2. Create a Flexible Page
3. Add a `Collection` component
4. Add a component inside the `Collection`
5. Confirm the Quarter, Course/Requirement, and Academic Year components are not in the list of components available to add
6. Create a Private Page
7. And repeat the same but with a `Private Collection`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213739527060586