### PR TITLE
HSD8-1914: Automated dependency updates | bump create-pull-request to v8 (Node 22); reschedule to 2:15 AM Central

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -6,8 +6,9 @@ name: Automated Dependency Updates
 
 on:
   schedule:
-    # Run on Fridays at 2 PM UTC.
-    - cron: '0 14 * * 5'
+    # Run on Fridays at ~2:15 AM Central (7:15 UTC / CDT). Off-peak to reduce
+    # GitHub scheduler delays.
+    - cron: '15 7 * * 5'
   workflow_dispatch:
 
 jobs:
@@ -87,7 +88,7 @@ jobs:
           echo '```' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Automated Dependency Updates ${{ steps.date.outputs.date }}"


### PR DESCRIPTION
# Summary
Two maintenance updates to the automated dependency update workflow: bump `peter-evans/create-pull-request` from v7 to v8 (Node 20 → Node 22) ahead of GitHub's deprecation deadline, and reschedule the cron trigger from 2 PM UTC (9 AM Central) to 2:15 AM Central to get more reliable run times.

## Backstory
[HSD8-1914](https://stanfordits.atlassian.net/browse/HSD8-1914)

`peter-evans/create-pull-request@v7` uses Node 20, which GitHub Actions is deprecating on June 16, 2026. v8 uses Node 22.

The scheduled workflow was configured to run at `0 14 * * 5` (2 PM UTC / 9 AM CDT). GitHub's scheduler is heavily loaded at the top of the hour, causing consistent 1–2 hour delays. Moving to `15 7 * * 5` (~2:15 AM Central) puts the run in a low-contention off-peak window and avoids triggering mid-morning while work is already underway.

## Need Review By (Date)
June 15 (before the Node 20 deprecation on June 16)

## Urgency
high (Node 20 deprecation) / low (schedule change)


[HSD8-1914]: https://stanfordits.atlassian.net/browse/HSD8-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ