### PR TITLE
SHS-6678: Main navigation D11 active-trail classes changed causing a different colour

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_main-nav.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_main-nav.scss
@@ -277,6 +277,14 @@ $item-line-height-lg: 110%;
               }
             }
             /* stylelint-enable max-nesting-depth */
+
+            // Link to frontpage has a different active accent color.
+            &[data-drupal-link-system-path="<front>"] {
+              &::before {
+                background-color: color('secondary');
+              }
+            }
+
           }
         }
       }


### PR DESCRIPTION
# Summary
- Fix color used for homepage link active state on dark pattern main navigation

## Backstory
- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6678)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Visit the homepage on the [Colorful tugboat site](https://hs-colorful-4hmlmakjjvvbmrhyst0u91hx1a8midpj.tugboatqa.com/)
2. Confirm that the site masthead dark variation is enabled. If not, [login](https://hs-colorful-4hmlmakjjvvbmrhyst0u91hx1a8midpj.tugboatqa.com/user) and set it in the theme settings
3. Confirm that the accent line under the "Home" menu item is using the "Secondary" color, instead of the default "Tertiary Reversed"
4. Repeat the test in the [Traditional Test Site](https://hs-traditional-4hmlmakjjvvbmrhyst0u91hx1a8midpj.tugboatqa.com/)

<img width="337" height="150" alt="Screenshot 2026-06-01 at 5 19 00 PM" src="https://github.com/user-attachments/assets/bcab22f9-4392-4bc0-8452-d4f8002827c3" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215085118320106