### PR TITLE
HSD8-1910: Document deploy hook adoption and create ADR

### DIFF
--- a/docs/CodeDeploy.md
+++ b/docs/CodeDeploy.md
@@ -211,8 +211,16 @@ If a site failed to update:
 	```bash
 	drush @DRUSHALIAS.prod updatedb -y
 	drush @DRUSHALIAS.prod ci
+	drush @DRUSHALIAS.prod deploy:hook -y
 	drush @DRUSHALIAS.prod cr
 	```
+
+	If you only need to re-run the full deploy sequence rather than step through commands individually, use:
+	```bash
+	drush @DRUSHALIAS.prod deploy
+	```
+
+	> **Important:** Always include `deploy:hook` after `config:import`. Deploy hooks run after config import by design and will be skipped if omitted. See [ADR 0004](architecture/decisions/0004-use-deploy-hooks-for-post-config-operations.md).
 3. For major failures, coordinate with other developers and consider a hotfix or rollback.
 
 ## Rolling Back a Deployment

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -41,6 +41,14 @@ The platform uses a combination of contributed and custom modules to manage conf
 - For more information see the [hs_config_partial module README](../docroot/modules/humsci/hs_config_partial/README.md).
 
 
+## Deploy Hooks and Post-Config-Import Operations
+
+Some operations must run after config import has completed. For example, granting permissions tied to a new content type that is itself created by config import. `hook_update_N()` runs before config import, so those operations will fail or be rolled back if placed in an update hook.
+
+Use `hook_deploy_NAME()` (in a `MODULE.deploy.php` file) for any operation that depends on configuration existing in active storage first. `drush deploy` and `drush drupal:sync` both run `deploy:hook` automatically after config import. When running updates manually, always include `drush deploy:hook` after `drush config:import`.
+
+See [ADR 0004](architecture/decisions/0004-use-deploy-hooks-for-post-config-operations.md) for the full decision and naming conventions used in this project.
+
 ## Best Practices
 
 - Always use standard config import/export commands unless you have a specific reason to bypass `config_ignore` or `config_split`.
@@ -49,6 +57,7 @@ The platform uses a combination of contributed and custom modules to manage conf
 - For local development, `config_ignore` and `config_split` can be overridden in settings files to match the local environment.
 - Running `config-import` twice is a recommended approach. Certain configuration can require a fully completed config import before it is respected, especially with `config_split`.
 - Use a database update hook to install or uninstall modules and do not rely on the config-import of the `core.extension.yml` to handle these.
+- Use `hook_deploy_NAME()` for operations that depend on config import having completed (e.g., permissions for new content types, entity operations tied to new bundles).
 - If you need to allow deletion of specific config (e.g., for module uninstalls or legacy cleanup), add the appropriate prefix to the allow-list in `settings.php` as described in the [hs_config_partial module README](../docroot/modules/humsci/hs_config_partial/README.md).
 
 

--- a/docs/DocumentationStandards.md
+++ b/docs/DocumentationStandards.md
@@ -137,5 +137,5 @@ ADRs in `docs/architecture/decisions/` are **immutable historical records**:
 1. If a new development tool is required by the project, add it to `docs/DevelopmentRequirements.md`
 1. If a step is unclear or potentially missing, note it explicitly with a `> **Note:**` rather than guessing
 1. Review links for accuracy — external links go stale
-1. If a new file was added under `docs/`, confirm it is linked from `README.md` in the appropriate Documentation section
+1. If a new file was added directly under `docs/` (not in a subdirectory), confirm it is linked from `README.md` in the appropriate Documentation section
 1. Update this file whenever new documentation conventions are established

--- a/docs/architecture/decisions/0004-use-deploy-hooks-for-post-config-operations.md
+++ b/docs/architecture/decisions/0004-use-deploy-hooks-for-post-config-operations.md
@@ -1,0 +1,31 @@
+# 4. Use Deploy Hooks for Post-Config-Import Operations
+
+## Status
+
+Accepted
+
+## Context
+
+On this platform, `config_ignore` prevents certain categories of config from being imported automatically on existing sites, so those changes must be applied programmatically. However, some of those programmatic operations depend on configuration that does not yet exist in active storage until config import has run. Because `hook_update_N()` runs before config import, it cannot be used for this work.
+
+Drush provides `hook_deploy_NAME()` (in a `MODULE.deploy.php` file) to solve this. It is not a Drupal core hook. This capability has always been available as part of Drush, but consistent use of `drush deploy` across all deployment and sync processes only became the standard with the migration to sws-drush-commands documented in [ADR 0002](0002-replace-blt-with-sws-drush-commands.md). Prior to that, deploy hooks could not be relied on to run in all contexts. This ADR formalizes their adoption as the standard pattern for post-config-import work now that the infrastructure consistently supports it.
+
+A concrete example: when introducing a new content type, the role permissions tied to it must be granted programmatically because `config_ignore` excludes them from import. Placing this in an update hook causes it to run before the content type exists, and Drupal silently discards the permissions. Placing it in a deploy hook, after config import has created the content type, works as expected.
+
+## Decision
+
+Use `hook_deploy_NAME()` for any operation that must run after config import has completed. Common cases include:
+
+- Granting or revoking role permissions tied to new content types or vocabularies introduced in the same deployment.
+- Any programmatic config or entity operation that depends on new configuration being present in active storage.
+
+Deploy hook names in this project must use a purely numerical suffix (e.g. `hs_admin_deploy_10001`). While Drush allows any alphanumeric string for `NAME` and executes hooks in alphanumeric order, this project adopts numerical suffixes as a standard to keep execution order explicit, auditable, and consistent with the `hook_update_N()` naming convention.
+
+Deploy hooks must be placed in `MODULE.deploy.php` alongside the module's `MODULE.install` file.
+
+## Consequences
+
+- Operations that depend on config import must not be placed in `hook_update_N()` or `hook_post_update_NAME()`.
+- When running site updates manually (e.g., troubleshooting a failed deployment), `drush deploy:hook` must be run explicitly after `drush config:import`. Omitting it will skip deploy hooks entirely.
+- Numerical naming of deploy hooks must be maintained as a project convention. New deploy hooks should continue the sequence within their module.
+- `hook_deploy_NAME()` is a Drush convention, not part of Drupal core. `hook_update_N()` and config import are standard Drupal operations available through any execution path, including the web UI (`/update.php`). Deploy hooks only run when Drush is the executor. On this platform all update paths go through Drush, so this is not a practical concern, but any future tooling that bypasses Drush would also bypass deploy hooks.


### PR DESCRIPTION
# Summary
Adds ADR 0004 documenting the adoption of Drush deploy hooks for post-config-import operations, with supporting updates to Config.md and CodeDeploy.md. Also clarifies the README linking rule in DocumentationStandards.md.

## Backstory
[HSD8-1910](https://stanfordits.atlassian.net/browse/HSD8-1910): Drush deploy hook adoption: Create ADR and update documentation

While working on [HSD8-1689](https://stanfordits.atlassian.net/browse/HSD8-1689) (#1786) we identified that some programmatic operations must run after config import, not before. Drush's `hook_deploy_NAME()` solves this, and our deployment and sync processes already call `deploy:hook`. However, there was no documented convention for when to use deploy hooks, the manual troubleshooting steps in CodeDeploy.md were missing `deploy:hook`, and there was no ADR recording the decision to adopt this pattern.

## Need Review By (Date)
ASAP

## Urgency
Low

## Steps to Test
1. Review ADR 0004 for accuracy and completeness.
1. Review and confirm documentation changes.


[HSD8-1689]: https://stanfordits.atlassian.net/browse/HSD8-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HSD8-1910]: https://stanfordits.atlassian.net/browse/HSD8-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ