### PR TITLE
SHS-6613: Uniform height on Curriculum Map cards

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
@@ -48,20 +48,22 @@ $cmap-colors: (
       minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr)
     );
     gap: var(--grid-layout-gap);
-    grid-auto-rows: auto;
-    column-gap: var(--grid-layout-gap);
-    row-gap: 0;
+
+    .hb-raised-cards--uniform-height & {
+      grid-auto-rows: auto;
+      column-gap: var(--grid-layout-gap);
+      row-gap: 0;
+
+      & > .paragraph-item {
+        display: grid;
+        grid-row: span 100;
+        grid-template-rows: subgrid;
+      }
+    }
   }
 
   .field-hs-cmap-year-qtr--cols-4 {
     --grid-column-count: 4;
-  }
-
-  // Level 1: direct grid child — span and subgrid downward
-  .field-hs-cmap-year-qtr > .paragraph-item {
-    display: grid;
-    grid-row: span 100;
-    grid-template-rows: subgrid;
   }
 }
 
@@ -71,10 +73,11 @@ $cmap-colors: (
   flex-direction: column;
   gap: hb-calculate-rems(16px);
 
-  // Level 2: pass subgrid tracks further down
-  display: grid;
-  grid-template-rows: subgrid;
-  grid-row: span 100;
+  .hb-raised-cards--uniform-height & {
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 100;
+  }
 
   .field-hs-cmap-qtr-quarter {
     margin: 0;

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
@@ -51,7 +51,7 @@ $cmap-colors: (
 
     .hb-raised-cards--uniform-height & {
       grid-auto-rows: auto;
-      gap: var(--grid-layout-gap) 0;
+      gap: 0 var(--grid-layout-gap);
 
       & > .paragraph-item {
         display: grid;

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
@@ -51,8 +51,7 @@ $cmap-colors: (
 
     .hb-raised-cards--uniform-height & {
       grid-auto-rows: auto;
-      column-gap: var(--grid-layout-gap);
-      row-gap: 0;
+      gap: var(--grid-layout-gap) 0;
 
       & > .paragraph-item {
         display: grid;

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_curriculum-map.scss
@@ -48,10 +48,20 @@ $cmap-colors: (
       minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr)
     );
     gap: var(--grid-layout-gap);
+    grid-auto-rows: auto;
+    column-gap: var(--grid-layout-gap);
+    row-gap: 0;
   }
 
   .field-hs-cmap-year-qtr--cols-4 {
     --grid-column-count: 4;
+  }
+
+  // Level 1: direct grid child — span and subgrid downward
+  .field-hs-cmap-year-qtr > .paragraph-item {
+    display: grid;
+    grid-row: span 100;
+    grid-template-rows: subgrid;
   }
 }
 
@@ -60,6 +70,11 @@ $cmap-colors: (
   display: flex;
   flex-direction: column;
   gap: hb-calculate-rems(16px);
+
+  // Level 2: pass subgrid tracks further down
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 100;
 
   .field-hs-cmap-qtr-quarter {
     margin: 0;


### PR DESCRIPTION
# Summary
Make the Curriculum Map respect the Uniform Height setting on its parent Collection.  

## Backstory
[SHS-6613](https://app.clickup.com/t/36718269/SHS-6613)

## Need Review By (Date)
04/14

## Urgency
medium

## Steps to Test
1. Log into [Colorful](https://hs-colorful-skhhjmxav2frrwag9pxlnuelu8wpfdxy.tugboatqa.com/user/login) or [Traditional](https://hs-traditional-skhhjmxav2frrwag9pxlnuelu8wpfdxy.tugboatqa.com/user/login)
2. Add a Collection with a Uniform Height, add a Curriculum Map similar to the first one here: https://ceas-stage.stanford.edu/east-asian-studies-sample-degree-timelines OR go to this example here: https://hs-colorful-skhhjmxav2frrwag9pxlnuelu8wpfdxy.tugboatqa.com/components/curriculum-map (first curriculum map)
3. Confirm the cards have the same height in each row
4. Just a note that subgrid won't work in the admin context. The extra Drupal admin markup breaks the subgrid chain because every wrapper div is an additional grid child that doesn't participate.
5. It should look like this:

<img width="1235" height="660" alt="Screenshot 2026-04-13 at 4 40 27 PM" src="https://github.com/user-attachments/assets/47e8cbbc-9d62-4936-9992-91ba1f5b914e" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213343096314010