### PR TITLE
HSD8-1890: Remove stale hs_page_reports permissions from site manager role config

### DIFF
--- a/config/default/user.role.site_manager.yml
+++ b/config/default/user.role.site_manager.yml
@@ -231,8 +231,6 @@ permissions:
   - 'use text format bold_italics_links'
   - 'use text format minimal_html'
   - 'use text format minimal_html_with_styles'
-  - 'view 403 reports'
-  - 'view 404 reports'
   - 'view any unpublished content'
   - 'view editoria11y checker'
   - 'view hs_basic_page revisions'


### PR DESCRIPTION
# Summary
Remove `hs_page_reports` permissions (`view 403 reports`, `view 404 reports`) from the site manager role config. These permissions were previously removed via a database update hook but were never exported to the config file due to config_ignore/config_split behavior.

## Backstory
In the previous PR (#2260) that uninstalled `hs_page_reports`, a database update hook removed these permissions from the site manager role at runtime. However, because of config_ignore settings (which ignore user permissions by default in the default split but not the local split), those permission removals were never exported to `config/default/user.role.site_manager.yml`. This PR manually removes the stale permissions from the config file so the exported config matches the actual state on production.

[HSD8-1890](https://stanfordits.atlassian.net/browse/HSD8-1890)

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. Apply the config import: `drush @<site>.local ci -y`
2. Navigate to **Admin > People > Roles** and confirm the Site Manager role no longer has `view 403 reports`, `view 404 reports`, or `rebuild cache access` permissions listed.
3. Confirm no unexpected permission changes occurred on other roles.


[HSD8-1890]: https://stanfordits.atlassian.net/browse/HSD8-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ