### PR TITLE
HSD8-1882: Update GitHub Actions to support Node.js 24 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/acquia-cleanup.yml
+++ b/.github/workflows/acquia-cleanup.yml
@@ -18,9 +18,9 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -9,9 +9,9 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -34,7 +34,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set git safe directory
@@ -54,7 +54,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -11,9 +11,9 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.tag.outputs.tag }}
         with:
           ref: ${{ github.sha }}
@@ -53,7 +53,7 @@ jobs:
           cache-dependency-path: docroot/themes/humsci/humsci_basic/package-lock.json
       - name: Restore Cache
         if: ${{ steps.tag.outputs.tag }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -37,7 +37,7 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Lint Theme
         run: npm run lint --prefix $themePath
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -24,9 +24,9 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -41,7 +41,7 @@ jobs:
           mkdir -p docroot/sites/simpletest &&
           drush sws:source:tests:phpunit --db-host=mysql --db-pass=drupal --db-name=drupal --db-user=drupal --with-coverage
       - name: Save Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-tests-results
@@ -51,7 +51,7 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
@@ -89,7 +89,7 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
@@ -97,7 +97,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ${{ env.themePath }}/package-lock.json
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -125,7 +125,7 @@ jobs:
           apachectl start
           drush sws:codeception --suite=functional --group=install --site-domain=localhost
       - name: Save Functional Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: codeception--functional
@@ -157,7 +157,7 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
@@ -165,7 +165,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ${{ env.themePath }}/package-lock.json
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -193,7 +193,7 @@ jobs:
           apachectl start
           drush sws:codeception --suite=acceptance --group=install --site-domain=localhost
       - name: Save Acceptance Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: codeception--acceptance
@@ -209,7 +209,7 @@ jobs:
       image: pookmish/drupal8ci:php8.3
       options: '--network-alias drupal8ci'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Set up Node.js from .nvmrc
@@ -219,7 +219,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ${{ env.themePath }}/package-lock.json
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor


### PR DESCRIPTION
# Summary
Updates GitHub Actions workflow references to versions that support Node.js 24, replacing deprecated Node.js 20-backed action versions before the June 2, 2026 runner default change.

## Backstory
[HSD8-1882](https://stanfordits.atlassian.net/browse/HSD8-1882): Update GitHub Actions to support Node.js 24 (Node 20 deprecation)

This PR exists to address the GitHub Actions deprecation warning for Node.js 20-based JavaScript actions. The same updates were already made as part of the Drupal 11 upgrade work but that larger PR is not expected to merge before the Node.js 24 deadline.

The affected action upgrades in `.github/workflows` are:
- `actions/checkout` from `v4` to `v6`
- `actions/cache` from `v4` to `v5`
- `actions/upload-artifact` from `v4` to `v7`

## Need Review By (Date)
before 6/2/26

## Urgency
high

## Steps to Test
1. Review the changed workflow files in `.github/workflows` and confirm `actions/checkout` now uses `v6`, `actions/cache` now uses `v5`, and `actions/upload-artifact` now uses `v7` where applicable.
2. Confirm there are no remaining references to `actions/checkout@v4`, `actions/cache@v4`, or `actions/upload-artifact@v4` in `.github/workflows`.
3. Let GitHub Actions run for the affected workflows and verify they start successfully without the Node.js 20 deprecation warning.

[HSD8-1882]: https://stanfordits.atlassian.net/browse/HSD8-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ