### PR TITLE
HSD8-1913: Fix drush alias hosts for aviditacharya and gavin_wright; remove dead livedev/oldprod aliases

### DIFF
--- a/drush/sites/archaeology.site.yml
+++ b/drush/sites/archaeology.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: archaeology-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: archaeology-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: archaeology-stage.stanford.edu

--- a/drush/sites/aviditacharya__humsci.site.yml
+++ b/drush/sites/aviditacharya__humsci.site.yml
@@ -4,12 +4,12 @@ local:
 dev:
   root: /var/www/html/humscigryphon.dev/docroot
   uri: aviditacharya-dev.humsci.stanford.edu
-  host: staging-25390.prod.hosting.acquia.com
+  host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: aviditacharya-stage.humsci.stanford.edu
-  host: staging-25390.prod.hosting.acquia.com
+  host: humscigryphontest.ssh.prod.acquia-sites.com
   user: humscigryphon.test
 prod:
   root: /var/www/html/humscigryphon.prod/docroot

--- a/drush/sites/dsresearch.site.yml
+++ b/drush/sites/dsresearch.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: dsresearch-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: dsresearch-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: dsresearch-stage.stanford.edu

--- a/drush/sites/duboislab.site.yml
+++ b/drush/sites/duboislab.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: duboislab-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: duboislab-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: duboislab-stage.stanford.edu

--- a/drush/sites/francestanford.site.yml
+++ b/drush/sites/francestanford.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: francestanford-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: francestanford-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: francestanford-stage.stanford.edu

--- a/drush/sites/gavin_wright__humsci.site.yml
+++ b/drush/sites/gavin_wright__humsci.site.yml
@@ -4,12 +4,12 @@ local:
 dev:
   root: /var/www/html/humscigryphon.dev/docroot
   uri: gavin-wright-dev.humsci.stanford.edu
-  host: staging-25390.prod.hosting.acquia.com
+  host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: gavin-wright-stage.humsci.stanford.edu
-  host: staging-25390.prod.hosting.acquia.com
+  host: humscigryphontest.ssh.prod.acquia-sites.com
   user: humscigryphon.test
 prod:
   root: /var/www/html/humscigryphon.prod/docroot

--- a/drush/sites/lowe.site.yml
+++ b/drush/sites/lowe.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: lowe-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: lowe-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: lowe-stage.stanford.edu

--- a/drush/sites/mrc.site.yml
+++ b/drush/sites/mrc.site.yml
@@ -1,20 +1,10 @@
 local:
   uri: mrc
   root: '${env.cwd}/docroot'
-oldprod:
-  root: /var/www/html/hsmrc.prod/docroot
-  uri: hsmrc.prod.acquia-sites.com
-  host: web-25384.prod.hosting.acquia.com
-  user: hsmrc.prod
 dev:
   root: /var/www/html/humscigryphon.dev/docroot
   uri: mrc-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: mrc-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot

--- a/drush/sites/popstudies.site.yml
+++ b/drush/sites/popstudies.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: popstudies-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: popstudies-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: popstudies-stage.stanford.edu

--- a/drush/sites/shenlab.site.yml
+++ b/drush/sites/shenlab.site.yml
@@ -6,11 +6,6 @@ dev:
   uri: shenlab-dev.stanford.edu
   host: humscigryphondev.ssh.prod.acquia-sites.com
   user: humscigryphon.dev
-livedev:
-  root: /home/humscigrypon/dev/livedev/docroot
-  uri: shenlab-dev.stanford.edu
-  host: humscigryphon.ssh.prod.acquia-sites.com
-  user: humscigryphon.dev
 stage:
   root: /var/www/html/humscigryphon.test/docroot
   uri: shenlab-stage.stanford.edu


### PR DESCRIPTION
# Summary
Fix incorrect Acquia SSH hostnames in drush aliases for `aviditacharya__humsci` and `gavin_wright__humsci` — dev and stage aliases were pointing to the old `staging-25390.prod.hosting.acquia.com` host instead of the correct gryphon hosts. While in there, removed dead `livedev` aliases (retired Acquia Cloud feature, present since 2018) from 8 site files, and removed the `oldprod` legacy alias from `mrc.site.yml` (added 2018, predates the gryphon migration).

## Backstory
[HSD8-1913](https://stanfordits.atlassian.net/browse/HSD8-1913)

The broken aliases were first discovered during HSD8-1911 (content_access migration work) when drush could not reach dev/stage for these two sites. The fix was applied locally during that work but never committed to a mergeable branch. The incorrect host (`staging-25390.prod.hosting.acquia.com`) was used for both dev and stage on `aviditacharya__humsci` and `gavin_wright__humsci`; prod was correct on both. All other site alias files were scanned and are clean.

The `livedev` aliases were an Acquia Cloud Live Development feature that Acquia has since retired. They were present in 8 files since the initial commit in May 2018 and serve no purpose. The `oldprod` alias in `mrc.site.yml` pointed to a pre-gryphon Acquia host from August 2018 and is similarly dead.

No site_manager role restoration was needed — investigation confirmed neither site was affected by the HSD8-1904 role loss issue (both had intact permissions; gavin_wright had been reprovisioned as gavin_wright2022 and copied back, effectively resetting the affected config).

## Need Review By (Date)
asap

## Urgency
low

## Steps to Test
1. Confirm `drush @aviditacharya__humsci.dev status` connects successfully.
2. Confirm `drush @aviditacharya__humsci.stage status` connects successfully.
3. Confirm `drush @gavin_wright__humsci.dev status` connects successfully.
4. Confirm `drush @gavin_wright__humsci.stage status` connects successfully.
5. Verify no `livedev` or `oldprod` alias keys remain in `drush/sites/`.


[HSD8-1913]: https://stanfordits.atlassian.net/browse/HSD8-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ