### PR TITLE
SHS-6663: Rename Accordion "Summary" fields to "Title"

### DIFF
--- a/config/default/field.field.paragraph.hs_accordion.field_hs_accordion_summary.yml
+++ b/config/default/field.field.paragraph.hs_accordion.field_hs_accordion_summary.yml
@@ -9,7 +9,7 @@ id: paragraph.hs_accordion.field_hs_accordion_summary
 field_name: field_hs_accordion_summary
 entity_type: paragraph
 bundle: hs_accordion
-label: Summary
+label: Title
 description: ''
 required: true
 translatable: false

--- a/config/default/field.field.paragraph.hs_accordion.field_summary_heading_level.yml
+++ b/config/default/field.field.paragraph.hs_accordion.field_summary_heading_level.yml
@@ -11,8 +11,8 @@ id: paragraph.hs_accordion.field_summary_heading_level
 field_name: field_summary_heading_level
 entity_type: paragraph
 bundle: hs_accordion
-label: 'Summary heading level'
-description: "Adjusts only the structure of the accordion summary (the appearance remains the same regardless). If you've added a Heading 2 as a title above the accordion, then each accordion summary heading level should be set to Heading 3."
+label: 'Title heading level'
+description: "Adjusts only the structure of the accordion title (the appearance remains the same regardless). If you've added a Heading 2 as a title above the accordion, then each accordion title heading level should be set to Heading 3."
 required: true
 translatable: false
 default_value:

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -393,7 +393,7 @@ class FlexiblePageCest {
     $I->waitForText('Add Component');
     $I->fillField('.paragraphs-ee-add-dialog input[type="search"]', 'accordion');
     $I->click('Accordion', '.paragraphs-ee-add-dialog');
-    $I->waitForText('Title');
+    $I->waitForText('Add Expand/Collapse All');
     $I->fillField('Title', 'Sed augue ipsum egestas nec');
     $I->fillField('.ck-editor__editable_inline', 'Vivamus in erat ut urna cursus vestibulum. Sed augue ipsum, egestas nec, vestibulum et, malesuada adipiscing, dui. Curabitur suscipit suscipit tellus. Suspendisse enim turpis, dictum sed, iaculis a, condimentum nec, nisi. Nullam vel sem.');
     $I->click('Save');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -393,8 +393,8 @@ class FlexiblePageCest {
     $I->waitForText('Add Component');
     $I->fillField('.paragraphs-ee-add-dialog input[type="search"]', 'accordion');
     $I->click('Accordion', '.paragraphs-ee-add-dialog');
-    $I->waitForText('Summary');
-    $I->fillField('Summary', 'Sed augue ipsum egestas nec');
+    $I->waitForText('Title');
+    $I->fillField('Title', 'Sed augue ipsum egestas nec');
     $I->fillField('.ck-editor__editable_inline', 'Vivamus in erat ut urna cursus vestibulum. Sed augue ipsum, egestas nec, vestibulum et, malesuada adipiscing, dui. Curabitur suscipit suscipit tellus. Suspendisse enim turpis, dictum sed, iaculis a, condimentum nec, nisi. Nullam vel sem.');
     $I->click('Save');
     $I->waitForText('Demo Basic Page');

--- a/tests/codeception/functional/Install/Content/FlexiblePageCest.php
+++ b/tests/codeception/functional/Install/Content/FlexiblePageCest.php
@@ -394,7 +394,7 @@ class FlexiblePageCest {
     $I->fillField('.paragraphs-ee-add-dialog input[type="search"]', 'accordion');
     $I->click('Accordion', '.paragraphs-ee-add-dialog');
     $I->waitForText('Add Expand/Collapse All');
-    $I->fillField('Title', 'Sed augue ipsum egestas nec');
+    $I->fillField('field_hs_page_components[1][subform][field_hs_accordion_summary][0][value]', 'Sed augue ipsum egestas nec');
     $I->fillField('.ck-editor__editable_inline', 'Vivamus in erat ut urna cursus vestibulum. Sed augue ipsum, egestas nec, vestibulum et, malesuada adipiscing, dui. Curabitur suscipit suscipit tellus. Suspendisse enim turpis, dictum sed, iaculis a, condimentum nec, nisi. Nullam vel sem.');
     $I->click('Save');
     $I->waitForText('Demo Basic Page');

--- a/tests/codeception/functional/Install/Content/PrivatePageContentCest.php
+++ b/tests/codeception/functional/Install/Content/PrivatePageContentCest.php
@@ -22,7 +22,7 @@ class PrivatePageContentCest {
       'disable_component' => FALSE,
     ],
     'Accordion' => [
-      'component_text' => 'Summary',
+      'component_text' => 'Title',
       'component_button_name' => 'Accordion',
       'admin_name' => '[name="settings[handler_settings][target_bundles_drag_drop][hs_accordion][enabled]"]',
       'disable_component' => FALSE,

--- a/tests/codeception/functional/Install/Content/PrivatePageContentCest.php
+++ b/tests/codeception/functional/Install/Content/PrivatePageContentCest.php
@@ -22,7 +22,7 @@ class PrivatePageContentCest {
       'disable_component' => FALSE,
     ],
     'Accordion' => [
-      'component_text' => 'Title',
+      'component_text' => 'Add Expand/Collapse All',
       'component_button_name' => 'Accordion',
       'admin_name' => '[name="settings[handler_settings][target_bundles_drag_drop][hs_accordion][enabled]"]',
       'disable_component' => FALSE,


### PR DESCRIPTION
# Summary
- Update field labels and help text in accordion component

## Backstory

- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6663)

## Need Review By (Date)
06/03

## Urgency
medium

## Steps to Test
1. Log into any of the tugboat test sites (e.g. [Colorful](https://hs-colorful-mhf8hahw91rz9f6qusop5k5whkg9wrpx.tugboatqa.com/user/login))
2. [Create a flexible page](https://hs-colorful-mhf8hahw91rz9f6qusop5k5whkg9wrpx.tugboatqa.com/admin/dashboard?check_logged_in=1) and add an accordion component
3. Confirm that the following changes are in place:
    1. "Summary" field label is now "Title"
    2. "Summary heading level" field label is now "Title heading label"
    3. "Title heading label" help text is now "Adjusts only the structure of the accordion title (the appearance remains the same regardless). If you've added a Heading 2 as a title above the accordion, then each accordion title heading level should be set to Heading 3."

<img width="773" height="497" alt="Screenshot 2026-05-26 at 11 05 39 AM" src="https://github.com/user-attachments/assets/53a91833-f4f1-4ddd-b71c-d9481f0011fd" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211009228126167
  - https://app.asana.com/0/0/1215172556904971