### PR TITLE
HSD8-1886: Adopt new major-version branching workflow and release process

### DIFF
--- a/.github/workflows/acquia-cleanup.yml
+++ b/.github/workflows/acquia-cleanup.yml
@@ -1,5 +1,5 @@
-# .github/workflows/acquia-cleanup.yml
-# Clean up stale site backups and branches on Acquia
+# .github/workflows/acquia_cleanup.yml
+# Clean up old manual database backups and git branches and tags on Acquia.
 name: Acquia Cleanup
 on:
   schedule:

--- a/.github/workflows/content-stage.yml
+++ b/.github/workflows/content-stage.yml
@@ -1,3 +1,5 @@
+# .github/workflows/content-stage.yml
+# Copies the databases from production sites to staging sites.
 name: Content Staging
 on:
   schedule:

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,11 +1,12 @@
 # .github/workflows/dependency-updates.yml
-# Automate dependency updates using the latest release branch.
+# Automate dependency updates.
 # Runs composer update, database updates, exports configurations, generates a
 # composer.lock diff, and creates a pull request.
 name: Automated Dependency Updates
 
 on:
   schedule:
+    # Run on Fridays at 2 PM UTC.
     - cron: '0 14 * * 5'
   workflow_dispatch:
 
@@ -39,17 +40,6 @@ jobs:
           fetch-depth: 0
       - name: Set git safe directory
         run: git config --system --add safe.directory '*'
-      - name: Fetch all branches
-        run: git fetch --all
-      - name: Find latest release branch
-        id: find_release
-        run: |
-          LATEST=$(git branch -r | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+-release' | sort -V | tail -n1)
-          echo "Latest release branch: $LATEST"
-          echo "branch=${LATEST}" >> $GITHUB_OUTPUT
-      - name: Checkout latest release branch
-        run: |
-          git checkout ${{ steps.find_release.outputs.branch }}
       - name: Set date variable
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
@@ -71,7 +61,7 @@ jobs:
           ln -snf $GITHUB_WORKSPACE /var/www/html
           mkdir -p docroot/sites/default/files
           chmod -R 777 docroot/sites/default/files/
-          drush sws:multisite:install -n -n
+          drush sws:multisite:install -n
       - name: Import configuration
         run: drush cim -y
       - name: Update Composer dependencies
@@ -83,7 +73,7 @@ jobs:
       - name: Generate composer.lock diff (markdown)
         id: lockdiff
         run: |
-          vendor/bin/composer-lock-diff --md --from origin/${{ steps.find_release.outputs.branch }}:composer.lock --to composer.lock > composer-lock-diff.md
+          vendor/bin/composer-lock-diff --md --from origin/${{ github.event.repository.default_branch }}:composer.lock --to composer.lock > composer-lock-diff.md
           echo "diff<<EOF" >> $GITHUB_OUTPUT
           cat composer-lock-diff.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -102,7 +92,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Automated Dependency Updates ${{ steps.date.outputs.date }}"
           branch: automated/dependency-update-${{ steps.date.outputs.date }}-${{ github.run_id }}
-          base: ${{ steps.find_release.outputs.branch }}
+          base: ${{ github.event.repository.default_branch }}
           title: "Automated Dependency Updates ${{ steps.date.outputs.date }}"
           body: |
             This PR was created automatically by a scheduled GitHub Actions workflow to update Composer dependencies and export Drupal configuration.

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,0 +1,54 @@
+# .github/workflows/deploy-branch.yml
+# Deploys the provided branch to the ACE application.
+name: Deploy current branch
+
+# Allow this workflow to be called from other workflows.
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy Artifact
+    runs-on: ubuntu-latest
+    container:
+      image: pookmish/drupal8ci:php8.3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || '' }}
+      - name: Set up Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+          cache-dependency-path: docroot/themes/humsci/humsci_basic/package-lock.json
+      - name: Restore Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            vendor
+            docroot/core
+            docroot/libraries
+            docroot/modules/contrib
+          key: 1.0-${{ hashFiles('drush/drush.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          if_key_exists: fail
+      - run: git config --system --add safe.directory '*'
+      - name: Install theme dependencies
+        run: npm ci --prefix docroot/themes/humsci/humsci_basic
+      - name: Deploy Artifact
+        run: |
+          git config --global user.email "sws-developers@lists.stanford.edu" &&
+          git config --global user.name "Github Actions" &&
+          ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
+          composer install -n &&
+          drush sws:artifact:deploy -v -n

--- a/.github/workflows/dev-branch-actions.yml
+++ b/.github/workflows/dev-branch-actions.yml
@@ -1,0 +1,23 @@
+# .github/workflows/dev-branch-actions.yml
+# Actions triggered on merge to current dev branch (e.g., 1.x, 2.x, etc.,).
+# - Runs the tests workflow and deploys an artifact when tests pass.
+name: Dev branch actions
+
+on:
+  push:
+    branches: ['*.x']
+
+jobs:
+  # Run tests on current PR branch.
+  tests:
+    uses: ./.github/workflows/tests.yml
+    # Allow secrets to be used in the called workflow.
+    secrets: inherit
+  # Deploy branch after tests pass by calling deploy workflow.
+  deploy:
+    uses: ./.github/workflows/deploy-branch.yml
+    with:
+      branch: ${{ github.ref_name }}
+    # Allow secrets to be used in the called workflow.
+    secrets: inherit
+    needs: [tests]

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,5 +1,6 @@
 # .github/workflows/phpcs.yml
 # Runs PHPCS on pull requests.
+name: Drupal PHP CodeSniffer
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,4 +1,5 @@
-name: Drupal PHP CodeSniffer
+# .github/workflows/phpcs.yml
+# Runs PHPCS on pull requests.
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]

--- a/.github/workflows/pull-request-actions.yml
+++ b/.github/workflows/pull-request-actions.yml
@@ -1,0 +1,23 @@
+# .github/workflows/pull-request-actions.yml
+# Actions triggered on pull_request.
+# - Runs the tests workflow and deploys an artifact when tests pass.
+name: Pull request actions
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
+
+jobs:
+  # Run tests on current PR branch.
+  tests:
+    uses: ./.github/workflows/tests.yml
+    # Allow secrets to be used in the called workflow.
+    secrets: inherit
+  # Deploy branch after tests pass by calling deploy workflow.
+  deploy:
+    uses: ./.github/workflows/deploy-branch.yml
+    with:
+      branch: ${{ github.head_ref }}
+    # Allow secrets to be used in the called workflow.
+    secrets: inherit
+    needs: [tests]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
 # .github/workflows/release.yml
+# This workflow automates the release and production deploy process.
+#
+# When a pull request is merged into the main branch it:
+# - Creates a new tag and release
+# - Creates a code artifact and pushes it to Acquia for deployment
 name: Release
 
 on:
@@ -8,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions: write-all
-    if: github.event.pull_request.merged
+    if: github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
@@ -17,7 +22,7 @@ jobs:
         uses: K-Phoen/semver-release-action@master
         with:
           release_strategy: none
-          release_branch: develop
+          release_branch: main
           tag_format: "%major%.%minor%.%patch%"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,24 +78,3 @@ jobs:
           ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
           drush sws:artifact:deploy --tag=$(date +'%Y-%m-%d')"_"${{ steps.tag.outputs.tag }} --commit-msg=${{ steps.tag.outputs.tag }} -v -n
-      - name: Get Next Release
-        if: ${{ steps.tag.outputs.tag }}
-        id: next_tag
-        run: |
-          NEXT_VERSION=$(echo ${{ steps.tag.outputs.tag }} | awk -F. -v OFS=. '{$NF += 1 ; print}') &&
-          sed -i "s/^version:.*/version: $NEXT_VERSION/g" docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml &&
-          echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-      - name: Create Next Release
-        if: ${{ steps.tag.outputs.tag }}
-        uses: peter-evans/create-pull-request@v6
-        with:
-          committer: Github Actions <sws-developers@lists.stanford.edu>
-          author: Github Actions <sws-developers@lists.stanford.edu>
-          commit-message: ${{ steps.next_tag.outputs.version }}
-          branch: ${{ steps.next_tag.outputs.version }}-release
-          base: develop
-          title: ${{ steps.next_tag.outputs.version }}
-          body: "# DO NOT DELETE"
-      - name: Push New Branch
-        if: ${{ steps.next_tag.outputs.version }}
-        run: drush sws:artifact:deploy --branch=${{ steps.next_tag.outputs.version }}-release-build --commit-msg=${{ steps.next_tag.outputs.version }} -n

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -1,3 +1,6 @@
+# .github/workflows/site-sync-test.yml
+# Syncs the default site and tests that a sync completes successfully on pull
+# requests.
 name: Test Default Site Sync
 on:
   pull_request:

--- a/.github/workflows/sites-test.yml
+++ b/.github/workflows/sites-test.yml
@@ -1,3 +1,5 @@
+# .github/workflows/sites-test.yml
+# Runs tests on current branch or tag.
 name: Unit, Acceptance and Functional Tests
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,16 @@
-# .github/workflows/sites-test.yml
+# .github/workflows/tests.yml
 # Runs tests on current branch or tag.
 name: Unit, Acceptance and Functional Tests
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+
+# Allow this workflow to be called from other workflows.
+on: [workflow_call]
+
+# Cancel previous runs of this workflow in the same branch if they're still in
+# progress.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 env:
   themePath: docroot/themes/humsci/humsci_basic
 jobs:
@@ -116,7 +120,7 @@ jobs:
           composer install -n &&
           mkdir -p docroot/sites/default/files &&
           chmod -R 777 docroot/sites/default/files/ &&
-          drush sws:multisite:install -n -n
+          drush sws:multisite:install -n
       - name: Install theme dependencies
         run: npm ci --prefix $themePath
       - name: Compile theme assets
@@ -184,7 +188,7 @@ jobs:
           composer install -n &&
           mkdir -p docroot/sites/default/files &&
           chmod -R 777 docroot/sites/default/files/ &&
-          drush sws:multisite:install -n -n
+          drush sws:multisite:install -n
       - name: Install theme dependencies
         run: npm ci --prefix $themePath
       - name: Compile theme assets
@@ -200,49 +204,3 @@ jobs:
         with:
           name: codeception--acceptance
           path: /var/www/html/artifacts
-  deploy_branch:
-    needs:
-      - test_phpunit
-      - lint_theme
-      - test_functional
-      - test_acceptance
-    runs-on: ubuntu-latest
-    container:
-      image: pookmish/drupal8ci:php8.3
-      options: '--network-alias drupal8ci'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Set up Node.js from .nvmrc
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: 'npm'
-          cache-dependency-path: ${{ env.themePath }}/package-lock.json
-      - name: Restore Cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            vendor
-            docroot/core
-            docroot/libraries
-            docroot/modules/contrib
-          key: 1.0-${{ hashFiles('drush/drush.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-          if_key_exists: fail
-      - run: git config --system --add safe.directory '*'
-      - name: Install theme dependencies
-        run: npm ci --prefix $themePath
-      - name: Deploy Branch
-        run: |
-          git config --global user.email "sws-developers@lists.stanford.edu" &&
-          git config --global user.name "Github Actions" &&
-          ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
-          composer install -n &&
-          drush sws:artifact:deploy -v -n

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This codebase runs the Humanities and Sciences Drupal (or Digital) Platform a.k.
 ## Overview
 
 Note the following properties of this project:
-* Stable branch: `develop`
-* Release branch naming convention: `[VERSION]-release` e.g. `11.2.3-release`
+* Default development branch: the current major version branch, e.g. `12.x`
+* Production release branch: `main`
 * Four Kitchens secondary release branch naming convention: `fk-stnfd-sprint-[SPRINT_NUMBER]`
-* Development branching convention: branch off the current release branch
+* Development branching convention: branch off the current major development branch
 * Local environment: DDEV, Lando or bare metal LAMP
 * Local drush alias: @[SITE_ALIAS].local
 * Local site URL: http://[SITE_ALIAS].suhumsci.loc
@@ -20,6 +20,7 @@ In April 2026 this repository moved from using BLT to SWS Drush Commands (SWSDC)
 
 - [Patching and patch management instructions](patches/README.md)
 - [Codeception Tests](docs/Codeception.md)
+- [Branching Strategy](docs/BranchingStrategy.md)
 - [Development Requirements](docs/DevelopmentRequirements.md)
 - [Release and Code Deployment Process](docs/CodeDeploy.md)
 - [Conding Standards](docs/CodingStandards.md)
@@ -46,7 +47,7 @@ You can either run the site on DDEV, Lando or bare metal.
 * [Follow the Lando legacy instructions](lando/README.md).
 
 #### Or setup on bare metal
-1. Clone the repository and check out the develop branch.
+1. Clone the repository and check out the current major development branch, for example `12.x`.
 1. Run `composer install`
 1. Run `drush sws:multisite:settings`
 1. Run `drush sws:keys`
@@ -86,13 +87,11 @@ The build process will automatically choose whether to run in/out of ddev/lando 
 ## Testing
 
 ### Codeception
-Acceptance testing and user testing id done use a testing framework [Codeception](https://codeception.com/). There is
-very good documentation on codeception testing steps and how that is structured.
+Acceptance testing and user testing id done use a testing framework [Codeception](https://codeception.com/). There is very good documentation on codeception testing steps and how that is structured.
 
 #### Codeception on bare metal
 - `drush sws:codeception` will run all acceptance tests.
-- `drush sws:codeception --group=[group-name]` will run tests that are annotated with the specified group. This is the most
-  effective method to run a single test.
+- `drush sws:codeception --group=[group-name]` will run tests that are annotated with the specified group. This is the most effective method to run a single test.
 - [List of current tests](/docs/Codeception.md)
 
 ### SASS

--- a/docs/BranchingStrategy.md
+++ b/docs/BranchingStrategy.md
@@ -1,0 +1,41 @@
+# H&S Branching Strategy
+
+This document describes the active branching model for the H&S application.
+
+## Branch Roles
+
+- `<major>.x` is the primary development branch for the current major version. Example: `12.x`.
+- `<major>.x` is the default branch in GitHub and the normal base branch for feature and maintenance pull requests.
+- `<major>.x-build` is the deployment artifact branch generated from `<major>.x` and deployed to staging.
+- `main` is the production release branch. Only release pull requests should merge into `main`.
+
+## Day-to-Day Development
+
+- Branch feature and maintenance work from the current `<major>.x` branch.
+- Open pull requests back into `<major>.x`.
+- After a pull request is merged into `<major>.x`, automation updates the `<major>.x-build` artifact branch.
+- Staging should track `<major>.x-build` so merged development work is available for review quickly.
+
+## Pull Requests
+
+- Pull requests should be scoped to the problem they are solving. Multiple smaller Pull Requests are generally preferred.
+
+## Release Flow
+
+- Ensure all work intended for a release has already been merged into the current `<major>.x` branch.
+- Create a short-lived release branch from `<major>.x` when you are ready to prepare a release.
+- Open a pull request from that release branch into `main`.
+- Apply the appropriate `major`, `minor`, or `patch` label to the release pull request.
+- Merge the release pull request into `main` using a merge commit.
+- When the release pull request is merged into `main`, release automation creates the GitHub release and deployable Acquia artifact tag.
+
+## Retired Workflow Pieces
+
+- Long-lived `<version>-release` branches are no longer used.
+- Automation no longer creates the next release branch or an automatic next-release pull request.
+- `develop` is no longer the default branch or the integration branch for current work.
+
+## Operational Notes
+
+- GitHub rulesets and branch protections should apply to `main` and `<major>.x` branches.
+- Tugboat base previews should track the current `<major>.x` branch rather than `main`.

--- a/docs/CodeDeploy.md
+++ b/docs/CodeDeploy.md
@@ -4,12 +4,16 @@ This document outlines the release and deployment workflow for the H&S applicati
 
 ## Overview
 - Releases follow [SEMVER](https://semver.org/) conventions: major, minor, patch.
-- All code changes for a release go through a PR into the release branch (`<version>-release`).
+- Day-to-day development work merges into the current `<major>.x` branch.
+- Staging should track the `<major>.x-build` artifact branch generated from the current `<major>.x` branch.
+- Production releases are created by merging a release pull request into `main`.
 - PRs must pass all required GitHub Actions checks.
 - PR labels (`major`, `minor`, `patch`) are required to trigger automation.
-- When a release branch is merged into `develop`, automation creates a deployment artifact/tag, a new GitHub release, and the next release branch/PR.
-- The deployment artifact is a tag named `YYYY-MM-DD_VERSION` (e.g., `2025-10-15_11.18.0`).
+- When a release pull request is merged into `main`, automation creates a deployment artifact/tag and a new GitHub release.
+- The deployment artifact is a tag named `YYYY-MM-DD_VERSION` (e.g., `2026-05-21_12.1.1`).
 - Manual database backups are required before production deployment.
+
+See also: [Branching Strategy](BranchingStrategy.md)
 
 ## Requirements
 *See [H&S Development Requirements](DevelopmentRequirements.md)*
@@ -30,25 +34,28 @@ Running the backup step now ensures the backups are completed by the time the re
 ## Create a New Release
 ### Prep the Code Locally
 ```bash
-git checkout develop && git fetch && git pull
-git checkout RELEASE_BRANCH && git fetch && git pull
+git checkout main && git fetch && git pull
+git checkout CURRENT_MAJOR_BRANCH && git fetch && git pull
+git checkout -b RELEASE_BRANCH
 composer install
 
 # Example:
-git checkout develop && git fetch && git pull
-git checkout 11.18.0-release && git fetch && git pull
+git checkout main && git fetch && git pull
+git checkout 12.x && git fetch && git pull
+git checkout -b 12.1.1-release
 composer install
 ```
 
 ### Prepare for Release
-- Ensure all code for the release is merged into the current release branch (`<version>-release`).
+- Ensure all code for the release is merged into the current major development branch before creating the release branch.
+- Create a short-lived release branch from the current major development branch.
 - Review code changes and determine the next version using SEMVER:
-	- **Major**: Incompatible API changes (e.g., `12.0.0`)
-	- **Minor**: New functionality, backward compatible (e.g., `11.18.0`)
-	- **Patch**: Bug fixes, backward compatible (e.g., `11.17.1`)
+	- **Major**: Incompatible API changes (e.g., `12.0.0`). Note that this should entail creating a new `<major>.x` development branch. This is typically reserved for Drupal core major version upgrades.
+	- **Minor**: New functionality, backward compatible (e.g., `12.1.0`)
+	- **Patch**: Bug fixes, backward compatible (e.g., `12.1.1`)
 - Use `git log` or the GitHub interface to review commits:
 	```bash
-	git log ^develop <version>-release --oneline
+	git log main..RELEASE_BRANCH --oneline
 	```
 
 ### Update Version Numbers
@@ -56,25 +63,35 @@ composer install
 	- `docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml`
 - Commit and push changes.
 
+### Create the Release PR
+- Push the new release branch to GitHub.
+- Open a pull request from `RELEASE_BRANCH` into `main`.
+- Confirm the PR contains only the code intended for the release.
+- Use a PR title that matches the target version number (e.g., `12.1.1`).
+
 ### Update the Release PR
-- Set the PR title to the version (e.g., `11.18.0`).
+- Set the PR title to the version (e.g., `12.1.1`).
 - Apply the correct `major`, `minor`, or `patch` label. This triggers automation.
-- Double-check the base branch is `develop`.
+- Double-check the base branch is `main`.
 - Review changes and confirm SEMVER alignment.
 
 :warning: **Double check the PR label!** Make sure the PR label is correct based on the version (major, minor, or patch).
 
 ### Merge the Release PR
 - Once all tests pass, merge the PR using a **merge commit** (not squash merge).
-- Set the merge commit title/message to the version (e.g., `11.18.0`).
+- Set the merge commit title/message to the version (e.g., `12.1.1`).
 - Confirm the correct PR label is applied before merging.
+
+### Back to Dev
+- After the release PR is merged into `main`, keep the release branch long enough to open a second pull request back into the current `<major>.x` branch.
+- Use this back-to-dev pull request to return version increments and any other release-only changes to the development branch.
+- Merge the back-to-dev pull request before deleting the release branch.
+- If a production hotfix is ever made directly on `main`, sync that change back to the current `<major>.x` branch separately.
 
 ### Confirm Automation
 - After merging, GitHub Actions will:
 	- Create a new tag and release with the version number.
 	- Create a deployment artifact and push it to Acquia (tag: `YYYY-MM-DD_VERSION`).
-	- Create the next release branch and PR for the following version.
-    - If you are actively maintaining this repo, it's recommended to subscribe to this PR.
 - Confirm the new release in GitHub and artifact in Acquia Cloud UI.
 
 ### Composer Lock Diff for Release Notes
@@ -85,16 +102,16 @@ composer install
 	composer-lock-diff --md --from=PREVIOUS_VERSION --to=NEW_VERSION
 
 	# Example:
-	composer-lock-diff --md --from=11.17.0 --to=11.18.0
+	composer-lock-diff --md --from=12.1.0 --to=12.1.1
 	```
 - Add the output to the GitHub release notes.
 - Keep the "Full Changelog" link and paste the diff at the bottom.
 
 ### Notify Teams of upcoming deployment
 - Announce in client Slack channel:
-	> :launch1: A new 11.18.0 release has been created. The deployment to production will begin momentarily.
+	> :launch1: A new 12.1.1 release has been created. The deployment to production will begin momentarily.
 - Announce in any internal Slack channels for developers:
-	> :version: A new 11.18.0 release has been created for suhumsci. The next release branch is 11.18.1: <next_release_pr_link>
+	> :version: A new 12.1.1 release has been created for suhumsci and the production artifact is ready to deploy.
 
 :information_source: The release has been created and a deployment artifact has been pushed, but no deployment has been made at this point. The next step is to deploy to production, which is the true “point of no return”.
 
@@ -107,11 +124,12 @@ composer install
 ### Deploy the Artifact to Production
 - In Acquia Cloud UI:
 	1. Click the icon next to the "Code" tab for Prod.
-	2. Select the deployment artifact tag (e.g., `tags/2025-10-15_11.18.0`).
+	2. Select the deployment artifact tag (e.g., `tags/2026-02-21_12.1.1`).
 	3. Click "Continue" and then "Switch" to start deployment.
 
-### Deploy Next Release Branch to Staging
-- Manually deploy the newly created next release branch to the staging environment in Acquia Cloud UI (e.g., `11.18.1-release`)
+### Staging Deployment Note
+- Staging should continue to track the current `<major>.x-build` branch.
+- The production release workflow does not change the staging branch.
 
 ### Monitor Deployment
 - Monitor progress in Acquia Cloud UI and Slack alerts.

--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -14,6 +14,3 @@ This repo folows [Drupal Coding Standards](https://www.drupal.org/docs/develop/s
 ## Automation and Tools
 - The PHPCS scanner for Drupal is included and can be ran with `vendor/bin/phpcs`. There is also a PHPCS CI runner on every pull request.
 - The PHPStan package is included and configured for Drupal code. There is currently no CI runner.
-
-## Pull Requests
-- Pull requests should be scoped to the problem they are solving. Multiple smaller Pull Requests are generally preferred.

--- a/docs/architecture/decisions/0003-adopt-major-version-development-branching-strategy.md
+++ b/docs/architecture/decisions/0003-adopt-major-version-development-branching-strategy.md
@@ -1,0 +1,29 @@
+# 3. Adopt a major-version development branching strategy
+
+## Status
+
+Accepted
+
+## Context
+The previous branching model relied on `develop` as the long-lived integration branch and on pre-created `<version>-release` branches for release preparation and staging deploys. That model created unnecessary branch churn, tied day-to-day work to release-specific branches, and made Tugboat base previews depend on a branch that did not always reflect the code path used for active development. It also required additional automation to create and maintain the next release branch after every production release.
+
+We need a simpler model that keeps active development on the current major version, keeps staging continuously updated from that development branch, and preserves a separate production release control point.
+
+## Decision
+- Use a current major version branch, such as `12.x`, as the primary development branch and default branch.
+- Use a current major version branch as the normal base branch for feature and maintenance pull requests.
+- Generate and deploy a corresponding `<major>.x-build` artifact branch for staging from the current `<major>.x` branch.
+- Use `main` as the production release branch.
+- Create release branches from the current `<major>.x` branch when preparing a production release.
+- Merge release pull requests into `main` to trigger production release automation.
+- After a release pull request is merged into `main`, merge the release branch back into the current `<major>.x` branch to return version increments and any other release-only changes.
+- Retire the use of long-lived `<version>-release` branches and retire automation that creates the next release branch automatically.
+
+## Consequences
+- Day-to-day development is consolidated on the current `<major>.x` branch.
+- Staging can track the current `<major>.x-build` branch and stay aligned with recently merged development work.
+- Production releases remain intentionally controlled through `main` rather than by every merge into the development branch.
+- Tugboat base previews should follow the current `<major>.x` branch instead of `develop`.
+- Release preparation now includes creating a short-lived release branch and a release pull request into `main`.
+- Release completion now includes a back-to-dev step so the current `<major>.x` branch receives version increments and other release-only changes.
+- Existing documentation, GitHub rulesets, branch protections, and automation must follow the `main` plus `<major>.x` branching model.


### PR DESCRIPTION
# Summary
Adopt the new branching strategy across GitHub Actions and project documentation by moving day-to-day development to the current major version branch, using `main` for production releases, and retiring the old long-lived `*-release` workflow.

## Backstory
[HSD8-1886](https://stanfordits.atlassian.net/browse/HSD8-1886): Adopt new branching strategy: main + *.x development branch

This PR updates the repo to support the new branch model for H&S.

Key changes in this PR:
- Splits branch deployment logic into reusable workflows for tests, pull requests, development-branch pushes, and artifact deploys.
- Updates release automation to trigger only for pull requests merged into `main`.
- Removes automation that created the next `*-release` branch and PR.
- Updates the dependency update workflow to use the repository default branch instead of the latest `*-release` branch.
- Renames the previous combined test workflow to `tests.yml` and moves deploy behavior into dedicated reusable workflows.
- Refreshes README and deployment documentation to describe the `main` plus `<major>.x` workflow.
- Adds `docs/BranchingStrategy.md` to document branch roles and day-to-day expectations.
- Adds ADR `0003` to record the move to the new major-version branching strategy.

This is part of the move away from `develop` plus pre-created release branches and toward:
- `<major>.x` as the default development branch
- `<major>.x-build` as the staging artifact branch
- `main` as the production release branch

## Need Review By (Date)
ASAP

## Urgency
medium

## Steps to Test
1. Review `.github/workflows/dependency-updates.yml` and confirm it no longer discovers or targets a `*-release` branch and instead uses `${{ github.event.repository.default_branch }}` for the lock diff and PR base.
2. Review `.github/workflows/release.yml` and confirm it only runs when a pull request is merged into `main`, uses `release_branch: main`, and no longer creates the next release branch or PR.
3. Review `.github/workflows/tests.yml`, `.github/workflows/pull-request-actions.yml`, `.github/workflows/dev-branch-actions.yml`, and `.github/workflows/deploy-branch.yml` to confirm tests and branch artifact deploys are now split into reusable workflows and that development-branch pushes deploy the corresponding `*.x-build` artifact branch.
4. Review `README.md`, `docs/BranchingStrategy.md`, and `docs/CodeDeploy.md` to confirm they describe the new `<major>.x` / `<major>.x-build` / `main` workflow, the back-to-dev step, and the `-build` artifact naming behavior.
5. Review `docs/architecture/decisions/0003-adopt-major-version-development-branching-strategy.md` and confirm it accurately captures the architectural decision behind the new branching model.
6. Optionally validate the GitHub Actions YAML and markdown rendering in GitHub after opening the PR.


[HSD8-1886]: https://stanfordits.atlassian.net/browse/HSD8-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ