### PR TITLE
HSD8-1883: Add themes to PHPStan scan and exclude node_modules

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Template\Attribute;
+use Drupal\file\FileInterface;
 use Drupal\node\Entity\Node;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\paragraphs\ParagraphInterface;
@@ -252,7 +253,7 @@ function humsci_basic_preload_full_width_image($image_referenced, $style_name, a
 
   $file = $image_referenced->get('field_media_image')->entity;
 
-  if (!$file) {
+  if (!$file instanceof FileInterface) {
     return;
   }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,10 @@ parameters:
   paths:
     - docroot/modules/humsci
     - docroot/profiles/humsci
+    - docroot/themes/humsci
+  excludePaths:
+    analyse:
+      - **/node_modules/**
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.
     - "#^Unsafe usage of new static#"


### PR DESCRIPTION
# Summary
Adds themes to the PHPStan scan, excludes any `node_modules` directories from analysis, and fixes the one real PHPStan issue found in `humsci_basic.theme`.

## Backstory
This is a small follow-up to HSD8-1883 after the larger PHPStan cleanup and CI work was already merged. While reviewing later PR work, I noticed PHP in a `.theme` file was not being covered by the current PHPStan configuration because `docroot/themes/humsci` was not part of the scan.

After adding themes to the scan, only three issues were reported:
- Two came from a bundled third-party PHP file inside `node_modules`, which should not be analyzed.
- One was a legitimate theme-level type issue in `humsci_basic.theme` where PHPStan could not guarantee the media entity was a file before `getFileUri()` was called.

This PR keeps the change narrowly scoped to that gap by expanding PHPStan coverage to custom themes, excluding `node_modules` globally, and fixing the one real issue that surfaced.

Related work:
- [HSD8-1883](https://stanfordits.atlassian.net/browse/HSD8-1883): Address PHP Stan warnings and Implement PHP Stan CI
- Prior PR: https://github.com/SU-HSDO/suhumsci/pull/2228

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Confirm `phpstan.neon` now scans `docroot/themes/humsci` and excludes `**/node_modules/**` from analysis.
2. Confirm `docroot/themes/humsci/humsci_basic/humsci_basic.theme` now checks that the referenced media image entity is a `FileInterface` before calling `getFileUri()`.
3. Run `vendor/bin/phpstan analyse --configuration=phpstan.neon` from the repo root.
4. Verify PHPStan completes with no errors.

[HSD8-1883]: https://stanfordits.atlassian.net/browse/HSD8-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ