### PR TITLE
SHS-6669: Reduce spacing of photos in the grid view of the Photo Gallery component

### DIFF
--- a/docroot/modules/humsci/hs_paragraph_types/css/stanford_gallery.css
+++ b/docroot/modules/humsci/hs_paragraph_types/css/stanford_gallery.css
@@ -1,18 +1,18 @@
 .stanford-gallery.default .su-gallery-images {
   display: grid;
   justify-content: space-between;
-  row-gap: 4rem;
+  gap: 2rem;
 }
 
 @media (min-width: 768px) {
   .stanford-gallery.default .su-gallery-images {
-    grid-template-columns: repeat(auto-fill, calc(50% - 2rem));
+    grid-template-columns: repeat(auto-fill, calc(50% - 1rem));
   }
 }
 
 @media (min-width: 975px) {
   .stanford-gallery.default .su-gallery-images {
-    grid-template-columns: repeat(auto-fill, calc(33% - 2rem));
+    grid-template-columns: repeat(auto-fill, calc(33% - 1.34rem));
   }
 }
 


### PR DESCRIPTION
# Summary
Reduce spacing of photos in the grid view of the Photo Gallery component

## Backstory
[SHS-6669](https://app.clickup.com/t/36718269/SHS-6669)

## Need Review By (Date)
06/09

## Urgency
medium

## Steps to Test
1. Go to the following pages on:
    - Colorful:
       - https://hs-colorful-wfqtl2jd9ktqvojvnncz8ejoc8wgb6tr.tugboatqa.com/components/photo-album
       - https://hs-colorful-wfqtl2jd9ktqvojvnncz8ejoc8wgb6tr.tugboatqa.com/test-photo-album-full-width
    - Traditional:
       - https://hs-traditional-wfqtl2jd9ktqvojvnncz8ejoc8wgb6tr.tugboatqa.com/components/photo-album
       - https://hs-traditional-wfqtl2jd9ktqvojvnncz8ejoc8wgb6tr.tugboatqa.com/test-photo-album-full-width 
2. Confirm the space is reduced by half, similar to what we use on [Vertical Postcards](https://hs-traditional.stanford.edu/components/collections-0/collections-postcards/vertical-cards#:~:text=Vertical%20Postcards%20with%20Image%20and%20Body%20in%20a%20Collection)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214954555173774
  - https://app.asana.com/0/0/1215316115493602