### PR TITLE
SHS-6620: Update ddev scripts to work with SWS Drupal config

### DIFF
--- a/.ddev/scripts/configure-local-settings.sh
+++ b/.ddev/scripts/configure-local-settings.sh
@@ -7,7 +7,7 @@ echo "Configuring local.settings.php files for DDEV environment..."
 
 # Update database username from 'root' to 'db'
 echo "Updating database username..."
-find /var/www/html/docroot/sites/ -name local.settings.php | xargs -I {} sed -i "s/'username' => 'root'/'username' => 'db'/g" {}
+find /var/www/html/docroot/sites/ -name local.settings.php | xargs -I {} sed -i "s/'username' => 'user'/'username' => 'db'/g" {}
 
 # Update database password from 'password' to 'db'
 echo "Updating database password..."

--- a/.ddev/scripts/create-local-databases.sh
+++ b/.ddev/scripts/create-local-databases.sh
@@ -10,7 +10,7 @@ for site_dir in /var/www/html/docroot/sites/*/; do
     site_name=$(basename "$site_dir")
     if [ "$site_name" != "default" ] && [ "$site_name" != "all" ] && [ "$site_name" != "example.sites.php" ]; then
       echo "Creating database for site: $site_name"
-      mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS suhumsci_$site_name;"
+      mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal_$site_name;"
     fi
   fi
 done


### PR DESCRIPTION
# Summary
- Update ddev scripts to match new config used with SWS Drush

## Backstory
- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6620)

## Need Review By (Date)
asap, ddev local envs are broken without these fixes

## Urgency
high

## Steps to Test
1. Setup a new environment from scratch following the [ddev readme](https://github.com/SU-HSDO/suhumsci/blob/develop/.ddev/DDEV-README.md) or execute the following commands in an existing environment:
    ```
    ddev delete --omit-snapshot && rm docroot/sites/*/settings/local.settings.php && ddev start
    ```
2. Sync one of the sites, using the `drupal:sync` drush command. For example:
    ```
    ddev drush drupal:sync --site=hs_colorful
    ```
3. Confirm that the site is correctly installed
 
