### PR TITLE
SHS-6638: Fix temp unavailable error after deleting media in spotlights

### DIFF
--- a/docroot/modules/humsci/hs_layouts/hs_layouts.module
+++ b/docroot/modules/humsci/hs_layouts/hs_layouts.module
@@ -190,10 +190,10 @@ function hs_layouts_preprocess_pattern_spotlight(&$variables) {
     }
     else {
       $media = $paragraph->get('field_hs_spotlight_image')->entity;
-      if ($media->bundle() == 'video') {
+      if ($media && $media->bundle() === 'video') {
         $spotlight_type = 'video';
       }
-      elseif ($media->bundle() == 'image' && $spotlight_type == 'classic') {
+      elseif ($media && $media->bundle() === 'image' && $spotlight_type === 'classic') {
         $view_mode = $context->getProperty('view_mode');
         $image_style = $view_mode == 'default' ? 'spotlight_framed_tall' : 'spotlight_framed_short';
         $variables['image']['field_hs_spotlight_image'][0]['#stanford_media_image_style'] = $image_style;

--- a/docroot/modules/humsci/hs_layouts/hs_layouts.module
+++ b/docroot/modules/humsci/hs_layouts/hs_layouts.module
@@ -185,15 +185,15 @@ function hs_layouts_preprocess_pattern_spotlight(&$variables) {
   $variables['attributes']->addClass('hb-spotlight--view-mode-' . $image_style);
 
   if ($paragraph->hasField('field_hs_spotlight_image')) {
-    if ($paragraph->get('field_hs_spotlight_image')->isEmpty()) {
+    if ($paragraph->get('field_hs_spotlight_image')->isEmpty() || !$paragraph->get('field_hs_spotlight_image')->entity) {
       $variables['attributes']->addClass('hb-spotlight--no-media');
     }
     else {
       $media = $paragraph->get('field_hs_spotlight_image')->entity;
-      if ($media && $media->bundle() === 'video') {
+      if ($media->bundle() === 'video') {
         $spotlight_type = 'video';
       }
-      elseif ($media && $media->bundle() === 'image' && $spotlight_type === 'classic') {
+      elseif ($media->bundle() === 'image' && $spotlight_type === 'classic') {
         $view_mode = $context->getProperty('view_mode');
         $image_style = $view_mode == 'default' ? 'spotlight_framed_tall' : 'spotlight_framed_short';
         $variables['image']['field_hs_spotlight_image'][0]['#stanford_media_image_style'] = $image_style;


### PR DESCRIPTION
# Summary
Fatal PHP error in custom code.

## Backstory
  [SHS-6638](https://app.clickup.com/t/36718269/SHS-6638)

## Need Review By (Date)
ASAP

## Urgency
high

## Steps to Test
1. Create a spotlight with an image media item
2. Delete the media item (without first changing the spotlight)
    e.g. https://hs-traditional-ksvi6tehwsxttm1mor9iuqvbj0adznt6.tugboatqa.com/components/hero-images-full-width-region-and-main-region/tall-spotlights-classic
3. Try and view the spotlight.  Before this PR you'd see a fatal PHP error.  Now it should work without issue. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214273606724062
  - https://app.asana.com/0/0/1214354688651999