### PR TITLE
Require davidrjonas/composer-lock-diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "php": ">=8.3",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
+        "davidrjonas/composer-lock-diff": "^1.0",
         "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.2",
         "drupal/address": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bb94c8005753c667ad4967901e1fbc9",
+    "content-hash": "386c9b5146a3eca4289a00939a373b05",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -1133,6 +1133,46 @@
                 "source": "https://github.com/davidbarratt/custom-installer/tree/1.1.0"
             },
             "time": "2020-12-11T16:40:39+00:00"
+        },
+        {
+            "name": "davidrjonas/composer-lock-diff",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/davidrjonas/composer-lock-diff.git",
+                "reference": "829047c7116f923486a107ae5cd7a1ba50c873ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/davidrjonas/composer-lock-diff/zipball/829047c7116f923486a107ae5cd7a1ba50c873ad",
+                "reference": "829047c7116f923486a107ae5cd7a1ba50c873ad",
+                "shasum": ""
+            },
+            "bin": [
+                "composer-lock-diff"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Jonas",
+                    "homepage": "https://github.com/davidrjonas"
+                }
+            ],
+            "description": "See what has changed after a composer update.",
+            "support": {
+                "issues": "https://github.com/davidrjonas/composer-lock-diff/issues",
+                "source": "https://github.com/davidrjonas/composer-lock-diff/tree/1.7.1"
+            },
+            "time": "2025-01-24T05:58:02+00:00"
         },
         {
             "name": "defuse/php-encryption",


### PR DESCRIPTION
# Summary
The `composer-lock-diff` is used in developer and automated workflows. The move to SWS Drush Commands removed the `su-sws/blt-sws` package, which is how `davidrjonas/composer-lock-diff` was being required. It now needs to be re-added manually.

