### PR TITLE
Display the correct non-Acquia environment in Environment Indicator

### DIFF
--- a/docroot/sites/settings/environment_indicator.php
+++ b/docroot/sites/settings/environment_indicator.php
@@ -30,7 +30,7 @@ switch (EnvironmentDetector::getAhEnv()) {
 
   default:
     $envs = array_filter(EnvironmentDetector::getEnvironments());
-    $env = key($envs);
+    $env = key($envs) ?? 'Local';
     $config['environment_indicator.indicator']['bg_color'] = '#086601';
     $config['environment_indicator.indicator']['fg_color'] = '#fff';
     $config['environment_indicator.indicator']['name'] = $env;

--- a/docroot/sites/settings/environment_indicator.php
+++ b/docroot/sites/settings/environment_indicator.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @file
+ * Environment indicator configuration.
+ * @see https://www.drupal.org/project/environment_indicator
+ * @see /admin/config/development/environment-indicator
+ */
+
 use Drupal\SwsDrush\Helpers\EnvironmentDetector;
 
 switch (EnvironmentDetector::getAhEnv()) {
@@ -8,19 +15,24 @@ switch (EnvironmentDetector::getAhEnv()) {
     $config['environment_indicator.indicator']['fg_color'] = '#fff';
     $config['environment_indicator.indicator']['name'] = 'Development';
     break;
+
   case 'test':
     $config['environment_indicator.indicator']['bg_color'] = '#4127C2';
     $config['environment_indicator.indicator']['fg_color'] = '#fff';
     $config['environment_indicator.indicator']['name'] = 'Staging';
     break;
+
   case 'prod':
     $config['environment_indicator.indicator']['bg_color'] = '#000';
     $config['environment_indicator.indicator']['fg_color'] = '#fff';
     $config['environment_indicator.indicator']['name'] = 'Production';
     break;
+
   default:
+    $envs = array_filter(EnvironmentDetector::getEnvironments());
+    $env = key($envs);
     $config['environment_indicator.indicator']['bg_color'] = '#086601';
     $config['environment_indicator.indicator']['fg_color'] = '#fff';
-    $config['environment_indicator.indicator']['name'] = 'Local';
+    $config['environment_indicator.indicator']['name'] = $env;
     break;
 }


### PR DESCRIPTION
# Summary
All non-Acquia environments were showing as "local"

## Need Review By (Date)
no rush

## Urgency
low

## Steps to Test
1. visit any page on tugboat
2. look at the favicon.  Does it have an "L" overlaid (for "local"), or "C" (for CI)?
