### PR TITLE
HSD8-1896: Add stanford_media patch for anonymous slider fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -312,6 +312,9 @@
             },
             "su-sws/stanford_fields": {
                 "Make Localist API Public": "patches/contrib/stanford_fields-localist-api-public.patch"
+            },
+            "su-sws/stanford_media": {
+                "HSD8-1896: jQuery dependency; remove after D11.3 stanford_media upgrade": "patches/contrib/stanford_media-add-jquery-dependency-20260601.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e84f72c4ca079832f17680b9d420065c",
+    "content-hash": "54370064c80607fa79390e03ad23fa32",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/patches/contrib/stanford_media-add-jquery-dependency-20260601.patch
+++ b/patches/contrib/stanford_media-add-jquery-dependency-20260601.patch
@@ -1,0 +1,11 @@
+diff --git a/stanford_media.libraries.yml b/stanford_media.libraries.yml
+index d8ff155..636ef26 100644
+--- a/stanford_media.libraries.yml
++++ b/stanford_media.libraries.yml
+@@ -13,4 +13,6 @@ display:
+   js:
+     js/stanford-media.js: {}
+   dependencies:
++    - core/drupal
++    - core/jquery
+     - core/once


### PR DESCRIPTION
# Summary
Adds a local Composer patch for `su-sws/stanford_media` so anonymous users no longer hit the missing `jQuery` dependency bug that breaks banner/spotlight sliders and photo album slideshows. This is a temporary app-level patch until this project can consume the D11.3-compatible upstream `stanford_media` release that will include the fix on next release.

## Backstory
[HSD8-1896](https://stanfordits.atlassian.net/browse/HSD8-1896): Slider Issues on banner image and spotlights
[HSD8-1895](https://stanfordits.atlassian.net/browse/HSD8-1895): Photo Album Slideshow not rendering properly for anonymous users

This addresses both HSD8-1896 and HSD8-1895. On staging/local, anonymous users could reproduce `jQuery is not defined` from `stanford-media.js`, which broke slider behavior on banner images, spotlights, and photo album slideshows. The root fix was merged upstream in `SU-SWS/stanford_media` via PR 170, but `suhumsci` is still on Drupal 11.2 and cannot yet take the newer D11.3-compatible module release, so this PR carries the upstream fix as a local Composer patch.

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Check out this branch.
2. Run `composer install`.
3. Run `drush cr` or `drush @humanbiology.local cr`.
4. As an anonymous user, visit a previously affected page
5. Confirm the slider behavior now works and the page no longer throws `jQuery is not defined` from `stanford-media.js`.

[HSD8-1896]: https://stanfordits.atlassian.net/browse/HSD8-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSD8-1895]: https://stanfordits.atlassian.net/browse/HSD8-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215085088382556
  - https://app.asana.com/0/0/1215085118320111