### PR TITLE
Update sws-drush-commands dependency from multisite-improvements branch to 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -195,7 +195,7 @@
         "su-sws/stanford_media": "^11.0",
         "su-sws/stanford_migrate": "^9.0",
         "su-sws/stanford_samlauth": "^2.0",
-        "su-sws/sws-drush-commands": "multisite-improvements-dev"
+        "su-sws/sws-drush-commands": "1.x-dev"
     },
     "require-dev": {
         "drupal/core-dev": "~11.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "129368c2c936f24da25b3df7563ffb76",
+    "content-hash": "0d2ba3d1e5d8cf84bfdf758087b98bbe",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -16741,16 +16741,16 @@
         },
         {
             "name": "su-sws/sws-drush-commands",
-            "version": "dev-multisite-improvements",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SU-SWS/sws-drush-commands.git",
-                "reference": "fce6cc246d6c072ede1af415937e087eef6e8939"
+                "reference": "5f39c7114a5dba768d3b6111f53497ac7a8bb35f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/fce6cc246d6c072ede1af415937e087eef6e8939",
-                "reference": "fce6cc246d6c072ede1af415937e087eef6e8939",
+                "url": "https://api.github.com/repos/SU-SWS/sws-drush-commands/zipball/5f39c7114a5dba768d3b6111f53497ac7a8bb35f",
+                "reference": "5f39c7114a5dba768d3b6111f53497ac7a8bb35f",
                 "shasum": ""
             },
             "require": {
@@ -16765,6 +16765,7 @@
             "replace": {
                 "drupal/artifact_deployment": "*"
             },
+            "default-branch": true,
             "type": "drupal-drush",
             "autoload": {
                 "psr-4": {
@@ -16781,7 +16782,7 @@
                 "issues": "https://github.com/SU-SWS/sws-drush-commands/issues",
                 "source": "https://github.com/SU-SWS/sws-drush-commands"
             },
-            "time": "2026-06-18T19:21:43+00:00"
+            "time": "2026-06-18T20:35:39+00:00"
         },
         {
             "name": "symfony/cache",


### PR DESCRIPTION
# Summary
Update `su-sws/sws-drush-commands` composer dependency from the `multisite-improvements` branch to the `1.x` branch, since the multisite improvements work has been merged into `1.x`.

## Backstory
We were pinned to `multisite-improvements-dev` in order to pick up custom changes that were being developed on that branch. Now that those changes have been merged into `1.x`, we should track the stable branch instead. This is the better long-term approach — we'll automatically receive upstream updates rather than relying on a feature branch that may eventually be deleted or fall behind.

## Steps to Test
1. Run `composer update su-sws/sws-drush-commands` and confirm it resolves from the `1.x` branch without errors.
2. Verify drush commands provided by the package still function as expected on a local or Tugboat environment.
