### PR TITLE
SHS-6593: New caption treatment is raising flags with SiteImprove "Hidden element has focusable content"

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
@@ -1,4 +1,6 @@
 (function (Drupal, once) {
+  let captionCount = 0;
+
   Drupal.behaviors.mediaCaptionToggle = {
     attach(context) {
       const captions = once('media-caption-toggle', '.field-media-image-caption', context);
@@ -10,8 +12,15 @@
         const content = caption.querySelector('.toggle-caption__content');
         const spotlight = caption.closest('.hb-spotlight--expanded');
         const mobileView = window.matchMedia('(max-width: 1293px)');
+        const showLabel = toggleButton?.dataset.showLabel || 'Show image caption';
+        const hideLabel = toggleButton?.dataset.hideLabel || 'Hide image caption';
 
         if (!content || !toggleButton) return;
+
+        captionCount += 1;
+        const captionId = caption.id || `media-caption-${captionCount}`;
+        caption.id = captionId;
+        toggleButton.setAttribute('aria-controls', captionId);
 
         // Debounce helper
         const debounce = (func, delay = 150) => {
@@ -22,8 +31,16 @@
           };
         };
 
+        const syncButtonState = (isOpen) => {
+          toggleButton.classList.toggle('is-open', isOpen);
+          toggleButton.setAttribute('aria-expanded', `${isOpen}`);
+          toggleButton.setAttribute('aria-label', isOpen ? hideLabel : showLabel);
+        };
+
         // Update state for a single caption
         const updateCaptionState = () => {
+          const isOpen = toggleButton.classList.contains('is-open');
+
           // Temporarily remove classes to get the “natural” rendered height
           caption.classList.remove('collapsible-caption');
           caption.classList.remove('is-open');
@@ -46,7 +63,9 @@
               // Keep the button focusable and accessible.
               toggleButton.removeAttribute('tabindex');
 
-              if (!toggleButton.classList.contains('is-open')) {
+              syncButtonState(isOpen);
+
+              if (!isOpen) {
                 content.classList.add('visually-hidden');
               } else {
                 caption.classList.add('is-open');
@@ -54,6 +73,7 @@
             } else {
               // Remove from keyboard navigation when not collapsible.
               toggleButton.setAttribute('tabindex', '-1');
+              syncButtonState(false);
             }
           });
         };
@@ -63,7 +83,8 @@
 
         // Toggle open/close.
         toggleButton.addEventListener('click', () => {
-          const isOpen = toggleButton.classList.toggle('is-open');
+          const isOpen = !toggleButton.classList.contains('is-open');
+          syncButtonState(isOpen);
           caption.classList.toggle('is-open', isOpen);
           content.classList.toggle('visually-hidden', !isOpen);
         });

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/media/media-caption-toggle.js
@@ -60,9 +60,6 @@
             if (collapsible) {
               caption.classList.add('collapsible-caption');
 
-              // Keep the button focusable and accessible.
-              toggleButton.removeAttribute('tabindex');
-
               syncButtonState(isOpen);
 
               if (!isOpen) {
@@ -71,8 +68,6 @@
                 caption.classList.add('is-open');
               }
             } else {
-              // Remove from keyboard navigation when not collapsible.
-              toggleButton.setAttribute('tabindex', '-1');
               syncButtonState(false);
             }
           });

--- a/docroot/themes/humsci/humsci_basic/templates/content/filter-caption.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/content/filter-caption.html.twig
@@ -20,10 +20,14 @@
     <button
         type="button"
         class="toggle-caption__toggle"
-        aria-hidden="true"
+        aria-expanded="false"
+        aria-label="{{ 'Show image caption'|t }}"
+        data-show-label="{{ 'Show image caption'|t }}"
+        data-hide-label="{{ 'Hide image caption'|t }}"
     >
     </button>
     <figcaption class="toggle-caption__content">
+      <span class="visually-hidden">{{ 'Image caption:'|t }}</span>
       {{ caption }}
     </figcaption>
   </div>

--- a/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
@@ -44,11 +44,15 @@
     <button
       type="button"
       class="toggle-caption__toggle"
-      aria-hidden="true"
+      aria-expanded="false"
+      aria-label="{{ 'Show image caption'|t }}"
+      data-show-label="{{ 'Show image caption'|t }}"
+      data-hide-label="{{ 'Hide image caption'|t }}"
       tabindex="-1"
     >
     </button>
     <div class="toggle-caption__content">
+      <span class="visually-hidden">{{ 'Image caption:'|t }}</span>
       {{ item.content }}
     </div>
   </div>

--- a/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/field/field--media--field-media-image-caption.html.twig
@@ -48,7 +48,6 @@
       aria-label="{{ 'Show image caption'|t }}"
       data-show-label="{{ 'Show image caption'|t }}"
       data-hide-label="{{ 'Hide image caption'|t }}"
-      tabindex="-1"
     >
     </button>
     <div class="toggle-caption__content">


### PR DESCRIPTION
# Summary
- Refactor a11y functionality in collapsible image captions

## Backstory
- [ClickUp ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6593)

## Need Review By (Date)
04/22

## Urgency
medium

## Steps to Test
1. Visit the following pages:
    - https://hs-colorful-kvpyyl15xua8sy2xigr41sdgjngnims9.tugboatqa.com/components/collections/collections-postcards/vertical-cards
    - https://hs-colorful-kvpyyl15xua8sy2xigr41sdgjngnims9.tugboatqa.com/components/text-area-typography
2. For all collapsed captions in the pages, confirm the following:
    1. Caption expand/collapse button doesn't have an `aria-hidden="true"` attribute
    2.  Caption expand/collapse button can be focused when tabbing with the keyboard
    3. Optional: using a screen reader, confirm that both expanded and collapsed captions are accessible.
