### PR TITLE
HSD8-1879: Add Acquia API credentials to Drush commands in GitHub Actions workflows

### DIFF
--- a/.github/workflows/acquia-cleanup.yml
+++ b/.github/workflows/acquia-cleanup.yml
@@ -39,5 +39,5 @@ jobs:
           git config --global user.name "Github Actions" &&
           ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
-          drush sws:acquia:clean-databases --minimum-age=10368000 &&
-          drush sws:acquia:clean-git
+          drush sws:acquia:clean-databases --minimum-age=10368000 --app-key="$ACQUIA_KEY" --app-secret="$ACQUIA_SECRET" &&
+          drush sws:acquia:clean-git --app-key="$ACQUIA_KEY" --app-secret="$ACQUIA_SECRET" 

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -26,4 +26,4 @@ jobs:
           ACQUIA_SECRET: ${{ secrets.ACQUIA_SECRET }}
         run: |
           composer install -n &&
-          drush sws:multisite:sync-stage -n
+          drush sws:multisite:sync-stage --app-key="$ACQUIA_KEY" --app-secret="$ACQUIA_SECRET" -n


### PR DESCRIPTION
# Summary
This PR updates GitHub Actions workflows to include Acquia API credentials (`app-key` and `app-secret`) in Drush commands that require them. This resolves failures due to missing required options when running certain Drush commands in CI.

Related ticket: [HSD8-1879](https://stanfordits.atlassian.net/browse/HSD8-1879): SWSDC | Fix and improve content staging workflow



[HSD8-1879]: https://stanfordits.atlassian.net/browse/HSD8-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ