### PR TITLE
HSD8-1861: Add humsci:reports:users-by-role drush command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Acceptance testing is done using the [Codeception](https://codeception.com/) fra
 
 - `npm test` — Run tests for all Sass in the project (including humsci_basic).
 
+## Reporting
+
+- `drush humsci:reports:users-by-role <ROLE> --env=prod`: Generate a CSV or JSON report of users assigned to a role across all sites. Run with `--help` for all options.
+
 ## Architecture Decision Records (ADRs)
 
 Architecture Decision Records (ADRs) are used to document important architectural decisions made in this project. The ADR process and format are explained in [0000-record-architecture-decisions.md](docs/architecture/decisions/0000-record-architecture-decisions.md). All significant architectural decisions should be documented as a new ADR in the `docs/architecture/decisions/` directory.

--- a/drush/Commands/HsReportsDrushCommands.php
+++ b/drush/Commands/HsReportsDrushCommands.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Commands;
+
+use Drupal\SwsDrush\Drush\Commands\SwsCommandsTrait;
+use Drush\Boot\DrupalBootLevels;
+use Drush\Commands\DrushCommands;
+use Drush\Attributes as CLI;
+
+/**
+ * Commands for generating reports across the H&S multisite platform.
+ */
+#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+final class HsReportsDrushCommands extends DrushCommands {
+
+  use SwsCommandsTrait;
+
+  /**
+   * Report users assigned to a given role across all sites.
+   *
+   * Replaces `blt humsci:role-report`.
+   */
+  #[CLI\Command(name: 'humsci:reports:users-by-role')]
+  #[CLI\Argument(name: 'role', description: 'Machine name of the Drupal role to report on.')]
+  #[CLI\Option(name: 'env', description: 'Environment to query: stage (default), prod, or dev.')]
+  #[CLI\Option(name: 'format', description: 'Output format: csv (default) or json.')]
+  #[CLI\Option(name: 'include-blocked', description: 'Include blocked users. Adds a Status column to the output.')]
+  #[CLI\Option(name: 'omit-empty', description: 'Omit sites with no matching users from the output.')]
+  #[CLI\Usage(name: 'drush humsci:reports:users-by-role site_manager --env=prod > report.csv', description: 'CSV report of active site_manager users on prod saved to file.')]
+  #[CLI\Usage(name: 'drush humsci:reports:users-by-role site_manager --env=prod --include-blocked', description: 'Include blocked users with a Status column.')]
+  #[CLI\Usage(name: 'drush humsci:reports:users-by-role site_manager --env=prod --omit-empty', description: 'Skip sites with no matching users.')]
+  #[CLI\Usage(name: 'drush humsci:reports:users-by-role site_manager --env=prod --format=json', description: 'JSON report on prod.')]
+  public function usersByRole(string $role, array $options = [
+    'env' => 'stage',
+    'format' => 'csv',
+    'include-blocked' => FALSE,
+    'omit-empty' => FALSE,
+  ]): void {
+    $env = $options['env'];
+    $format = $options['format'];
+    $includeBlocked = (bool) $options['include-blocked'];
+    $omitEmpty = (bool) $options['omit-empty'];
+
+    if (!in_array($env, ['stage', 'prod', 'dev'], TRUE)) {
+      throw new \InvalidArgumentException(dt('Invalid environment "!env". Allowed values: stage, prod, dev.', ['!env' => $env]));
+    }
+
+    if (!in_array($format, ['csv', 'json'], TRUE)) {
+      throw new \InvalidArgumentException(dt('Invalid format "!format". Allowed values: csv, json.', ['!format' => $format]));
+    }
+
+    if (!preg_match('/^[a-z0-9_]+$/', $role)) {
+      throw new \InvalidArgumentException(dt('Role "!role" is not a valid machine name.', ['!role' => $role]));
+    }
+
+    $multisites = $this->getConfig()->get('command.sws.options.multisites') ?? ['default'];
+
+    $select = $includeBlocked ? 'd.name, d.mail, d.status' : 'd.name, d.mail';
+    $statusClause = $includeBlocked ? '' : 'AND d.status = 1';
+    $sql = trim("SELECT $select FROM users_field_data d INNER JOIN user__roles r ON d.uid = r.entity_id WHERE r.roles_target_id = '$role' $statusClause");
+
+    $out = NULL;
+    $jsonData = [];
+
+    if ($format === 'csv') {
+      $out = fopen('php://stdout', 'w');
+      $headers = ['Site', 'URL', 'Role', 'Name', 'Email'];
+      if ($includeBlocked) {
+        $headers[] = 'Status';
+      }
+      fputcsv($out, $headers);
+    }
+
+    foreach ($multisites as $site) {
+      $alias = "@{$site}.{$env}";
+      $url = $this->getSiteUrl($site, $env);
+
+      $result = $this->localMachineHelper()->execute(
+        ['drush', $alias, 'sqlq', $sql],
+        NULL,
+        $this->getDir(),
+        FALSE
+      );
+
+      if (!$result->isSuccessful()) {
+        $this->logger()->warning(dt('Failed to query "!alias", skipping.', ['!alias' => $alias]));
+        continue;
+      }
+
+      $lines = array_values(array_filter(explode("\n", trim($result->getOutput()))));
+
+      $users = [];
+      foreach ($lines as $line) {
+        $cols = explode("\t", $line);
+        $user = [
+          'name' => $cols[0] ?? '',
+          'email' => $cols[1] ?? '',
+        ];
+        if ($includeBlocked) {
+          $user['status'] = isset($cols[2]) ? ($cols[2] === '1' ? 'Active' : 'Blocked') : '';
+        }
+        $users[] = $user;
+      }
+
+      if ($format === 'json') {
+        if (empty($users) && $omitEmpty) {
+          continue;
+        }
+        $jsonData[] = [
+          'role' => $role,
+          'site' => $site,
+          'url' => $url,
+          'users' => $users,
+        ];
+        continue;
+      }
+
+      if (empty($users)) {
+        if ($omitEmpty) {
+          continue;
+        }
+        $row = [$site, $url, $role, '(No users found)', ''];
+        if ($includeBlocked) {
+          $row[] = '';
+        }
+        fputcsv($out, $row);
+        continue;
+      }
+
+      foreach ($users as $user) {
+        $row = [$site, $url, $role, $user['name'], $user['email']];
+        if ($includeBlocked) {
+          $row[] = $user['status'];
+        }
+        fputcsv($out, $row);
+      }
+    }
+
+    if ($format === 'csv') {
+      fclose($out);
+      return;
+    }
+
+    $this->output()->writeln(json_encode($jsonData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+  }
+
+  /**
+   * Build the site URL for a given environment from the multisite machine name.
+   *
+   * Applies the same substitution documented in docroot/sites/sites.php:
+   * double underscores become dots, single underscores become dashes.
+   */
+  protected function getSiteUrl(string $site, string $env): string {
+    $parts = explode('.', str_replace('_', '-', str_replace('__', '.', $site)));
+    $parts[0] .= '-' . $env;
+    return 'https://' . implode('.', $parts) . '.stanford.edu';
+  }
+
+}


### PR DESCRIPTION
# Summary
Adds `drush humsci:reports:users-by-role`, a new custom H&S drush command that generates CSV or JSON reports of users assigned to a given Drupal role across all platform multisites. Replaces the removed `blt humsci:role-report` with improved functionality including username, environment selection, blocked user support, and flexible output formats.

## Backstory
[HSD8-1861](https://stanfordits.atlassian.net/browse/HSD8-1861): SWSDC | Support humsci:role-report command

`blt humsci:role-report` was removed during the BLT to SWSDC migration with no replacement. The command is used on an ad-hoc basis to generate user role reports when requested. A drush command was chosen over a bash script to leverage existing SWSDC multisite infrastructure and make the tool available to the broader H&S team.

## Steps to Test
1. Run `drush humsci:reports:users-by-role --help` and verify all options and usage examples are documented correctly.
1. Run `drush humsci:reports:users-by-role site_manager --env=prod > report.csv` and verify the CSV contains Site, URL, Role, Name, Email columns with correct data.
1. Open `report.csv` and confirm no drush notice output was captured alongside the CSV data.
1. Run with `--include-blocked` and verify a Status column is added showing Active or Blocked for each user.
1. Run with `--omit-empty` and verify sites with no matching users are excluded from the output.
1. Run with `--format=json` and verify per-site JSON output containing role, site, url, and a users array.
1. Run with an invalid role machine name (e.g. `Site Manager` with a space) and verify an exception is thrown.
1. Run with `--env=invalid` and verify an exception is thrown.


[HSD8-1861]: https://stanfordits.atlassian.net/browse/HSD8-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ