### PR TITLE
Fix CloneNode VBO action label (restores "Clone selected content")

### DIFF
--- a/docroot/modules/humsci/hs_actions/src/Plugin/Action/CloneNode.php
+++ b/docroot/modules/humsci/hs_actions/src/Plugin/Action/CloneNode.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[Action(
   id: 'node_clone_action',
-  action_label: new TranslatableMarkup('Publish'),
+  action_label: new TranslatableMarkup('Clone selected content'),
   type: 'node',
 )]
 class CloneNode extends ViewsBulkOperationsActionBase implements PluginFormInterface, ContainerFactoryPluginInterface {


### PR DESCRIPTION
# Summary
Restore the correct label for the `CloneNode` bulk action. The label was accidentally set to "Publish" instead of "Clone selected content", causing the VBO dropdown to display the wrong label for this action.

## Backstory
During the Drupal 11 upgrade, the annotation-to-attribute migration for `CloneNode.php` incorrectly replaced the `action_label` value with "Publish" instead of preserving the original "Clone selected content". No ticket; this is a targeted one-line bugfix.

## Need Review By (Date)
asap

## Urgency
medium

## Steps to Test
1. On a site with the `hs_actions` module enabled, navigate to a content listing that supports Views Bulk Operations.
2. Select one or more nodes.
3. Open the bulk operations dropdown.
4. Confirm the clone action is labeled **"Clone selected content"** (not "Publish").