### PR TITLE
HSD8-1848: Hide Content Access rebuild permissions link for non-developer workflows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -232,6 +232,9 @@
             "drupal/block_class": {
                 "Click JavaScript to close details causes modals to scroll unnecessarily https://www.drupal.org/project/block_class/issues/3497768": "patches/contrib/block_class/60.patch"
             },
+            "drupal/content_access": {
+                "Hide rebuild permissions link from Content Access status messages": "patches/contrib/content_access-hide-rebuild-permissions-link-20260527.patch"
+            },
             "drupal/content_access_simple": {
                 "https://www.drupal.org/project/content_access_simple/issues/3575304: Check for permission changes before running any actions on node submit": "patches/contrib/content_access_simple-3575304-mr-1.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ca6c8b7375d697b2247a0dfd7a102e1",
+    "content-hash": "e84f72c4ca079832f17680b9d420065c",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -27092,5 +27092,5 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/patches/contrib/content_access-hide-rebuild-permissions-link-20260527.patch
+++ b/patches/contrib/content_access-hide-rebuild-permissions-link-20260527.patch
@@ -1,0 +1,53 @@
+diff --git a/content_access.module b/content_access.module
+index 7429298..3566198 100644
+--- a/content_access.module
++++ b/content_access.module
+@@ -75,9 +75,7 @@ function content_access_user_update(EntityInterface $account) {
+     // Check if the user has 'access administration pages' permissions.
+     $account = \Drupal::currentUser();
+     if ($account->hasPermission('access administration pages')) {
+-      // Rebuild the permissions.
+-      \Drupal::messenger()->addMessage(t('Your changes have been saved. You may have to <a href=":rebuild">rebuild permissions</a> for your changes to take effect.',
+-        [':rebuild' => Url::fromRoute('node.configure_rebuild_confirm')->toString()]));
++      \Drupal::messenger()->addMessage(t('Your changes have been saved. You may have to rebuild permissions for your changes to take effect.'));
+     }
+   }
+ }
+diff --git a/src/Form/ContentAccessAdminSettingsForm.php b/src/Form/ContentAccessAdminSettingsForm.php
+index 1725c11..efbca0f 100644
+--- a/src/Form/ContentAccessAdminSettingsForm.php
++++ b/src/Form/ContentAccessAdminSettingsForm.php
+@@ -204,10 +204,9 @@ class ContentAccessAdminSettingsForm extends FormBase {
+           $node_types = node_type_get_names();
+         }
+         // This does not guarantee a rebuild.
+-        $this->messenger()->addMessage($this->t('Permissions have been changed for the content type @types.<br />You may have to <a href=":rebuild">rebuild permissions</a> for your changes to take effect.',
++        $this->messenger()->addMessage($this->t('Permissions have been changed for the content type @types.<br />You may have to rebuild permissions for your changes to take effect.',
+         [
+           '@types' => $node_types[$node_type],
+-          ':rebuild' => Url::fromRoute('node.configure_rebuild_confirm')->toString(),
+         ]));
+       }
+     }
+diff --git a/src/Form/ContentAccessPageForm.php b/src/Form/ContentAccessPageForm.php
+index 1bba34c..22732c2 100644
+--- a/src/Form/ContentAccessPageForm.php
++++ b/src/Form/ContentAccessPageForm.php
+@@ -8,7 +8,6 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
+ use Drupal\Core\Form\FormBase;
+ use Drupal\Core\Form\FormStateInterface;
+ use Drupal\Core\Template\Attribute;
+-use Drupal\Core\Url;
+ use Drupal\node\NodeGrantDatabaseStorageInterface;
+ use Drupal\node\NodeInterface;
+ use Symfony\Component\DependencyInjection\ContainerInterface;
+@@ -193,8 +192,7 @@ class ContentAccessPageForm extends FormBase {
+     // xxxx
+     // route: node.configure_rebuild_confirm:
+     // path:  '/admin/reports/status/rebuild'.
+-    $this->messenger()->addMessage($this->t('Your changes have been saved. You may have to <a href=":rebuild">rebuild permissions</a> for your changes to take effect.',
+-      [':rebuild' => Url::fromRoute('node.configure_rebuild_confirm')->toString()]));
++    $this->messenger()->addMessage($this->t('Your changes have been saved. You may have to rebuild permissions for your changes to take effect.'));
+   }
+ 
+   /**


### PR DESCRIPTION
# Summary
Hide the rebuild permissions link shown by `content_access` status messages by adding a local Composer patch for `drupal/content_access` 2.1.0.

## Backstory
[HSD8-1848](https://stanfordits.atlassian.net/browse/HSD8-1848): Non developer roles getting the rebuild permissions when granting a role

Site Managers and other non-developer roles can see Content Access messages telling them to rebuild permissions after role or access changes. In practice, those users either cannot access the rebuild flow at all or hit a 404 partway through it because Drupal now requires broader permissions to complete the rebuild flow. That has been generating support questions and confusion.

Rather than wait on the upstream refactor work in `content_access`, this PR takes the agreed short-term approach: keep the warning text, but remove the clickable rebuild link from the three `content_access` messages that surface it.

Implementation notes:
- Added a local patch file for `drupal/content_access`.
- Registered that patch in `composer.json`.
- Ran `composer install` to verify Composer config after wiring the patch.

Related context:
- https://www.drupal.org/node/3357478
- https://www.drupal.org/project/content_access/issues/3464095
- https://www.drupal.org/project/content_access/issues/3579507

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Run `composer install`.
2. Confirm the local patch is applied for `drupal/content_access`.
3. Log in as a Site Manager or another non-developer role that can trigger the Content Access messages.
4. Assign a role to a user or make a Content Access change that previously showed the rebuild permissions link.
5. Confirm the message still appears, but `rebuild permissions` is plain text and no longer a clickable link.
6. Confirm there is no regression in the surrounding save flow.

[HSD8-1848]: https://stanfordits.atlassian.net/browse/HSD8-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211009481851005