### PR TITLE
SHS-6680: Fix Tagify Select color contrast issue on hover

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -303,3 +303,9 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 .media-library-item .media-library-item__preview.media-library-item__preview--video img {
   display: block;
 }
+
+/* Temporary fix for tagify regression (drupal.org/project/tagify#3590671)
+Remove once drupal/tagify next released is deployed. */
+.tagify__dropdown__item--active {
+  color: var(--gin-color-button-text);
+}

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -304,8 +304,8 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
   display: block;
 }
 
-/* Temporary fix for tagify regression (drupal.org/project/tagify#3590671)
-Remove once drupal/tagify next released is deployed. */
+/* Temporary fix for tagify regression. */
+/* Remove once drupal/tagify next released is deployed. */
 .tagify__dropdown__item--active {
   color: var(--gin-color-button-text);
 }


### PR DESCRIPTION
# Summary
Fix for Tagify select color contrast issue on hover. Temp until this is updated in a future release and we update to that version of Tagify, (see https://git.drupalcode.org/project/tagify/-/work_items/3590671

## Backstory
[SHS-6680](https://app.clickup.com/t/36718269/SHS-6680)

## Need Review By (Date)
06/23

## Urgency
medium

## Steps to Test
1. Please log in to this [Tugboat preview](https://pr2282-fvtzyfyxuqhri74hzwovlr8vulgaots5.tugboatqa.com/user/tugboat)
2. Create a [News Item](https://pr2282-fvtzyfyxuqhri74hzwovlr8vulgaots5.tugboatqa.com/node/add/hs_news)
3. Scroll down in the form to the "Categories" field (This field should be displayed as a Tagify Select dropdown)
4. Confirm the color contrast issue in the active state is gone; it should look like this:

<img width="1281" height="231" alt="Screenshot 2026-06-14 at 6 39 13 PM" src="https://github.com/user-attachments/assets/213df2ce-3863-4a4d-b6a9-2dfc3a735a06" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215512003839731