### PR TITLE
HSD8-1879: Update db-scrub.sh to rebuild cache before sql-sanitize after database copy

### DIFF
--- a/hooks/common/post-db-copy/db-scrub.sh
+++ b/hooks/common/post-db-copy/db-scrub.sh
@@ -18,6 +18,10 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
+# Run cache rebuild before sanitization, otherwise errors may occur due to
+# code changes between environments and the entire post-db-copy hook will cease
+# to run.
+drush cr --uri=$db_name
 drush sql-sanitize --ignored-roles=decoupled_site_users --uri=$db_name
 
 set +v


### PR DESCRIPTION
# Summary
Fixes an issue where database copy post-hooks fail due to service container mismatches after module updates, by running `drush cr` before `drush sql-sanitize` in db-scrub.sh. This ensures the Drupal service container is rebuilt before any Drush command is executed on the new database, preventing errors like constructor mismatches.

## Backstory
This PR specifically addresses an error that occurred in the post-db-copy workflow when copying databases between environments after a module update (e.g., config_ignore 3.3.0 → 3.4.0). The error occurs because the service container is out of sync with the updated code, causing Drush commands (including sql-sanitize) to fail until a cache rebuild is performed. The fix is to explicitly run `drush cr` before any other Drush command in db-scrub.sh.

This is done as part of [HSD8-1879](https://stanfordits.atlassian.net/browse/HSD8-1879): SWSDC | Fix and improve content staging workflow




[HSD8-1879]: https://stanfordits.atlassian.net/browse/HSD8-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ