### PR TITLE
HSD8-1897: Increase deploy artifact log verbosity in CI

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -51,4 +51,4 @@ jobs:
           git config --global user.name "Github Actions" &&
           ssh-keyscan -t rsa svn-2314.prod.hosting.acquia.com >> /root/.ssh/known_hosts &&
           composer install -n &&
-          drush sws:artifact:deploy -v -n
+          drush sws:artifact:deploy -vv -n


### PR DESCRIPTION
# Summary
Increase deploy artifact logging from `-v` to `-vv` in the GitHub Actions deploy workflow so post-build failures surface the actual underlying npm/theme-build error instead of only the generic `Failed to run post build script` message. This is intended both to diagnose the current intermittent CI deploy failures and to keep more actionable output available for future debugging.

## Backstory
[HSD8-1897](https://stanfordits.atlassian.net/browse/HSD8-1897): Investigate and fix intermittent post-build script failures in CI deploys

Deploy Artifact runs in both dev branch actions and pull request actions started failing intermittently in late May with only the upstream Drush wrapper error from `sws:artifact:deploy`, which was not enough to identify the real cause. Local testing showed `-v` did not surface the post-build script error text, while `-vv` did.

## Need Review By (Date)
ASAP

## Urgency
medium

## Steps to Test
1. Review the workflow diff in [.github/workflows/deploy-branch.yml](/home/joegl/apache_www/suhumsci/.github/workflows/deploy-branch.yml) and confirm the only behavioral change is `drush sws:artifact:deploy -v -n` to `drush sws:artifact:deploy -vv -n`.
2. Trigger a Deploy Artifact run through the existing GitHub Actions path.
3. If the post-build step fails, confirm the job log now includes the underlying npm/theme-build error output rather than only `Failed to run post build script`.
4. If the deploy succeeds, confirm the added verbosity does not otherwise change workflow behavior beyond more detailed logging.


[HSD8-1897]: https://stanfordits.atlassian.net/browse/HSD8-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ