### PR TITLE
HSD8-1920: Fix blank/broken VBO bulk action labels (CloneNode & MigrationIgnore)

### DIFF
--- a/docroot/modules/humsci/hs_actions/src/Plugin/Action/CloneNode.php
+++ b/docroot/modules/humsci/hs_actions/src/Plugin/Action/CloneNode.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[Action(
   id: 'node_clone_action',
-  action_label: new TranslatableMarkup('Clone selected content'),
+  label: new TranslatableMarkup('Clone selected content'),
   type: 'node',
 )]
 class CloneNode extends ViewsBulkOperationsActionBase implements PluginFormInterface, ContainerFactoryPluginInterface {

--- a/docroot/modules/humsci/hs_actions/src/Plugin/Action/MigrationIgnore.php
+++ b/docroot/modules/humsci/hs_actions/src/Plugin/Action/MigrationIgnore.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[Action(
   id: 'migration_ignore',
-  action_label: new TranslatableMarkup('Ignore from importing'),
+  label: new TranslatableMarkup('Ignore from importing'),
   type: 'node',
 )]
 class MigrationIgnore extends ViewsBulkOperationsActionBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
# Summary
Fix two VBO bulk actions (`CloneNode` and `MigrationIgnore`) that appeared as blank, broken options in the bulk actions dropdown. The root cause was the wrong PHP attribute parameter name (`action_label:` instead of `label:`) introduced during the D11 / 12.0.0 annotation-to-attribute migration.

## Backstory
[HSD8-1920](https://stanfordits.atlassian.net/browse/HSD8-1920)

During the Drupal 11 upgrade (`37e7ad4cc`), both action plugins were converted from `@Action` annotations to `#[Action]` PHP attributes. The conversion used `action_label:` for the display label, but that parameter is only intended for action derivers. The correct parameter is `label:`. With `label: null`, VBO still discovers the actions but renders them as blank options — and throws an error when clicked. A previous PR fixed the text of the label (it had been set to "Publish") but didn't catch that the parameter name itself was wrong.

## Need Review By (Date)
ASAP

## Urgency
High — bulk actions are broken/unusable for affected content operations

## Steps to Test
1. Go to a content listing view that has a VBO bulk operations field configured (e.g. the content admin view).
2. Verify the bulk actions dropdown no longer contains blank/broken options.
3. Confirm **"Clone selected content"** and **"Ignore from importing"** appear correctly in the dropdown.
4. Select one or more nodes and run "Clone selected content" — confirm it clones without error.
5. Select one or more nodes and run "Ignore from importing" — confirm it executes without error.


[HSD8-1920]: https://stanfordits.atlassian.net/browse/HSD8-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215739139698831