### PR TITLE
HSD8-1860: Implement Slack notifications for deployments and cron failures

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -16745,12 +16745,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/sws-drush-commands.git",
-                "reference": "2aa2a3b52f7868ac7addfbd8354ee7340addf59b"
+                "reference": "ea87542ccf71172dcd12cc8125f0aa4fedb988dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/2aa2a3b52f7868ac7addfbd8354ee7340addf59b",
-                "reference": "2aa2a3b52f7868ac7addfbd8354ee7340addf59b",
+                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/ea87542ccf71172dcd12cc8125f0aa4fedb988dc",
+                "reference": "ea87542ccf71172dcd12cc8125f0aa4fedb988dc",
                 "shasum": ""
             },
             "require": {
@@ -16781,7 +16781,7 @@
                 "issues": "https://github.com/SU-SWS/sws-drush-commands/issues",
                 "source": "https://github.com/SU-SWS/sws-drush-commands"
             },
-            "time": "2026-05-04T16:22:25+00:00"
+            "time": "2026-06-18T19:03:23+00:00"
         },
         {
             "name": "symfony/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -16745,12 +16745,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/sws-drush-commands.git",
-                "reference": "ea87542ccf71172dcd12cc8125f0aa4fedb988dc"
+                "reference": "fce6cc246d6c072ede1af415937e087eef6e8939"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/ea87542ccf71172dcd12cc8125f0aa4fedb988dc",
-                "reference": "ea87542ccf71172dcd12cc8125f0aa4fedb988dc",
+                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/fce6cc246d6c072ede1af415937e087eef6e8939",
+                "reference": "fce6cc246d6c072ede1af415937e087eef6e8939",
                 "shasum": ""
             },
             "require": {
@@ -16781,7 +16781,7 @@
                 "issues": "https://github.com/SU-SWS/sws-drush-commands/issues",
                 "source": "https://github.com/SU-SWS/sws-drush-commands"
             },
-            "time": "2026-06-18T19:03:23+00:00"
+            "time": "2026-06-18T19:21:43+00:00"
         },
         {
             "name": "symfony/cache",


### PR DESCRIPTION
# Summary
SWSDC now has Slack notifications for deployments, cron failures, and database syncing — matching BLT's alerting behavior. Implemented via incoming webhook URL for simplicity and low permission overhead.

## Backstory
[HSD8-1860](https://stanfordits.atlassian.net/browse/HSD8-1860)

BLT had Slack notifications; SWSDC didn't. Added notifications for:
- Deployments to any Acquia environment (via `sws:multisite:update:parallel` cloud hooks)
- Cron failures (Drupal and Scheduler cron jobs)
- Database syncs from prod to staging

## Implementation
All changes are in the upstream `sws-drush-commands` repo ([multisite-improvements branch](https://github.com/SU-SWS/sws-drush-commands/compare/multisite-improvements)):
- Added `sendWebhookNotification()` helper to `SwsCommandsTrait` — posts to `SLACK_NOTIFICATION_URL` env var
- New `sws:slack-notify` Drush command for testing (accepts `--slack-url` to override env var)
- Wired into `sws:multisite:update:parallel`, `sws:multisite:sync-stage`, and `sws:multisite:cron` commands
- Messages: deployment status, failed site counts, sync completion counts

This PR bumps the `composer.lock` to pull in those changes.

## Steps to Test
1. Notifications are sent automatically when:
   - Code is deployed to Acquia (cloud hooks fire `sws:multisite:update:parallel`)
   - Cron jobs run and fail
   - Database syncs complete (weekly via `content-stage.yml`)
2. For manual testing: `drush sws:slack-notify "test message" --slack-url="YOUR_WEBHOOK_URL"`
3. Verify messages appear in #hs-sws (or test channel during initial rollout)


[HSD8-1860]: https://stanfordits.atlassian.net/browse/HSD8-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ