### PR TITLE
HSD8-1863: Improve Parallel Output Handling for Drush Multisite Updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -16739,12 +16739,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/sws-drush-commands.git",
-                "reference": "2ec0802406c43d0f8ea30d49ca31b11746166962"
+                "reference": "a704d26a574cd31a12515fa1d223569f05fb1856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/2ec0802406c43d0f8ea30d49ca31b11746166962",
-                "reference": "2ec0802406c43d0f8ea30d49ca31b11746166962",
+                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/a704d26a574cd31a12515fa1d223569f05fb1856",
+                "reference": "a704d26a574cd31a12515fa1d223569f05fb1856",
                 "shasum": ""
             },
             "require": {
@@ -16775,7 +16775,7 @@
                 "issues": "https://github.com/SU-SWS/sws-drush-commands/issues",
                 "source": "https://github.com/SU-SWS/sws-drush-commands"
             },
-            "time": "2026-04-03T18:43:04+00:00"
+            "time": "2026-04-10T18:52:59+00:00"
         },
         {
             "name": "symfony/cache",
@@ -27029,5 +27029,5 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -24,6 +24,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-drush sws:multisite:update:parallel
+drush sws:multisite:update:parallel --show-output
 
 set +v

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -27,6 +27,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-drush sws:multisite:update:parallel
+drush sws:multisite:update:parallel --show-output
 
 set +v


### PR DESCRIPTION
# Summary
Improves the output handling for parallel Drush multisite update commands, especially in non-interactive (TTY-disabled) environments like Acquia Cloud hooks. Ensures real-time output from all parallel processes is visible and provides a full output summary for each process at the end.

## Backstory
Previously, when running `drush sws:multisite:update:parallel` in non-interactive mode (e.g., Acquia Cloud hooks), only the output from the first parallel process was visible. This was traced to the use of the `wait()` method, which blocks PHP execution until a process finishes, preventing real-time output from other parallel processes.

The code was updated to:
- Remove the blocking `wait()` call in the parallel process loop.
- Use `getIncrementalOutput()` and `getIncrementalErrorOutput()` to poll and print output from all running processes every 50ms.
- Prefix each output line with the process number and mark error output with `[ERR]` for clarity.
- At the end, print the full standard and error output for each process to aid in debugging, since real-time output from parallel processes can be interleaved and hard to read.

These changes were made in the `sws-drush-commands repo` and are now being integrated here.  

- https://github.com/SU-SWS/sws-drush-commands/pull/2
- https://github.com/SU-SWS/sws-drush-commands/pull/2/changes/a704d26a574cd31a12515fa1d223569f05fb1856
- Reference: [Symfony Process Documentation](https://symfony.com/doc/current/components/process.html)

