### PR TITLE
HSD8-1921: Added default training view

### DIFF
--- a/config/default/views.view.hs_default_trainings.yml
+++ b/config/default/views.view.hs_default_trainings.yml
@@ -1526,4 +1526,3 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-

--- a/config/default/views.view.hs_default_trainings.yml
+++ b/config/default/views.view.hs_default_trainings.yml
@@ -630,7 +630,6 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
-      css_class: 'hb-raised-cards hb-raised-cards--uniform-height'
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -841,7 +840,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: Date
+          label: Date/Time
           exclude: false
           alter:
             alter_text: false
@@ -1011,6 +1010,7 @@ display:
             field_hs_training_date_range: field_hs_training_date_range
             field_hs_training_deliverymethod: field_hs_training_deliverymethod
             field_hs_training_resource_links: field_hs_training_resource_links
+            field_hs_training_name: field_hs_training_name
           default: '-1'
           info:
             title:
@@ -1040,6 +1040,13 @@ display:
               empty_column: false
               responsive: ''
             field_hs_training_resource_links:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_hs_training_name:
+              sortable: false
+              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
@@ -1091,13 +1098,11 @@ display:
               destination: column_4
               weight: 4
       defaults:
-        css_class: false
         pager: false
         style: false
         row: false
         fields: false
         header: false
-      css_class: ''
       display_description: 'Table of all trainings.'
       header: {  }
       display_extenders: {  }
@@ -1121,6 +1126,47 @@ display:
     position: 1
     display_options:
       fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         field_hs_training_name:
           id: field_hs_training_name
           table: node__field_hs_training_name
@@ -1130,34 +1176,10 @@ display:
           admin_label: ''
           plugin_id: field
           label: ''
-          exclude: true
+          exclude: false
           alter:
             alter_text: false
-            text: ''
             make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1184,59 +1206,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        view_node_1:
-          id: view_node_1
-          table: node
-          field: view_node
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: entity_link
-          label: ''
-          exclude: false
-          alter:
-            alter_text: true
-            text: '<a href="{{ view_node_1 }}">{{ field_hs_training_name }}</a>'
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          text: ''
-          output_url_as_text: true
-          absolute: false
         field_hs_training_date_range:
           id: field_hs_training_date_range
           table: node__field_hs_training_date_range
@@ -1501,6 +1470,35 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'See training details'
+          output_url_as_text: false
+          absolute: false
       pager:
         type: some
         options:
@@ -1669,36 +1667,37 @@ display:
         options:
           default_field_elements: true
           inline:
-            view_node_1: '0'
+            title: '0'
             field_hs_training_name: '0'
             field_hs_training_date_range: '0'
             field_hs_training_date_range_1: '0'
             field_hs_training_date_range_2: '0'
             field_hs_training_location: '0'
             body: '0'
+            view_node: '0'
           separator: ''
           hide_empty: true
           pattern: date_stacked_vertical_card
           pattern_mapping:
-            'views_row:view_node_1':
-              plugin: views_row
-              source: view_node_1
-              destination: title
-              weight: 0
             'views_row:field_hs_training_date_range_2':
               plugin: views_row
               source: field_hs_training_date_range_2
               destination: time
-              weight: 1
+              weight: 0
             'views_row:body':
               plugin: views_row
               source: body
               destination: description
+              weight: 1
+            'views_row:view_node':
+              plugin: views_row
+              source: view_node
+              destination: button
               weight: 2
             'views_row:field_hs_training_name':
               plugin: views_row
               source: field_hs_training_name
-              destination: category
+              destination: title
               weight: 3
             'views_row:field_hs_training_date_range_1':
               plugin: views_row

--- a/config/default/views.view.hs_default_trainings.yml
+++ b/config/default/views.view.hs_default_trainings.yml
@@ -1,0 +1,1529 @@
+uuid: 5bd1a434-7e53-44fa-84ce-7ed9948a09cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - field.storage.node.field_hs_training_audience
+    - field.storage.node.field_hs_training_date_range
+    - field.storage.node.field_hs_training_deliverymethod
+    - field.storage.node.field_hs_training_location
+    - field.storage.node.field_hs_training_name
+    - field.storage.node.field_hs_training_provider
+    - field.storage.node.field_hs_training_resource_links
+    - field.storage.node.field_hs_training_unit
+    - node.type.hs_training
+  module:
+    - hs_field_helpers
+    - hs_layouts
+    - link
+    - node
+    - smart_date
+    - taxonomy
+    - text
+    - ui_patterns
+    - ui_patterns_views
+    - user
+id: hs_default_trainings
+label: 'Default Trainings'
+module: views
+description: ''
+tag: sparkbox
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Trainings
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_date_range:
+          id: field_hs_training_date_range
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          label: 'Date & Time'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: custom
+          custom_date_format: 'l, F j, Y'
+          click_sort_column: value
+          type: datetime_hs
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_location:
+          id: field_hs_training_location
+          table: node__field_hs_training_location
+          field: field_hs_training_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Location
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_deliverymethod:
+          id: field_hs_training_deliverymethod
+          table: node__field_hs_training_deliverymethod
+          field: field_hs_training_deliverymethod
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Delivery Method'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_audience:
+          id: field_hs_training_audience
+          table: node__field_hs_training_audience
+          field: field_hs_training_audience
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Audience
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_unit:
+          id: field_hs_training_unit
+          table: node__field_hs_training_unit
+          field: field_hs_training_unit
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Unit
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_provider:
+          id: field_hs_training_provider
+          table: node__field_hs_training_provider
+          field: field_hs_training_provider
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Provided by'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<p>There are no trainings to display at this time. Please check back again soon.</p>'
+          tokenize: false
+      sorts:
+        field_hs_training_date_range_value:
+          id: field_hs_training_date_range_value
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            hs_training: hs_training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_table:
+    id: block_table
+    display_title: 'Trainings Table'
+    display_plugin: block
+    position: 2
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_audience:
+          id: field_hs_training_audience
+          table: node__field_hs_training_audience
+          field: field_hs_training_audience
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: —
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_date_range:
+          id: field_hs_training_date_range
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: —
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: smartdate_custom
+          settings:
+            separator: ' - '
+            date_format: 'D, M j, Y'
+            time_format: 'g:ia'
+            time_hour_format: ga
+            allday_label: 'All day'
+            join: ', '
+            ampm_reduce: true
+            date_first: '1'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_deliverymethod:
+          id: field_hs_training_deliverymethod
+          table: node__field_hs_training_deliverymethod
+          field: field_hs_training_deliverymethod
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_resource_links:
+          id: field_hs_training_resource_links
+          table: node__field_hs_training_resource_links
+          field: field_hs_training_resource_links
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: —
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: null
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '<br />'
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: pattern
+        options:
+          pattern: table_pattern
+          pattern_mapping:
+            rows:
+              destination: items
+              weight: '0'
+            title:
+              destination: ''
+              weight: '0'
+            'header:area':
+              destination: header
+              weight: '0'
+      row:
+        type: ui_patterns
+        options:
+          default_field_elements: true
+          inline:
+            title: '0'
+            field_hs_training_audience: '0'
+            field_hs_training_date_range: '0'
+            field_hs_training_deliverymethod: '0'
+            field_hs_training_resource_links: '0'
+          separator: ''
+          hide_empty: false
+          pattern: table_row
+          pattern_mapping:
+            'views_row:title':
+              plugin: views_row
+              source: title
+              destination: column_1
+              weight: 0
+            'views_row:field_hs_training_audience':
+              plugin: views_row
+              source: field_hs_training_audience
+              destination: column_2
+              weight: 1
+            'views_row:field_hs_training_date_range':
+              plugin: views_row
+              source: field_hs_training_date_range
+              destination: column_3
+              weight: 2
+            'views_row:field_hs_training_deliverymethod':
+              plugin: views_row
+              source: field_hs_training_deliverymethod
+              destination: column_3
+              weight: 3
+            'views_row:field_hs_training_resource_links':
+              plugin: views_row
+              source: field_hs_training_resource_links
+              destination: column_4
+              weight: 4
+      defaults:
+        pager: false
+        style: false
+        row: false
+        fields: false
+        header: false
+      display_description: 'Table of all trainings.'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"Cell\" role=\"columnheader\" id=\"a1\">\n  Training\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a2\">\n  Audience\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a3\">\n  Dates &amp; Delivery Method\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a4\">\n  Resources\n</div>"
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_upcoming:
+    id: block_upcoming
+    display_title: 'Upcoming Trainings'
+    display_plugin: block
+    position: 1
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_name:
+          id: field_hs_training_name
+          table: node__field_hs_training_name
+          field: field_hs_training_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_date_range:
+          id: field_hs_training_date_range
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: 'Date - Stacked Month'
+          plugin_id: date
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: custom
+          custom_date_format: F
+          click_sort_column: value
+          type: datetime_hs
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_date_range_1:
+          id: field_hs_training_date_range_1
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: 'Date - Stacked Day'
+          plugin_id: date
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: custom
+          custom_date_format: j
+          click_sort_column: value
+          type: datetime_hs
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_date_range_2:
+          id: field_hs_training_date_range_2
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range
+          relationship: none
+          group_type: group
+          admin_label: 'Date - Time'
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: smartdate_custom
+          settings:
+            separator: ' - '
+            date_format: 'D, M j, Y'
+            time_format: 'g:ia'
+            time_hour_format: ga
+            allday_label: 'All day'
+            join: ', '
+            ampm_reduce: true
+            date_first: '1'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_training_location:
+          id: field_hs_training_location
+          table: node__field_hs_training_location
+          field: field_hs_training_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: body
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 200
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'See training details'
+          output_url_as_text: false
+          absolute: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 6
+      sorts:
+        field_hs_training_date_range_value:
+          id: field_hs_training_date_range_value
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            hs_training: hs_training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_hs_training_date_range_value:
+          id: field_hs_training_date_range_value
+          table: node__field_hs_training_date_range
+          field: field_hs_training_date_range_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: now
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: grid
+        options:
+          grouping: {  }
+          columns: 3
+          automatic_width: false
+          alignment: horizontal
+          row_class_custom: ''
+          row_class_default: true
+          col_class_custom: ''
+          col_class_default: true
+      row:
+        type: ui_patterns
+        options:
+          default_field_elements: true
+          inline:
+            field_hs_training_name: '0'
+            field_hs_training_date_range: '0'
+            field_hs_training_date_range_1: '0'
+            field_hs_training_date_range_2: '0'
+            title: '0'
+            field_hs_training_location: '0'
+            body: '0'
+            view_node: '0'
+          separator: ''
+          hide_empty: true
+          pattern: date_stacked_vertical_card
+          pattern_mapping:
+            'views_row:title':
+              plugin: views_row
+              source: title
+              destination: title
+              weight: 0
+            'views_row:field_hs_training_date_range_2':
+              plugin: views_row
+              source: field_hs_training_date_range_2
+              destination: time
+              weight: 1
+            'views_row:body':
+              plugin: views_row
+              source: body
+              destination: description
+              weight: 2
+            'views_row:view_node':
+              plugin: views_row
+              source: view_node
+              destination: button
+              weight: 3
+            'views_row:field_hs_training_name':
+              plugin: views_row
+              source: field_hs_training_name
+              destination: category
+              weight: 4
+            'views_row:field_hs_training_date_range_1':
+              plugin: views_row
+              source: field_hs_training_date_range_1
+              destination: day
+              weight: 5
+            'views_row:field_hs_training_date_range':
+              plugin: views_row
+              source: field_hs_training_date_range
+              destination: month
+              weight: 6
+            'views_row:field_hs_training_location':
+              plugin: views_row
+              source: field_hs_training_location
+              destination: location
+              weight: 7
+          variants:
+            spotlight: default
+            hero_text_overlay: default
+            generic_three_column: default
+            accordion: closed
+      defaults:
+        pager: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+      display_description: 'Trainings with upcoming dates.'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+

--- a/config/default/views.view.hs_default_trainings.yml
+++ b/config/default/views.view.hs_default_trainings.yml
@@ -10,18 +10,12 @@ dependencies:
     - field.storage.node.field_hs_training_location
     - field.storage.node.field_hs_training_name
     - field.storage.node.field_hs_training_provider
-    - field.storage.node.field_hs_training_resource_links
     - field.storage.node.field_hs_training_unit
     - node.type.hs_training
   module:
-    - hs_field_helpers
-    - hs_layouts
-    - link
     - node
     - smart_date
-    - taxonomy
     - text
-    - ui_patterns
     - ui_patterns_views
     - user
 id: hs_default_trainings
@@ -636,8 +630,10 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
+      css_class: 'hb-raised-cards hb-raised-cards--uniform-height'
       header: {  }
       footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -645,7 +641,12 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_hs_training_audience'
+        - 'config:field.storage.node.field_hs_training_deliverymethod'
+        - 'config:field.storage.node.field_hs_training_location'
+        - 'config:field.storage.node.field_hs_training_provider'
+        - 'config:field.storage.node.field_hs_training_unit'
   block_table:
     id: block_table
     display_title: 'Trainings Table'
@@ -653,21 +654,43 @@ display:
     position: 2
     display_options:
       fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+        field_hs_training_name:
+          id: field_hs_training_name
+          table: node__field_hs_training_name
+          field: field_hs_training_name
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: title
           plugin_id: field
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -680,11 +703,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: string
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            link_to_entity: true
-          group_column: value
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -694,6 +717,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: Training
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="{{ view_node }}">{{ field_hs_training_name }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: ''
+          output_url_as_text: true
+          absolute: false
         field_hs_training_audience:
           id: field_hs_training_audience
           table: node__field_hs_training_audience
@@ -702,11 +778,35 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: Audience
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -741,11 +841,35 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: Date
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -762,13 +886,26 @@ display:
           type: smartdate_custom
           settings:
             separator: ' - '
+            time_diff:
+              enabled: 0
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: '2'
+              refresh: '60'
+              description: ''
             date_format: 'D, M j, Y'
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            join: ', '
             time_format: 'g:ia'
             time_hour_format: ga
             allday_label: 'All day'
-            join: ', '
-            ampm_reduce: true
             date_first: '1'
+            ampm_reduce: 1
+            site_time_toggle: '1'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -787,11 +924,35 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: 'Delivery Method'
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -817,49 +978,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_hs_training_resource_links:
-          id: field_hs_training_resource_links
-          table: node__field_hs_training_resource_links
-          field: field_hs_training_resource_links
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            make_link: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: —
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: uri
-          type: link
-          settings:
-            trim_length: null
-            url_only: false
-            url_plain: false
-            rel: '0'
-            target: '0'
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: '<br />'
-          field_api_classes: false
       pager:
         type: full
         options:
@@ -882,19 +1000,57 @@ display:
             offset_label: Offset
           quantity: 9
       style:
-        type: pattern
+        type: table
         options:
-          pattern: table_pattern
-          pattern_mapping:
-            rows:
-              destination: items
-              weight: '0'
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            title: title
+            field_hs_training_audience: field_hs_training_audience
+            field_hs_training_date_range: field_hs_training_date_range
+            field_hs_training_deliverymethod: field_hs_training_deliverymethod
+            field_hs_training_resource_links: field_hs_training_resource_links
+          default: '-1'
+          info:
             title:
-              destination: ''
-              weight: '0'
-            'header:area':
-              destination: header
-              weight: '0'
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_hs_training_audience:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_hs_training_date_range:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_hs_training_deliverymethod:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_hs_training_resource_links:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+          class: ''
       row:
         type: ui_patterns
         options:
@@ -935,35 +1091,29 @@ display:
               destination: column_4
               weight: 4
       defaults:
+        css_class: false
         pager: false
         style: false
         row: false
         fields: false
         header: false
+      css_class: ''
       display_description: 'Table of all trainings.'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: false
-          content:
-            value: "<div class=\"Cell\" role=\"columnheader\" id=\"a1\">\n  Training\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a2\">\n  Audience\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a3\">\n  Dates &amp; Delivery Method\n</div>\n<div class=\"Cell\" role=\"columnheader\" id=\"a4\">\n  Resources\n</div>"
-            format: basic_html
-          tokenize: false
+      header: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_hs_training_audience'
+        - 'config:field.storage.node.field_hs_training_date_range'
+        - 'config:field.storage.node.field_hs_training_deliverymethod'
+        - 'config:field.storage.node.field_hs_training_name'
   block_upcoming:
     id: block_upcoming
     display_title: 'Upcoming Trainings'
@@ -971,47 +1121,6 @@ display:
     position: 1
     display_options:
       fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            make_link: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         field_hs_training_name:
           id: field_hs_training_name
           table: node__field_hs_training_name
@@ -1021,10 +1130,34 @@ display:
           admin_label: ''
           plugin_id: field
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1051,6 +1184,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        view_node_1:
+          id: view_node_1
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="{{ view_node_1 }}">{{ field_hs_training_name }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: ''
+          output_url_as_text: true
+          absolute: false
         field_hs_training_date_range:
           id: field_hs_training_date_range
           table: node__field_hs_training_date_range
@@ -1137,11 +1323,35 @@ display:
           group_type: group
           admin_label: 'Date - Time'
           plugin_id: field
-          label: ''
+          label: Date
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1158,13 +1368,26 @@ display:
           type: smartdate_custom
           settings:
             separator: ' - '
+            time_diff:
+              enabled: 0
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: '2'
+              refresh: '60'
+              description: ''
             date_format: 'D, M j, Y'
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            join: ', '
             time_format: 'g:ia'
             time_hour_format: ga
             allday_label: 'All day'
-            join: ', '
-            ampm_reduce: true
             date_first: '1'
+            ampm_reduce: 1
+            site_time_toggle: '1'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1183,11 +1406,35 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: ''
+          label: Location
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1254,40 +1501,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        view_node:
-          id: view_node
-          table: node
-          field: view_node
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: entity_link
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            make_link: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          text: 'See training details'
-          output_url_as_text: false
-          absolute: false
       pager:
         type: some
         options:
           offset: 0
-          items_per_page: 6
+          items_per_page: 3
       sorts:
         field_hs_training_date_range_value:
           id: field_hs_training_date_range_value
@@ -1451,21 +1669,20 @@ display:
         options:
           default_field_elements: true
           inline:
+            view_node_1: '0'
             field_hs_training_name: '0'
             field_hs_training_date_range: '0'
             field_hs_training_date_range_1: '0'
             field_hs_training_date_range_2: '0'
-            title: '0'
             field_hs_training_location: '0'
             body: '0'
-            view_node: '0'
           separator: ''
           hide_empty: true
           pattern: date_stacked_vertical_card
           pattern_mapping:
-            'views_row:title':
+            'views_row:view_node_1':
               plugin: views_row
-              source: title
+              source: view_node_1
               destination: title
               weight: 0
             'views_row:field_hs_training_date_range_2':
@@ -1478,37 +1695,39 @@ display:
               source: body
               destination: description
               weight: 2
-            'views_row:view_node':
-              plugin: views_row
-              source: view_node
-              destination: button
-              weight: 3
             'views_row:field_hs_training_name':
               plugin: views_row
               source: field_hs_training_name
               destination: category
-              weight: 4
+              weight: 3
             'views_row:field_hs_training_date_range_1':
               plugin: views_row
               source: field_hs_training_date_range_1
               destination: day
-              weight: 5
+              weight: 4
             'views_row:field_hs_training_date_range':
               plugin: views_row
               source: field_hs_training_date_range
               destination: month
-              weight: 6
+              weight: 5
             'views_row:field_hs_training_location':
               plugin: views_row
               source: field_hs_training_location
               destination: location
-              weight: 7
+              weight: 6
           variants:
-            spotlight: default
-            hero_text_overlay: default
-            generic_three_column: default
             accordion: closed
+            alert: default
+            callout_box: right
+            color_band: default
+            generic_three_column: default
+            gradient-hero: default
+            spotlight: default
+            testimonial: top
+            timeline-item: closed
+            timeline: expanded
       defaults:
+        css_class: false
         pager: false
         style: false
         row: false
@@ -1516,6 +1735,7 @@ display:
         sorts: false
         filters: false
         filter_groups: false
+      css_class: 'hb-raised-cards hb-raised-cards--uniform-height'
       display_description: 'Trainings with upcoming dates.'
       display_extenders: {  }
     cache_metadata:
@@ -1525,4 +1745,8 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_hs_training_date_range'
+        - 'config:field.storage.node.field_hs_training_location'
+        - 'config:field.storage.node.field_hs_training_name'


### PR DESCRIPTION
# Summary
We add a default view for training content.

## Backstory
We add a new view with two blocks.  They provide displays for Training CT. 
Upcoming Trainings → `date_stacked_vertical_card` cards in a 3-across grid (same pattern the Events view uses):
- Date badge (month F / day j), training-name label, bold serif linked title, date/time line, location, description, and a "See training details" button.

Trainings Table → table_pattern / table_row (same pattern the Courses view uses):
- Renders as `<div role="grid">` with `hb-table-row__column` cells, so no `<table>` element in the markup
- Header row (TRAINING / AUDIENCE / DATES & DELIVERY METHOD / RESOURCES) from a header area, zebra striping, `em-dash` placeholders so empty cells keep column alignment. 
- Color is selected by the theme, consistent with the 


### Open question: 
Is `em-dash` what we want to use for placeholder, or non-breaking spaces instead?

## Need Review By (Date)
For 7/15 release

## Urgency
Medium

## Steps to Test
1. pull down code, `drush cim && drush cr`
2. Create a little bit of test content for the Training CT
3. Use Layout Builder to add the blocks to a page
4. Verify the blocks appear as expected
5. Check the code for correctness


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215709173084355
  - https://app.asana.com/0/0/1216178353134181