### PR TITLE
HSD8-1888: Add Shield middleware patch for Drupal 11 hook loading error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -291,7 +291,8 @@
                 "https://www.drupal.org/project/redirect/issues/3018897": "patches/contrib/redirect-3018897-mr-92-20260501.patch"
             },
             "drupal/shield": {
-                "https://www.drupal.org/project/shield/issues/3479117": "patches/shield-undefined_array_key_explode-3479117.patch"
+                "https://www.drupal.org/project/shield/issues/3479117": "patches/shield-undefined_array_key_explode-3479117.patch",
+                "https://www.drupal.org/project/shield/issues/3277210: Shield middleware invokes hooks before modules are loaded, corrupting module_implements cache": "patches/contrib/shield-3277210-mr-5-20260521.patch"
             },
             "drupal/ui_patterns": {
                 "Ui Patterns Views Preview": "patches/contrib/ui_patterns_views-preview.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "455c9d6708de26914c66b5d4ac97fd52",
+    "content-hash": "9ca6c8b7375d697b2247a0dfd7a102e1",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/patches/contrib/shield-3277210-mr-5-20260521.patch
+++ b/patches/contrib/shield-3277210-mr-5-20260521.patch
@@ -1,0 +1,15 @@
+diff --git a/src/ShieldMiddleware.php b/src/ShieldMiddleware.php
+index 3b0f3bf5617143bfa0a95ed6a2808f53188e7d9a..afe6c55fae02643b87f9699aec2dc97c63bbcbb4 100644
+--- a/src/ShieldMiddleware.php
++++ b/src/ShieldMiddleware.php
+@@ -174,6 +174,10 @@ class ShieldMiddleware implements HttpKernelInterface {
+       }
+     }
+ 
++    // @see https://www.drupal.org/project/shield/issues/3277210
++    // Prevent corrupting the module_implements cache.
++    $this->moduleHandler->loadAll();
++
+     // Check if user has provided credentials.
+     $user = NULL;
+     switch ($config->get('credential_provider')) {


### PR DESCRIPTION
# Summary
Add a temporary Shield patch for Drupal 11.2 compatibility that calls `moduleHandler->loadAll()` in `ShieldMiddleware` before credential-provider logic runs. This is intended to stop the repeated Shield-triggered `TypeError` / module hook loading issue seen on staging during the Drupal 11 upgrade work.

## Backstory
This came out of HSD8-1888, which was split off from the broader Drupal 11 upgrade work in HSD8-1833 after staging deployments started failing.

There were two separate issues happening at the same time:
- The staging Cloud Hook failure was mitigated by lowering multisite deploy parallelism from 5 to 3.
- A separate PHP runtime error was occurring thousands of times in a short window:
  `TypeError: Drupal\Core\Entity\EntityTypeManager::{closure}(): Argument #1 ($hook) must be of type callable, string given`

The stack trace consistently pointed to `ShieldMiddleware` triggering entity/config-driven hook paths before module files were fully loaded. After reviewing the related Drupal core and Shield issue threads, the short-term conclusion was:
- there is not a near-term core fix to rely on for Drupal 11.2
- core maintainers are generally pushing contrib modules to avoid this pattern in middleware
- the most practical temporary mitigation for this codebase is the Shield patch from issue #3277210 that calls `moduleHandler->loadAll()` before Shield does its middleware work

This PR adds that patch to Composer so it is applied consistently in builds and deploys.

Related context:
- [HSD8-1888](https://stanfordits.atlassian.net/browse/HSD8-1888): Staging deploy failure: Shield module D11 TypeError & Cloud Hook failure
- https://www.drupal.org/project/drupal/issues/3518705
- https://www.drupal.org/project/shield/issues/3497718
- https://www.drupal.org/project/shield/issues/3277210
- https://www.drupal.org/project/drupal/issues/3207813
- https://www.drupal.org/project/drupal/issues/1905334


## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Run `composer install` and confirm the Shield patch applies cleanly.
2. Verify the new patch entry is present under `drupal/shield` in `composer.json` and that the patch file exists at `patches/contrib/shield-3277210-mr-5-20260521.patch`.


[HSD8-1888]: https://stanfordits.atlassian.net/browse/HSD8-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ