### PR TITLE
HSD8-1924: Added default projects view

### DIFF
--- a/config/default/views.view.hs_default_projects.yml
+++ b/config/default/views.view.hs_default_projects.yml
@@ -9,12 +9,9 @@ dependencies:
     - field.storage.node.field_hs_project_lead
     - node.type.hs_project
   module:
-    - hs_layouts
     - node
     - stanford_media
-    - taxonomy
     - text
-    - ui_patterns
     - ui_patterns_views
     - user
 id: hs_default_projects
@@ -45,7 +42,31 @@ display:
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -59,11 +80,12 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: media_image_formatter
+          type: media_responsive_image_formatter
           settings:
-            view_mode: default
+            view_mode: responsive_lazy
             link: true
-            image_style: medium
+            image_style: hp_3_down_events
+            remove_alt: 0
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -86,9 +108,33 @@ display:
           exclude: false
           alter:
             alter_text: false
+            text: ''
             make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
-          element_class: ''
+          element_class: hb-pill
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
@@ -565,23 +611,33 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
+      css_class: hb-raised-cards
       header: {  }
       footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_hs_project_description'
+        - 'config:field.storage.node.field_hs_project_featured_image'
+        - 'config:field.storage.node.field_hs_project_is_active'
+        - 'config:field.storage.node.field_hs_project_lead'
   block_projects:
     id: block_projects
     display_title: Projects
     display_plugin: block
     position: 1
     display_options:
+      defaults:
+        css_class: true
+        fields: true
       display_extenders: {  }
       block_description: 'Default Projects'
       block_category: 'Projects (Views)'
@@ -591,6 +647,11 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_hs_project_description'
+        - 'config:field.storage.node.field_hs_project_featured_image'
+        - 'config:field.storage.node.field_hs_project_is_active'
+        - 'config:field.storage.node.field_hs_project_lead'

--- a/config/default/views.view.hs_default_projects.yml
+++ b/config/default/views.view.hs_default_projects.yml
@@ -1,0 +1,597 @@
+uuid: c9d0e1f2-3a4b-4c5d-8e9f-0a1b2c3d4e5f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hs_project_description
+    - field.storage.node.field_hs_project_featured_image
+    - field.storage.node.field_hs_project_is_active
+    - field.storage.node.field_hs_project_lead
+    - node.type.hs_project
+  module:
+    - hs_layouts
+    - node
+    - stanford_media
+    - taxonomy
+    - text
+    - ui_patterns
+    - ui_patterns_views
+    - user
+id: hs_default_projects
+label: 'Default Projects'
+module: views
+description: ''
+tag: sparkbox
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Projects
+      fields:
+        field_hs_project_featured_image:
+          id: field_hs_project_featured_image
+          table: node__field_hs_project_featured_image
+          field: field_hs_project_featured_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_image_formatter
+          settings:
+            view_mode: default
+            link: true
+            image_style: medium
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_project_is_active:
+          id: field_hs_project_is_active
+          table: node__field_hs_project_is_active
+          field: field_hs_project_is_active
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Past
+            format_custom_true: Active
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_project_description:
+          id: field_hs_project_description
+          table: node__field_hs_project_description
+          field: field_hs_project_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 300
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_hs_project_lead:
+          id: field_hs_project_lead
+          table: node__field_hs_project_lead
+          field: field_hs_project_lead
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'View project'
+          output_url_as_text: false
+          absolute: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<p>There are no projects to display at this time.</p>'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            hs_project: hs_project
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_hs_project_is_active_value:
+          id: field_hs_project_is_active_value
+          table: node__field_hs_project_is_active
+          field: field_hs_project_is_active_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_hs_project_is_active_value_op
+            label: 'Active / Past Projects'
+            description: ''
+            use_operator: false
+            operator: field_hs_project_is_active_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: project_status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Active / Past Projects'
+            description: ''
+            identifier: project_status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Active
+                operator: '='
+                value: '1'
+              2:
+                title: Past
+                operator: '='
+                value: '0'
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: combine
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: 'Keyword Search'
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: keyword
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            title: title
+            field_hs_project_description: field_hs_project_description
+            field_hs_project_lead: field_hs_project_lead
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+      row:
+        type: ui_patterns
+        options:
+          default_field_elements: true
+          inline:
+            field_hs_project_featured_image: '0'
+            field_hs_project_is_active: '0'
+            title: '0'
+            field_hs_project_description: '0'
+            view_node: '0'
+          separator: ''
+          hide_empty: false
+          pattern: horizontal_card
+          pattern_mapping:
+            'views_row:title':
+              plugin: views_row
+              source: title
+              destination: title
+              weight: 0
+            'views_row:field_hs_project_featured_image':
+              plugin: views_row
+              source: field_hs_project_featured_image
+              destination: image
+              weight: 1
+            'views_row:field_hs_project_is_active':
+              plugin: views_row
+              source: field_hs_project_is_active
+              destination: category
+              weight: 2
+            'views_row:field_hs_project_description':
+              plugin: views_row
+              source: field_hs_project_description
+              destination: description
+              weight: 3
+            'views_row:view_node':
+              plugin: views_row
+              source: view_node
+              destination: button
+              weight: 4
+          variants:
+            hero_text_overlay: default
+            generic_three_column: default
+            accordion: closed
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_projects:
+    id: block_projects
+    display_title: Projects
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Default Projects'
+      block_category: 'Projects (Views)'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+

--- a/config/default/views.view.hs_default_projects.yml
+++ b/config/default/views.view.hs_default_projects.yml
@@ -594,4 +594,3 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-


### PR DESCRIPTION
# Summary
Adds a default Default Projects view (config/default/views.view.hs_default_projects.yml) for the hs_project content type, based on the [JRBP projects page](https://jrbp.stanford.edu/research/projects).

## Backstory
[HSD8-1924](https://stanfordits.atlassian.net/browse/HSD8-1924): Default Projects view

- Block display (block_projects) rendering projects as horizontal cards via the existing horizontal_card UI pattern (no custom CSS — reuses theme components, consistent with the Trainings and News views).
- Card mapping: featured image → image, is_active → Active/Past label, title (linked) → heading, description (trimmed) → body, node link → button.

Exposed filters per the ticket:
- Active / Past Projects — grouped filter on field_hs_project_is_active (Any / Active / Past)
- Keyword Search — core combine filter across title, description, and lead (no Search API dependency)
- Full pager (10/page), sorted newest first.

## Need Review By (Date)
Prior to 7/15 release

## Urgency
medium

## Steps to Test
1. Pull down branch
2. `drush @default.local cim`
3. Create some Project CT content on the site.  Give them different parameters
4. Using Layout Builder, add the block to a page, verify it works as expected.
5. Check code for correctness



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215742880980173
  - https://app.asana.com/0/0/1216310914424931

[HSD8-1924]: https://stanfordits.atlassian.net/browse/HSD8-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ