### PR TITLE
SHS-6686: Add classes to views for Siteimprove policies

### DIFF
--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
@@ -37,8 +37,8 @@
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
     'view',
-    'view__' ~ view.id()|replace({'_': '-'}),
-    'view__' ~ view.id()|replace({'_': '-'}) ~ '__' ~ view.current_display|replace({'_': '-'}),
+    'view__' ~ view.id()|clean_class,
+    'view__' ~ view.id()|clean_class ~ '__' ~ view.current_display|clean_class,
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
@@ -37,8 +37,8 @@
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
     'view',
-    'view__' ~ view.id()|clean_class,
-    'view__' ~ view.id()|clean_class ~ '__' ~ view.current_display|clean_class,
+    'view--' ~ view.id()|clean_class,
+    'view--' ~ view.id()|clean_class ~ '--' ~ view.current_display|clean_class,
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
@@ -37,8 +37,8 @@
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
     'view',
-    'view--' ~ view.id(),
-    'view--' ~ view.id() ~ '--' ~ view.current_display,
+    'view__' ~ view.id()|replace({'_': '-'}),
+    'view__' ~ view.id()|replace({'_': '-'}) ~ '__' ~ view.current_display|replace({'_': '-'}),
   ]
 %}
 

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view.html.twig
@@ -36,8 +36,12 @@
 {%
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
+    'view',
+    'view--' ~ view.id(),
+    'view--' ~ view.id() ~ '--' ~ view.current_display,
   ]
 %}
+
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {{ title }}


### PR DESCRIPTION
# Summary
Add classes to views for Siteimprove policies

## Backstory
[SHS-6686](https://app.clickup.com/t/36718269/SHS-6686)

## Need Review By (Date)
06/23

## Urgency
medium

## Steps to Test
1. Go to any of the following pages:
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/courses
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/events
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/views/event-series
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/news
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/people
  - https://hs-colorful-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/publications
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/courses
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/events
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/views/event-series
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/news
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/people
  - https://hs-traditional-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/default-views/publications
  - https://english-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/news-events/recent-news
  - https://history-hheovtirzdr2lfrlcrp64qn8824z7zmi.tugboatqa.com/events/upcoming-events
2. Inspect the code and confirm that the wrapper for the view has the following classes pattern: `view`, `view--view-[id]`, `view--view-[id]--view-[current-display]`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215899857991582
  - https://app.asana.com/0/0/1215739139713200