### PR TITLE
SHS-6653: Update heading wrapping behavior

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
@@ -38,15 +38,17 @@
   );
   text-wrap: balance;
 
-  @supports (text-wrap: pretty) {
-    text-wrap: pretty;
-  }
-
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
 
     .hb-font-sans-serif & {
       font-family: $hb-traditional-font--sans;
+    }
+  }
+
+  @supports (text-wrap: pretty) {
+    @at-root #{&} {
+      text-wrap: pretty;
     }
   }
 }
@@ -64,15 +66,17 @@
   );
   text-wrap: balance;
 
-  @supports (text-wrap: pretty) {
-    text-wrap: pretty;
-  }
-
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
 
     .hb-font-sans-serif & {
       font-family: $hb-traditional-font--sans;
+    }
+  }
+
+  @supports (text-wrap: pretty) {
+    @at-root #{&} {
+      text-wrap: pretty;
     }
   }
 }
@@ -90,15 +94,17 @@
   );
   text-wrap: balance;
 
-  @supports (text-wrap: pretty) {
-    text-wrap: pretty;
-  }
-
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
 
     .hb-font-sans-serif & {
       font-family: $hb-traditional-font--sans;
+    }
+  }
+
+  @supports (text-wrap: pretty) {
+    @at-root #{&} {
+      text-wrap: pretty;
     }
   }
 }
@@ -117,7 +123,9 @@
   text-wrap: balance;
 
   @supports (text-wrap: pretty) {
-    text-wrap: pretty;
+    @at-root #{&} {
+      text-wrap: pretty;
+    }
   }
 }
 
@@ -135,7 +143,9 @@
   text-wrap: balance;
 
   @supports (text-wrap: pretty) {
-    text-wrap: pretty;
+    @at-root #{&} {
+      text-wrap: pretty;
+    }
   }
 }
 
@@ -154,7 +164,9 @@
   text-wrap: balance;
 
   @supports (text-wrap: pretty) {
-    text-wrap: pretty;
+    @at-root #{&} {
+      text-wrap: pretty;
+    }
   }
 }
 

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
@@ -36,7 +36,11 @@
     ),
     hb-calculate-rems(47px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -58,7 +62,11 @@
     ),
     hb-calculate-rems(35px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -80,7 +88,11 @@
     ),
     hb-calculate-rems(26px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -102,7 +114,11 @@
     ),
     hb-calculate-rems(21px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 }
 
 @mixin hb-heading-5 {
@@ -116,7 +132,11 @@
     ),
     hb-calculate-rems(18px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 }
 
 @mixin hb-heading-6 {
@@ -131,7 +151,11 @@
     ),
     hb-calculate-rems(16px)
   );
-  text-wrap: pretty;
+  text-wrap: balance;
+
+  @supports (text-wrap: pretty) {
+    text-wrap: pretty;
+  }
 }
 
 @mixin hb-body--small {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/mixins/_text.scss
@@ -36,7 +36,7 @@
     ),
     hb-calculate-rems(47px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -58,7 +58,7 @@
     ),
     hb-calculate-rems(35px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -80,7 +80,7 @@
     ),
     hb-calculate-rems(26px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 
   @include hb-traditional {
     font-family: $hb-traditional-font--serif;
@@ -102,7 +102,7 @@
     ),
     hb-calculate-rems(21px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 }
 
 @mixin hb-heading-5 {
@@ -116,7 +116,7 @@
     ),
     hb-calculate-rems(18px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 }
 
 @mixin hb-heading-6 {
@@ -131,7 +131,7 @@
     ),
     hb-calculate-rems(16px)
   );
-  text-wrap: balance;
+  text-wrap: pretty;
 }
 
 @mixin hb-body--small {


### PR DESCRIPTION
# Summary
Update heading styles to use `text-wrap: pretty` instead of `text-wrap: balance`.

## Backstory
https://fourkitchens.clickup.com/t/36718269/SHS-6653

## Need Review By (Date)
TBD

## Urgency
normal

## Steps to Test:

- Go to the [English](https://english-wdq0esbdy71llfhm4rmyi5q9gfuiydrq.tugboatqa.com/) site homepage in Chrome or Safari and verify that the banner title “Welcome to the Stanford University Department of English” has text-wrap: pretty applied.

<img width="1724" height="599" alt="image" src="https://github.com/user-attachments/assets/ae66d210-8e7e-4f01-89a3-ba1e84071459" />

- Also, verify that the same property is applied to the card headings in the Recent News section.

<img width="1719" height="808" alt="image" src="https://github.com/user-attachments/assets/58a1f459-18fb-4ff8-954f-df2eee67a003" />

- In Firefox, verify that text-wrap: balance is still being used as the fallback behavior.

<img width="1727" height="741" alt="image" src="https://github.com/user-attachments/assets/ee8f8cf0-e8b9-4fed-af36-7f5920b3c849" />

- Test other pages in the site (and other tugboat sites), for example:
    - https://english-wdq0esbdy71llfhm4rmyi5q9gfuiydrq.tugboatqa.com/news-events/recent-news
    - https://english-wdq0esbdy71llfhm4rmyi5q9gfuiydrq.tugboatqa.com/academics/phd-program/joint-degree-program-school-law-jdphd
    - https://history-wdq0esbdy71llfhm4rmyi5q9gfuiydrq.tugboatqa.com/
    - https://history-wdq0esbdy71llfhm4rmyi5q9gfuiydrq.tugboatqa.com/recent-news

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214061824825253
  - https://app.asana.com/0/0/1215978615376432