### PR TITLE
HSD8-1868: Consolidated ui_patterns_field_variants module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,7 +157,6 @@
         "drupal/token_or": "^2.2",
         "drupal/transliterate_filenames": "^2.0",
         "drupal/ui_patterns": "^1.10",
-        "drupal/ui_patterns_field_variants": "1.x-dev",
         "drupal/video_embed_field": "^3.0",
         "drupal/view_unpublished": "^1.0",
         "drupal/viewfield": "^3.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "386c9b5146a3eca4289a00939a373b05",
+    "content-hash": "f4098f042e2471f3d32c3db5f54262ca",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -11970,49 +11970,6 @@
             "homepage": "https://www.drupal.org/project/ui_patterns",
             "support": {
                 "source": "https://git.drupalcode.org/project/ui_patterns"
-            }
-        },
-        {
-            "name": "drupal/ui_patterns_field_variants",
-            "version": "dev-1.x",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/ui_patterns_field_variants.git",
-                "reference": "6e8a9408aea930ec1b2027dd941c7edce61055ba"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9 || ^10",
-                "drupal/ui_patterns": "~1.1"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1692829724",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Mike Decker",
-                    "homepage": "https://www.drupal.org/user/3059577",
-                    "email": "pookmish@gmail.com"
-                }
-            ],
-            "description": "Pass field values into variants",
-            "homepage": "https://www.drupal.org/project/ui_patterns_field_variants",
-            "support": {
-                "source": "https://git.drupalcode.org/project/ui_patterns_field_variants"
             }
         },
         {
@@ -27015,7 +26972,6 @@
         "drupal/selective_better_exposed_filters": 10,
         "drupal/spamspan": 10,
         "drupal/style_selector": 10,
-        "drupal/ui_patterns_field_variants": 20,
         "drupal/viewfield": 10,
         "drupal/views_field_view": 10,
         "drupal/views_ical": 15,
@@ -27029,5 +26985,5 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.info.yml
+++ b/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.info.yml
@@ -1,0 +1,8 @@
+name: 'UI Patterns Field Variants'
+type: module
+description: 'Allows the configuration of UI Pattern Variants through field values'
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10
+package: 'Custom'
+dependencies:
+  - ui_patterns:ui_patterns

--- a/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.info.yml
+++ b/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.info.yml
@@ -1,8 +1,7 @@
 name: 'UI Patterns Field Variants'
 type: module
 description: 'Allows the configuration of UI Pattern Variants through field values'
-core: 8.x
-core_version_requirement: ^8 || ^9 || ^10
-package: 'Custom'
+package: 'Humanities & Sciences'
+core_version_requirement: ^10 || ^11
 dependencies:
   - ui_patterns:ui_patterns

--- a/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.module
+++ b/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.module
@@ -58,8 +58,8 @@ function ui_patterns_field_variants_ui_patterns_layouts_display_settings_form_al
     '#states' => [
       'visible' => [
         ':input[name="layout_configuration[pattern][variant]"]' => ['value' => '_field'],
-      ]
-    ]
+      ],
+    ],
   ];
 
   $form['variant_field_values'] = [
@@ -69,15 +69,15 @@ function ui_patterns_field_variants_ui_patterns_layouts_display_settings_form_al
     '#states' => [
       'visible' => [
         ':input[name="layout_configuration[pattern][variant]"]' => ['value' => '_field'],
-      ]
-    ]
+      ],
+    ],
   ];
 
   foreach ($form['variant']['#options'] as $key => $label) {
     if ($key == '_field') {
       continue;
     }
-    // TODO: find a way to render the field's form.
+    // @todo Find a way to render the field's form.
     $form['variant_field_values'][$key] = [
       '#type' => 'textfield',
       '#title' => t('Field value for @variant variant', ['@variant' => $label]),

--- a/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.module
+++ b/docroot/modules/humsci/ui_patterns_field_variants/ui_patterns_field_variants.module
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @file
+ * Contains ui_patterns_field_variants.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\ui_patterns\Definition\PatternDefinition;
+use Drupal\field\Entity\FieldConfig;
+
+/**
+ * Implements hook_help().
+ */
+function ui_patterns_field_variants_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the ui_patterns_field_variants module.
+    case 'help.page.ui_patterns_field_variants':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Allows the configuration of UI Pattern Variants through field values') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_ui_patterns_layouts_display_settings_form_alter().
+ */
+function ui_patterns_field_variants_ui_patterns_layouts_display_settings_form_alter(array &$form, PatternDefinition $definition, array $configuration) {
+  $current_request = \Drupal::requestStack()->getCurrentRequest();
+  $entity_type = $current_request->attributes->get('entity_type_id');
+  $entity_bundle = $current_request->attributes->get('bundle');
+
+  /** @var \Drupal\Core\Entity\EntityFieldManager $field_manager */
+  $field_manager = \Drupal::service('entity_field.manager');
+  $fields = $field_manager->getFieldDefinitions($entity_type, $entity_bundle);
+
+  // Filter out fields that aren't config fields or allow multiple values.
+  $fields = array_filter($fields, function ($field_definition) {
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
+    $field_storage = $field_definition->getFieldStorageDefinition();
+    return $field_definition instanceof FieldConfig && $field_storage->getCardinality() == 1;
+  });
+
+  // Walk through the array of fields to get just the label of the object.
+  array_walk($fields, function (&$field_definition) {
+    $field_definition = $field_definition->label();
+  });
+
+  $form['variant']['#options']['_field'] = t('- Use Field Value -');
+  $form['variant_field'] = [
+    '#type' => 'select',
+    '#title' => t('Field'),
+    '#options' => $fields,
+    '#default_value' => $configuration['pattern']['variant_field'] ?? NULL,
+    '#states' => [
+      'visible' => [
+        ':input[name="layout_configuration[pattern][variant]"]' => ['value' => '_field'],
+      ]
+    ]
+  ];
+
+  $form['variant_field_values'] = [
+    '#type' => 'details',
+    '#title' => t('Variant Values'),
+    '#tree' => TRUE,
+    '#states' => [
+      'visible' => [
+        ':input[name="layout_configuration[pattern][variant]"]' => ['value' => '_field'],
+      ]
+    ]
+  ];
+
+  foreach ($form['variant']['#options'] as $key => $label) {
+    if ($key == '_field') {
+      continue;
+    }
+    // TODO: find a way to render the field's form.
+    $form['variant_field_values'][$key] = [
+      '#type' => 'textfield',
+      '#title' => t('Field value for @variant variant', ['@variant' => $label]),
+      '#default_value' => $configuration['pattern']['variant_field_values'][$key] ?? NULL,
+    ];
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function ui_patterns_field_variants_preprocess_ds_entity_view(&$variables) {
+  // If the display suite is using a pattern & it's configured to take the field
+  // value.
+  if ($variables['content']['#type'] == 'pattern' && $variables['content']['#variant'] == '_field') {
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    $entity = $variables['content']['#entity'];
+
+    $pattern_settings = $variables['content']['#ds_configuration']['layout']['settings']['pattern'];
+
+    $field_variant = $pattern_settings['variant_field'];
+
+    // Grab the field value from the entity and use it's mapped variant.
+    if ($entity->hasField($field_variant)) {
+      $field_value = $entity->get($field_variant)->getString();
+      $variant = array_search($field_value, $pattern_settings['variant_field_values']);
+
+      $variables['content']['#variant'] = $variant ?: 'default';
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Consolidate `ui_patterns_field_variants` module into codebase to unblock Drupal 11 development.

## Backstory
[HSD8-1868](https://stanfordits.atlassian.net/browse/HSD8-1868): D11 | Consolidate ui_patterns_field_variants module

The `drupal/ui_patterns_field_variants` module was blocking our upgrade to Drupal 11. It is not used in any SWS projects and is only present in H&S. The module has no official release, no usage statistics, and all open issues are automated. It is minimally maintained and has not been updated since February 2024. To simplify maintenance and unblock D11 work, the module was consolidated directly into the codebase and removed from composer dependencies.

## Need Review By (Date)
ASAP – required to proceed with Drupal 11 upgrade.

## Urgency
High

## Steps to Test
1. Verify that the `ui_patterns_field_variants` functionality is present under `docroot/modules/humsci/`.
2. Confirm that the module is no longer present in `composer.json` or `composer.lock`.
3. Run `composer install` and ensure there are no errors related to `ui_patterns_field_variants`.
4. Validate that H&S functionality dependent on this module continues to work as expected.
5. Confirm that the codebase is unblocked for Drupal 11 development (e.g., update info.yml, run D11 readiness checks).



[HSD8-1868]: https://stanfordits.atlassian.net/browse/HSD8-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214139186248543