### PR TITLE
Remove back-to-dev release step; document direct-to-main policy and fix profile version

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 12.0.1-dev
+version: 12.x-dev
 core_version_requirement: ^10.3 || ^11
 dependencies:
   - 'drupal:block'

--- a/docs/BranchingStrategy.md
+++ b/docs/BranchingStrategy.md
@@ -29,6 +29,25 @@ This document describes the active branching model for the H&S application.
 - Merge the release pull request into `main` using a merge commit.
 - When the release pull request is merged into `main`, release automation creates the GitHub release and deployable Acquia artifact tag.
 
+## Profile Version in the Development Branch
+
+The version number in `docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml` on the current `<major>.x` branch should always reflect the development branch as `<major>.x-dev` (e.g., `12.x-dev`). If you ever merge `main` into `<major>.x` directly, verify this value remains `<major>.x-dev` afterward.
+
+## Direct Merges to Main
+
+All code should reach `main` through the release process described in [CodeDeploy.md](CodeDeploy.md). Direct merges to `main` that bypass `<major>.x` should be rare and treated as exceptional (for example, a critical production hotfix).
+
+When a change is merged directly into `main`, it must also be applied to the current `<major>.x` branch. Use a squash merge when merging directly into `main`. The preferred way to bring the change into `<major>.x` is to cherry-pick the specific commit via a new branch and pull request:
+
+1. Create a branch off the current `<major>.x` branch.
+1. Cherry-pick the commit that was applied to `main`:
+	```bash
+	git cherry-pick <COMMIT_SHA>
+	```
+1. Push and open a pull request targeting the current `<major>.x` branch.
+
+If a bulk merge from `main` into `<major>.x` is the better option in a given situation, do that through a new branch and pull request as well. In either case, verify the profile version in `su_humsci_profile.info.yml` remains `<major>.x-dev` after the merge.
+
 ## Retired Workflow Pieces
 
 - Long-lived `<version>-release` branches are no longer used.

--- a/docs/CodeDeploy.md
+++ b/docs/CodeDeploy.md
@@ -96,39 +96,7 @@ composer install
 - Merge the PR using a **merge commit** (not squash merge).
 - The merge commit subject should be the version number (e.g., `12.1.1`).
 
-### Back to Dev (Sync main into current development branch)
-After the release PR is merged into `main`, create and merge a "back to dev" pull request to sync `main` back into the current `<major>.x` development branch:
-
-1. Fetch and pull the latest `main` and current major branch:
-	```bash
-	git checkout main && git fetch && git pull
-	git checkout CURRENT_MAJOR_BRANCH && git fetch && git pull
-	```
-
-2. Create a back-to-dev branch off the current major branch:
-	```bash
-	git checkout CURRENT_MAJOR_BRANCH && git checkout -b backtodev-VERSION
-	
-	# Example:
-	git checkout 12.x && git checkout -b backtodev-12.1.1
-	```
-
-3. Merge `main` into your back-to-dev branch:
-	```bash
-	git merge main
-	```
-
-4. Update the version number in `docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml` to the next dev version (e.g., `12.1.2-dev`):
-	```bash
-	git add . && git commit -m "backtodev-VERSION"
-	git push
-	```
-
-5. Open a pull request from `backtodev-VERSION` into the current `<major>.x` branch.
-
-6. Merge the back-to-dev pull request before deleting the release branch. This PR may be force-merged if necessary to bypass test checks on the development branch.
-
-**Note:** If a production hotfix is ever made directly on `main`, sync that change back to the current `<major>.x` branch in a separate pull request.
+> **Note:** Syncing `main` back into the current `<major>.x` branch is not part of the release process. Every release branch is created from `<major>.x`, so `main` contains nothing that `<major>.x` does not already have. If a change is ever merged directly into `main` outside the normal release flow, follow the policy in [Branching Strategy](BranchingStrategy.md).
 
 ### Confirm Automation (Release PR Merge)
 When the release PR is merged into `main`, GitHub Actions automatically:


### PR DESCRIPTION
# Summary
Removes the "back to dev" step from the release process, documents the policy for changes merged directly to `main`, and corrects the profile version in the development branch from `12.0.1-dev` to `12.x-dev`.

## Backstory
Identified during the v12.1.0 deployment that the back-to-dev step is unnecessary overhead. Every release branch is created from `<major>.x`, so after a release PR merges into `main`, there is nothing on `main` that is not already in `<major>.x`. The only thing back-to-dev was ever syncing back was the version bump from the release branch, which was then immediately overwritten with a dev version anyway.

This change removes the step from `CodeDeploy.md` and adds two new sections to `BranchingStrategy.md`: one that defines how to handle the rare case of a change merged directly to `main` bypassing `<major>.x`, and one that defines the expected profile version in the development branch (`<major>.x-dev`, fixed and unchanging). The profile version in `su_humsci_profile.info.yml` is also corrected to match that convention.

## Need Review By (Date)
No rush.

## Urgency
low

## Steps to Test
1. Review `docs/CodeDeploy.md` and confirm the back-to-dev section is gone, replaced by a note directing to `BranchingStrategy.md`.
1. Review `docs/BranchingStrategy.md` and confirm the two new sections ("Profile Version in the Development Branch" and "Direct Merges to Main") are present and accurate.
1. Confirm `docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml` shows `version: 12.x-dev`.
