### PR TITLE
SHS-6690: Update Format:Table so that it looks good on small screens

### DIFF
--- a/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.libraries.yml
@@ -115,6 +115,13 @@ swiper-reduced-motion:
     - core/drupal
     - core/once
 
+table:
+  js:
+    dist/js/table.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 table-pattern:
   js:
     dist/js/table-pattern.js: {}

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/tables/table.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/tables/table.js
@@ -1,7 +1,7 @@
 (function (Drupal, once) {
   Drupal.behaviors.viewsTableHeaders = {
     attach(context) {
-      const tables = once('views-table-headers', '.table', context);
+      const tables = once('views-table-headers', '.views-table', context);
 
       tables.forEach((table) => {
         // retrieve table column headings
@@ -27,10 +27,7 @@
                   if (!tableCells[h].querySelector('.views-table__heading')) {
                     const heading = document.createElement('span');
                     heading.className = 'views-table__heading';
-                    // hide the heading on the first column
-                    if (h === 0) {
-                      heading.classList.add('views-table__heading--hidden');
-                    }
+                    heading.setAttribute('aria-hidden', 'true');
                     heading.innerHTML = columnHeaders[h].innerHTML;
                     tableCells[h].insertAdjacentElement('afterbegin', heading);
                   }

--- a/docroot/themes/humsci/humsci_basic/src/js/shared/tables/table.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/tables/table.js
@@ -1,0 +1,66 @@
+(function (Drupal, once) {
+  Drupal.behaviors.viewsTableHeaders = {
+    attach(context) {
+      const tables = once('views-table-headers', '.table', context);
+
+      tables.forEach((table) => {
+        // retrieve table column headings
+        const columnHeaders = table.querySelectorAll('thead th');
+
+        // retrieve all rows
+        const tableRows = table.querySelectorAll('tbody tr');
+
+        if (tableRows) {
+          // only inject headings on mobile
+          const mediaQuery = window.matchMedia('(max-width: 767px)');
+
+          const injectHeadings = () => {
+            // For each row in the table
+            for (let i = 0; i < tableRows.length; i += 1) {
+              // find the cells in each row
+              const tableCells = tableRows[i].querySelectorAll('td');
+
+              // we need h to step through columnHeaders and get the correct heading text
+              for (let h = 0; h < tableCells.length; h += 1) {
+                if (columnHeaders[h]) {
+                  // avoid duplicate injection on resize
+                  if (!tableCells[h].querySelector('.views-table__heading')) {
+                    const heading = document.createElement('span');
+                    heading.className = 'views-table__heading';
+                    // hide the heading on the first column
+                    if (h === 0) {
+                      heading.classList.add('views-table__heading--hidden');
+                    }
+                    heading.innerHTML = columnHeaders[h].innerHTML;
+                    tableCells[h].insertAdjacentElement('afterbegin', heading);
+                  }
+                }
+              }
+            }
+          };
+
+          // strip injected headings so the visible <thead> isn't duplicated
+          const removeHeadings = () => {
+            table
+              .querySelectorAll('.views-table__heading')
+              .forEach((heading) => heading.remove());
+          };
+
+          // inject on load if already mobile
+          if (mediaQuery.matches) {
+            injectHeadings();
+          }
+
+          // sync on viewport changes in both directions
+          mediaQuery.addEventListener('change', (event) => {
+            if (event.matches) {
+              injectHeadings();
+            } else {
+              removeHeadings();
+            }
+          });
+        }
+      });
+    },
+  };
+}(Drupal, once));

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
@@ -93,12 +93,13 @@
   // Injected column label — mirrors .hb-table-row__heading
   .views-table__heading {
     display: block;
-    font-weight: hb-theme-font-weight(bold);
+    margin: 0 0 hb-calculate-rems(4px);
+
     // Adding font styles here to ensure the injected heading
     // text matches the styles, even if the table data
     // font styles are overridden by an utility class.
     font-size: hb-calculate-rems(13px);
-    margin: 0 0 hb-calculate-rems(4px);
+    font-weight: hb-theme-font-weight(bold);
     text-transform: uppercase;
     text-align: left;
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
@@ -1,6 +1,10 @@
+@use '../variables/general' as *;
 @use '../functions/general' as *;
 @use '../functions/color' as *;
 @use '../mixins/tables' as *;
+@use '../mixins/breakpoints' as *;
+@use '../functions/fonts' as *;
+@use '../mixins/general' as *;
 
 .hb-table-wrap {
   margin: auto;
@@ -27,6 +31,80 @@
     .field-content,
     td {
       color: color('black', 'global');
+    }
+  }
+
+  // Responsive behavior for Views tables
+  table {
+    display: block;
+
+    @include grid-media-min('md') {
+      display: table;
+    }
+
+    thead {
+      display: none;
+
+      @include grid-media-min('md') {
+        display: table-header-group;
+      }
+    }
+
+    tbody {
+      display: block;
+
+      @include grid-media-min('md') {
+        display: table-row-group;
+      }
+    }
+
+    tr {
+      display: block;
+      padding-bottom: hb-calculate-rems(14px);
+
+      @include grid-media-min('md') {
+        display: table-row;
+      }
+
+      &::before {
+        content: '';
+        display: block;
+        height: hb-calculate-rems(11px);
+        background-color: color('primary');
+
+        @include grid-media-min('md') {
+          display: none;
+        }
+      }
+    }
+
+    td {
+      display: block;
+      border: 0 none;
+
+      @include grid-media-min('md') {
+        display: table-cell;
+        border: $hb-thin-border;
+        border-color: color('gray-medium', 'global');
+      }
+    }
+  }
+
+  // Injected column label — mirrors .hb-table-row__heading
+  .views-table__heading {
+    display: block;
+    font-weight: hb-theme-font-weight(bold);
+    // Adding font styles here to ensure the injected heading
+    // text matches the styles, even if the table data
+    // font styles are overridden by an utility class.
+    font-size: hb-calculate-rems(13px);
+    margin: 0 0 hb-calculate-rems(4px);
+    text-transform: uppercase;
+    text-align: left;
+
+    @include grid-media-min('sm') {
+      font-size: hb-calculate-rems(16px);
+      margin: 0 0 hb-calculate-rems(6px);
     }
   }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/base/_tables.scss
@@ -35,7 +35,7 @@
   }
 
   // Responsive behavior for Views tables
-  table {
+  .views-table {
     display: block;
 
     @include grid-media-min('md') {
@@ -43,10 +43,8 @@
     }
 
     thead {
-      display: none;
-
-      @include grid-media-min('md') {
-        display: table-header-group;
+      @include grid-media-between('xs', 'sm') {
+        @include visually-hidden;
       }
     }
 

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-table.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-table.html.twig
@@ -42,7 +42,7 @@
     'cols-' ~ header|length,
     responsive ? 'responsive-enabled',
     sticky ? 'sticky-enabled',
-    'table',
+    'views-table',
   ]
 %}
 <table{{ attributes.addClass(classes) }}>

--- a/docroot/themes/humsci/humsci_basic/templates/views/views-view-table.html.twig
+++ b/docroot/themes/humsci/humsci_basic/templates/views/views-view-table.html.twig
@@ -33,6 +33,7 @@
  * @ingroup themeable
  */
 #}
+{{ attach_library('humsci_basic/table') }}
 {{ attach_library('humsci_basic/table-wrap') }}
 {{ attach_library('humsci_basic/table-scope') }}
 
@@ -41,6 +42,7 @@
     'cols-' ~ header|length,
     responsive ? 'responsive-enabled',
     sticky ? 'sticky-enabled',
+    'table',
   ]
 %}
 <table{{ attributes.addClass(classes) }}>

--- a/docroot/themes/humsci/humsci_basic/webpack.common.js
+++ b/docroot/themes/humsci/humsci_basic/webpack.common.js
@@ -35,6 +35,7 @@ const shared = {
   'table-scope': 'shared/tables/scope.js',
   'table-pattern': 'shared/tables/table-pattern.js',
   'table-wrap': 'shared/tables/wrap.js',
+  table: 'shared/tables/table.js',
   timeline: 'shared/timeline/expand-collapse-timeline.js',
 };
 


### PR DESCRIPTION
# Summary
Make views that use _Format: Table_ look good on small screens, similar to views with _Format: Pattern_ Table do.

## Backstory
[SHS-6690](https://app.clickup.com/t/36718269/SHS-6690)

## Need Review By (Date)
06/23

## Urgency
medium

## Steps to Test
1. Visit the following page with a view that has Format: Table on [Colorful](https://hs-colorful-42hza1ia0soc5sqra6ourhm1u3sspmsx.tugboatqa.com/default-views/publications) and [Traditional](https://hs-traditional-42hza1ia0soc5sqra6ourhm1u3sspmsx.tugboatqa.com/default-views/publications)
2. On a small screen size (< 768px), confirm the table styles look better. The table should look and behave similarly to a [view with Format: Pattern Table ](https://hs-colorful-42hza1ia0soc5sqra6ourhm1u3sspmsx.tugboatqa.com/default-views/courses)
3. Confirm that this is targeting only views tables and not other tables, for example in the WYSIWYG (see `/components/text-area-typography`)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215981638595299
  - https://app.asana.com/0/0/1215688370496573