### PR TITLE
HSD8-1887: Upgrade su-sws modules and regenerate Localist API patch for stanford_fields 9.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,6 @@
         "drupal/purge": "^3.2",
         "drupal/purge_users": "^5.0",
         "drupal/rabbit_hole": "^1.0-beta4",
-        "drupal/readonly_field_widget": "^1.4",
         "drupal/real_aes": "^2.3",
         "drupal/redirect": "^1.12",
         "drupal/role_delegation": "^1.1",
@@ -192,10 +191,10 @@
         "onlyextart/colorbox": "dev-master#e58476becbc89dc671093d1bcd9f99b2167fa8f7",
         "sainsburys/guzzle-oauth2-plugin": "^3.0",
         "su-sws/ckeditor5_plugins": "^1.0",
-        "su-sws/stanford_fields": "^8.1",
+        "su-sws/stanford_fields": "^9.0",
         "su-sws/stanford_media": "^11.0",
-        "su-sws/stanford_migrate": "^8.4",
-        "su-sws/stanford_samlauth": "^1.0",
+        "su-sws/stanford_migrate": "^9.0",
+        "su-sws/stanford_samlauth": "^2.0",
         "su-sws/sws-drush-commands": "multisite-improvements-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -310,7 +310,7 @@
                 "https://www.drupal.org/project/views_taxonomy_term_name_depth/issues/2877249": "patches/contrib/views_taxonomy_term_name_depth-2877249-mr-2.patch"
             },
             "su-sws/stanford_fields": {
-                "Make Localist API Public": "patches/contrib/stanford_fields-localist-api-public.patch"
+                "Make Localist API Public": "patches/contrib/stanford_fields-localist-api-public-20260601.patch"
             },
             "su-sws/stanford_media": {
                 "HSD8-1896: jQuery dependency; remove after D11.3 stanford_media upgrade": "patches/contrib/stanford_media-add-jquery-dependency-20260601.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67700a169d08577879c19b73509c4a68",
+    "content-hash": "2d7377e24bdc4cdfdfb91d44441a84bd",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -10295,17 +10295,17 @@
         },
         {
             "name": "drupal/readonly_field_widget",
-            "version": "1.6.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/readonly_field_widget.git",
-                "reference": "8.x-1.6"
+                "reference": "2.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/readonly_field_widget-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "595c7b27ddbf535594d9a4e2d8fb206dd50e2a63"
+                "url": "https://ftp.drupal.org/files/projects/readonly_field_widget-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "7aa60522e3d89aba5ddce1c7a8b59435c5d616c3"
             },
             "require": {
                 "drupal/core": "^8 || ^9 || ^10 || ^11"
@@ -10313,8 +10313,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1726986724",
+                    "version": "2.1.0",
+                    "datestamp": "1754564080",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -16537,30 +16537,37 @@
         },
         {
             "name": "su-sws/stanford_fields",
-            "version": "8.6.3",
+            "version": "9.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/stanford_fields.git",
-                "reference": "3abfc931a4e652a3c48ea01c6a548b42b4ca0207"
+                "reference": "535ab07fee7a8f16ccd63f33b77f86707899c471"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_fields/zipball/3abfc931a4e652a3c48ea01c6a548b42b4ca0207",
-                "reference": "3abfc931a4e652a3c48ea01c6a548b42b4ca0207",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_fields/zipball/535ab07fee7a8f16ccd63f33b77f86707899c471",
+                "reference": "535ab07fee7a8f16ccd63f33b77f86707899c471",
                 "shasum": ""
             },
             "require": {
-                "drupal/core": "^10.3 || ^11",
-                "drupal/ds": "~3.3 || ^5.0@alpha"
+                "drupal/core": "^11.1",
+                "drupal/ds": "^3.3"
             },
             "conflict": {
                 "drupal/book": "<2.0"
             },
             "require-dev": {
                 "drupal/book": "^2.0",
-                "drupal/cshs": "^4.0"
+                "drupal/cshs": "^4.0",
+                "drupal/fontawesome": ">=3.0",
+                "drupal/search_api": "^1.38"
             },
             "type": "drupal-custom-module",
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\stanford_fields\\": "./src"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
@@ -16569,9 +16576,9 @@
             "homepage": "https://github.com/SU-SWS/stanford_fields",
             "support": {
                 "issues": "https://github.com/SU-SWS/stanford_fields/issues",
-                "source": "https://github.com/SU-SWS/stanford_fields/tree/8.6.3"
+                "source": "https://github.com/SU-SWS/stanford_fields/tree/9.1.4"
             },
-            "time": "2025-08-15T22:28:52+00:00"
+            "time": "2026-05-06T21:00:25+00:00"
         },
         {
             "name": "su-sws/stanford_media",
@@ -16637,29 +16644,29 @@
         },
         {
             "name": "su-sws/stanford_migrate",
-            "version": "8.7.0",
+            "version": "9.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/stanford_migrate.git",
-                "reference": "afbd341b760b6a17ece4267f014e11b5b767c7a7"
+                "reference": "6242db8b03379561c56ea3dc6c0c214e4d68d1ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_migrate/zipball/afbd341b760b6a17ece4267f014e11b5b767c7a7",
-                "reference": "afbd341b760b6a17ece4267f014e11b5b767c7a7",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_migrate/zipball/6242db8b03379561c56ea3dc6c0c214e4d68d1ec",
+                "reference": "6242db8b03379561c56ea3dc6c0c214e4d68d1ec",
                 "shasum": ""
             },
             "require": {
-                "drupal/core": "^10.3 || ^11",
+                "drupal/core": "^11.1",
                 "drupal/empty_fields": "^1.0@beta",
                 "drupal/migrate_file": "^2.0 || ^3.0",
                 "drupal/migrate_plus": "^6.0",
                 "drupal/migrate_source_csv": "^3.4",
                 "drupal/migrate_tools": "^6.1",
-                "drupal/readonly_field_widget": "^1.6",
+                "drupal/readonly_field_widget": "^2.1",
                 "drupal/ultimate_cron": "^2.0@alpha",
                 "joshfraser/php-name-parser": "dev-master",
-                "php": ">=8.0"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "drupal/entity_reference_revisions": "^1.9"
@@ -16688,27 +16695,27 @@
             "homepage": "https://github.com/SU-SWS/stanford_migrate",
             "support": {
                 "issues": "https://github.com/SU-SWS/stanford_migrate/issues",
-                "source": "https://github.com/SU-SWS/stanford_migrate/tree/8.7.0"
+                "source": "https://github.com/SU-SWS/stanford_migrate/tree/9.2.0"
             },
-            "time": "2025-07-16T19:11:16+00:00"
+            "time": "2025-11-03T17:05:13+00:00"
         },
         {
             "name": "su-sws/stanford_samlauth",
-            "version": "1.2.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/stanford_samlauth.git",
-                "reference": "26a91913e5e7251793a8d3dec1439074a20a6035"
+                "reference": "b8818300242ad85f2a59becbf444d837adb7d5b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/stanford_samlauth/zipball/26a91913e5e7251793a8d3dec1439074a20a6035",
-                "reference": "26a91913e5e7251793a8d3dec1439074a20a6035",
+                "url": "https://api.github.com/repos/SU-SWS/stanford_samlauth/zipball/b8818300242ad85f2a59becbf444d837adb7d5b2",
+                "reference": "b8818300242ad85f2a59becbf444d837adb7d5b2",
                 "shasum": ""
             },
             "require": {
                 "drupal/autologout": "^1 || ^2",
-                "drupal/core": "^10.3 || ^11",
+                "drupal/core": "^11.1",
                 "drupal/r4032login": "^2",
                 "drupal/samlauth": "^3",
                 "php": ">=8.1"
@@ -16728,9 +16735,9 @@
             ],
             "support": {
                 "issues": "https://github.com/SU-SWS/stanford_samlauth/issues",
-                "source": "https://github.com/SU-SWS/stanford_samlauth/tree/1.2.2"
+                "source": "https://github.com/SU-SWS/stanford_samlauth/tree/2.1.3"
             },
-            "time": "2026-05-05T16:23:18+00:00"
+            "time": "2026-05-05T16:24:58+00:00"
         },
         {
             "name": "su-sws/sws-drush-commands",
@@ -19750,16 +19757,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.27.0",
+            "version": "v3.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
-                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae2071bffb38f04847fc0864d730c94b9cb8ab74",
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74",
                 "shasum": ""
             },
             "require": {
@@ -19814,7 +19821,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.1"
             },
             "funding": [
                 {
@@ -19826,7 +19833,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T13:05:51+00:00"
+            "time": "2026-05-30T17:09:26+00:00"
         },
         {
             "name": "typhonius/acquia-php-sdk-v2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d7377e24bdc4cdfdfb91d44441a84bd",
+    "content-hash": "129368c2c936f24da25b3df7563ffb76",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/docroot/modules/humsci/hs_dashboard/src/Plugin/views/field/SourceField.php
+++ b/docroot/modules/humsci/hs_dashboard/src/Plugin/views/field/SourceField.php
@@ -27,7 +27,7 @@ class SourceField extends FieldPluginBase {
       return $this->t('Local');
     }
 
-    $migration = \Drupal::service('stanford_migrate')->getNodesMigration($node);
+    $migration = \Drupal::service('stanford_migrate')->getEntityMigration($node);
     return ($migration) ? $this->t('Imported') : $this->t('Local');
   }
 

--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -797,7 +797,7 @@ function _hs_field_helpers_get_imported_fields(NodeInterface $node) : array {
   // @see stanford_migrate_entity_form_display_alter.
   $imported_fields = [];
 
-  $migration = \Drupal::service('stanford_migrate')->getNodesMigration($node);
+  $migration = \Drupal::service('stanford_migrate')->getEntityMigration($node);
 
   // Check if the current node was imported.
   if (!$migration) {
@@ -825,13 +825,14 @@ function _hs_field_helpers_get_imported_fields(NodeInterface $node) : array {
     // If the migration destination has the `overwrite_properties` configured,
     // those fields specifically should be locked, not the other fields that
     // are not designated in the original process configuration.
-    if ($processing && !empty($migration->get('destination')['overwrite_properties'])) {
+    $destination = $migration->getDestinationConfiguration();
+    if ($processing && !empty($destination['overwrite_properties'])) {
       // If the current field doesn't exist in the overwrite_properties, it
       // should not be considered to be processing since it's a one time only
       // import.
       $processing = FALSE;
 
-      foreach ($migration->get('destination')['overwrite_properties'] as $overwrite_property) {
+      foreach ($destination['overwrite_properties'] as $overwrite_property) {
         // If any part of the field is set to overwrite, lock the whole field
         // down.
         $overwrite_property = strstr($overwrite_property, '/', TRUE) ?: $overwrite_property;

--- a/docroot/modules/humsci/hs_migrate/hs_migrate.module
+++ b/docroot/modules/humsci/hs_migrate/hs_migrate.module
@@ -120,7 +120,7 @@ function _hs_migrate_media_imported($media_id) {
       $migration = NULL;
       $nodes = Node::loadMultiple($results);
       foreach ($nodes as $node) {
-        $migration = \Drupal::service('stanford_migrate')->getNodesMigration($node);
+        $migration = \Drupal::service('stanford_migrate')->getEntityMigration($node);
       }
       if ($migration) {
         return TRUE;

--- a/docroot/modules/humsci/hs_migrate/src/Plugin/views/field/EntityMigrationField.php
+++ b/docroot/modules/humsci/hs_migrate/src/Plugin/views/field/EntityMigrationField.php
@@ -60,7 +60,7 @@ class EntityMigrationField extends FieldPluginBase {
         return '';
       }
 
-      $migration = $this->stanfordMigrate->getNodesMigration($values->_entity);
+      $migration = $this->stanfordMigrate->getEntityMigration($values->_entity);
       if ($migration) {
         return $migration->label();
       }

--- a/patches/contrib/stanford_fields-localist-api-public-20260601.patch
+++ b/patches/contrib/stanford_fields-localist-api-public-20260601.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php b/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
-index 8178161..cba6be6 100644
+index f2d6526..93dbc63 100644
 --- a/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
 +++ b/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
-@@ -343,13 +343,13 @@ protected function getPlaces(?string $default_value = NULL): array {
+@@ -344,13 +344,13 @@ class LocalistUrlWidget extends LinkWidget {
    /**
     * Get the data from the localist API.
     */
@@ -12,30 +12,30 @@ index 8178161..cba6be6 100644
      if ($this->apiData) {
        return $this->apiData;
      }
-
+ 
 -    $base_url = $this->getSetting('base_url');
 +    $base_url = $base_url ?? $this->getSetting('base_url');
-
+ 
      // Check for some cached data before we fetch it all again.
      if ($cache = $this->cache->get("localist_api:$base_url")) {
-@@ -363,7 +363,7 @@ protected function getApiData() {
+@@ -364,13 +364,15 @@ class LocalistUrlWidget extends LinkWidget {
      }
-
+ 
      try {
 -      $this->fetchApiData();
 +      $this->fetchApiData($base_url);
      }
      catch (\Throwable $e) {
        if (!$this->apiData) {
-@@ -371,6 +371,7 @@ protected function getApiData() {
+         throw $e;
        }
      }
-
++
 +    return $this->apiData;
    }
-
+ 
    /**
-@@ -379,8 +380,7 @@ protected function getApiData() {
+@@ -379,8 +381,7 @@ class LocalistUrlWidget extends LinkWidget {
     * @return array
     *   Keyed array of api data.
     */
@@ -45,16 +45,16 @@ index 8178161..cba6be6 100644
      $options = [
        'timeout' => 5,
        'base_uri' => $base_url,
-@@ -402,7 +402,7 @@ protected function fetchApiData(): array {
+@@ -402,7 +403,7 @@ class LocalistUrlWidget extends LinkWidget {
          continue;
        }
-
+ 
 -      $this->apiData[$key] = $this->fetchPagedApiData($key, $response['page']['total']);
 +      $this->apiData[$key] = $this->fetchPagedApiData($base_url, $key, $response['page']['total']);
      }
-
+ 
      $this->cache->set("localist_api:$base_url", [
-@@ -424,8 +424,7 @@ protected function fetchApiData(): array {
+@@ -424,8 +425,7 @@ class LocalistUrlWidget extends LinkWidget {
     * @return array
     *   Indexed array of api data.
     */


### PR DESCRIPTION
# Summary
Upgrades su-sws modules for D11 compatibility and fixes the custom Localist API patch so it applies on the new stanford_fields release.

- Updated module constraints:
  - su-sws/stanford_fields: ^8.1 -> ^9.0
  - su-sws/stanford_migrate: ^8.4 -> ^9.0
  - su-sws/stanford_samlauth: ^1.0 -> ^2.0
  - su-sws/stanford_media remains on ^11.0 (already current for this effort)
- Removed direct root requirement for drupal/readonly_field_widget; now resolved via stanford_migrate dependency.
- Replaced Localist patch reference with a newly regenerated patch compatible with stanford_fields 9.1.4:
  - patches/contrib/stanford_fields-localist-api-public-20260601.patch
- Addressed PHPStan findings introduced by stanford_migrate API updates:
  - Replaced deprecated `getNodesMigration()` calls with `getEntityMigration()` in hs_dashboard/hs_field_helpers/hs_migrate.
  - Replaced unsupported MigrationInterface `get('destination')` access with `getDestinationConfiguration()` in hs_field_helpers.
- Synced lockfile updates from composer resolution.

## Backstory
This follows HSD8-1833/HSD8-1887 work to move su-sws modules to current compatible versions for D11.

While upgrading stanford_fields to 9.1.4, the existing custom patch for exposing Localist API access no longer applied cleanly. That patch is required by hs_dashboard (4k dashboard use case), so a replacement patch was recreated against the newer stanford_fields code and wired into composer patching.

After dependency updates, the phpstan workflow also flagged deprecated/invalid migration API usage in humsci modules. This PR includes compatibility updates to align with current stanford_migrate APIs and clear those errors.

## Need Review By (Date)
asap

## Urgency
medium-high

## Steps to Test
1. From repo root, run `composer install`.
2. Confirm composer applies `patches/contrib/stanford_fields-localist-api-public-20260601.patch` successfully.
4. Run database updates: `drush @default.local updatedb -y`.
6. Spot-check hs_dashboard Localist importer info pages still render filter/group/place lookup data (no Localist API regressions).
7. Sanity-check migrated module functionality for:
   - stanford_fields
   - stanford_migrate
   - stanford_samlauth
