### PR TITLE
HSD8-1945: Standardize and improve Copy/Delete Site documentation

### DIFF
--- a/docs/BranchingStrategy.md
+++ b/docs/BranchingStrategy.md
@@ -1,6 +1,6 @@
 # H&S Branching Strategy
 
-This document describes the active branching model for the H&S application.
+This document describes the active branching model for the HSDP application.
 
 ## Branch Roles
 

--- a/docs/CodeDeploy.md
+++ b/docs/CodeDeploy.md
@@ -1,6 +1,6 @@
 # H&S Code Release and Deployment Guide
 
-This document outlines the release and deployment workflow for the H&S application.
+This document outlines the release and deployment workflow for the HSDP application.
 
 ## Overview
 - Releases follow [SEMVER](https://semver.org/) conventions: major, minor, patch.

--- a/docs/CopySite.md
+++ b/docs/CopySite.md
@@ -44,7 +44,7 @@ If the provision was not done correctly or the URLs are not set up, correct thos
 
 Before starting, notify the H&S web team and/or site owner that there will be brief downtime and they should refrain from editing the site until the copy is complete. Any edits made to the site after the database is copied down locally will not be transferred.
 
-### Create Database Backups
+### Back Up the SOURCE and DESTINATION Databases
 
 Create a database backup of both `<SOURCE>` and `<DESTINATION>`. The `<DESTINATION>` backup is especially important because its database and files are about to be dropped and overwritten by the copy.
 
@@ -90,7 +90,7 @@ The command prints the downloaded file's path in the system temp directory when 
 
 ```bash
 mkdir -p ~/site-backups
-mv /tmp/prod-<DESTINATION>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<DESTINATION>-prod-db-<YYYY-MM-DD>.sql.gz
+mv <FILEPATH> ~/site-backups/<DESTINATION>-prod-db-<YYYY-MM-DD>.sql.gz
 ```
 
 **With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
@@ -103,7 +103,7 @@ mv /tmp/prod-<DESTINATION>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<DESTINATION
 
 > **Important:** Whichever method you used above, upload the renamed backup to Google Drive before continuing.
 
-#### Back Up DESTINATION Files
+### Back Up DESTINATION Files
 
 Create a local directory:
 
@@ -315,12 +315,6 @@ drush @<DESTINATION>.prod cr
 ```
 
 Verify the canonical redirect is working by opening `https://<DESTINATION>-prod.stanford.edu/?foo` in an incognito window and confirming it redirects to `https://<LIVEURL>.stanford.edu/?foo`.
-
-Rebuild the cache:
-
-```bash
-drush @<DESTINATION>.prod cr
-```
 
 ### Update Live Domain Pointing in sites.php
 

--- a/docs/CopySite.md
+++ b/docs/CopySite.md
@@ -16,7 +16,7 @@ See [Development Requirements](DevelopmentRequirements.md).
 
 ## Provision a New Site to Copy To
 
-If the site to be copied to does not exist, the first step is to [provision a new site](NewSite.md) to be copied to. Follow all the steps up to the deployment of the code. The profile install is unnecessary because this is not for a fresh site — the existing site will be copied over.
+If the site to be copied to does not exist, the first step is to [provision a new site](NewSite.md) to be copied to. Follow all the steps up to the deployment of the code. The profile install is unnecessary because this is not for a fresh site: the existing site will be copied over.
 
 The provision step needs to happen first and the copy cannot continue until the provisioned code is deployed.
 
@@ -30,7 +30,7 @@ In the example above, `mathematics2024` is `<SOURCE>` and `mathematics` is `<DES
 
 ### Verify DESTINATION URLs Were Provisioned
 
-Make sure the following aliases have been set up correctly in [NetDB](https://netdb.stanford.edu/) — especially the `-prod` URL — before continuing.
+Make sure the following aliases, especially the `-prod` URL, have been set up correctly in [NetDB](https://netdb.stanford.edu/) before continuing.
 
 - `<DESTINATION>-dev`
 - `<DESTINATION>-test` (the staging environment)
@@ -48,11 +48,87 @@ Check the `<DESTINATION>` site's `/admin/content` page to verify there are no re
 
 ### Create Database Backups
 
-If `<SOURCE>` is going to be shut down or re-purposed, create a backup in case it needs to be restored or referenced.
+Create a database backup of both `<SOURCE>` and `<DESTINATION>`. The `<DESTINATION>` backup is especially important because its database and files are about to be dropped and overwritten by the copy.
 
-Create a backup of `<DESTINATION>` as well, in case there is confusion during the process.
+**With ACLI:**
 
-> **Warning:** Complete both backups before proceeding. The next steps will drop and overwrite the `<DESTINATION>` database. Confirm backups exist and are readable before continuing.
+You can target the environment by ID or by its `humscigryphon.prod` application alias (the alias rarely changes and is easier to remember):
+
+```bash
+# Using an environment ID:
+acli api:environments:database-backup-create <PROD_ENV_ID> <SOURCE>
+acli api:environments:database-backup-create <PROD_ENV_ID> <DESTINATION>
+
+# Using the humscigryphon.prod alias:
+acli api:environments:database-backup-create humscigryphon.prod <SOURCE>
+acli api:environments:database-backup-create humscigryphon.prod <DESTINATION>
+```
+
+**With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
+
+1. Open the Acquia Cloud UI for the HumSci Gryphon application.
+1. Click on the production environment (Prod).
+1. Click on the Databases tab in the left-side navigation.
+1. Find the `<SOURCE>` database, click its three-dot button, then **Backup**.
+1. Repeat for the `<DESTINATION>` database.
+
+#### Download the DESTINATION Database Backup
+
+`<DESTINATION>`'s database is about to be dropped and overwritten, so download the backup just created above, rename it, and upload it to Google Drive as a safety net.
+
+**With ACLI:**
+
+Download the backup just created above, without importing it anywhere:
+
+```bash
+# Using an environment ID:
+acli pull:database --no-import <PROD_ENV_ID> <DESTINATION>
+
+# Using the humscigryphon.prod alias:
+acli pull:database --no-import humscigryphon.prod <DESTINATION>
+```
+
+The command prints the downloaded file's path in the system temp directory when it finishes. Move it to your backup location and rename it to a clear, dated format:
+
+```bash
+mkdir -p ~/site-backups
+mv /tmp/prod-<DESTINATION>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<DESTINATION>-prod-db-<YYYY-MM-DD>.sql.gz
+```
+
+**With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
+
+1. Open the Acquia Cloud UI for the HumSci Gryphon application.
+1. Click on the production environment (Prod).
+1. Click on the Databases tab in the left-side navigation.
+1. Find the `<DESTINATION>` database, click its three-dot button, then **Download**.
+1. Rename the downloaded backup to a clear, dated format such as `<DESTINATION>-prod-db-<YYYY-MM-DD>.sql.gz`.
+
+> **Important:** Whichever method you used above, upload the renamed backup to Google Drive before continuing.
+
+#### Back Up DESTINATION Files
+
+Create a local directory:
+
+```bash
+mkdir -p ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>
+```
+
+Download the files:
+
+```bash
+drush rsync @<DESTINATION>.prod:%files/ ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>/files
+drush rsync @<DESTINATION>.prod:%private/ ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>/files-private
+```
+
+Archive the backup:
+
+```bash
+tar -czvf ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>.tar.gz ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>
+```
+
+Upload the archive to Google Drive, then delete the local backup directory and archive.
+
+> **Warning:** Complete both the `<DESTINATION>` database and files backups before proceeding. The next steps will drop and overwrite the `<DESTINATION>` database and files. Confirm the backups are uploaded and readable before continuing.
 
 ### Copy the Source Database and Files Locally
 

--- a/docs/CopySite.md
+++ b/docs/CopySite.md
@@ -178,11 +178,13 @@ Drop the existing `<DESTINATION>` database:
 drush @<DESTINATION>.prod sql-drop -y
 ```
 
-Push the `<SOURCE>` database to `<DESTINATION>`:
+Push the `<SOURCE>` database to `<DESTINATION>`. Piping a large file through `sql-cli` is slow because Drush stays in the data path; connect directly with `sql:connect` instead:
 
 ```bash
-drush @<DESTINATION>.prod sql-cli < ~/site-copies/<SOURCE>-<DESTINATION>-transfer/<SOURCE>.sql
+$(drush @<DESTINATION>.prod sql:connect) < ~/site-copies/<SOURCE>-<DESTINATION>-transfer/<SOURCE>.sql
 ```
+
+> **Note:** `sql:connect` prints the database credentials as part of the connection command. Avoid running this in a context where the command line is logged or visible to others.
 
 Push the `<SOURCE>` files and private files to `<DESTINATION>`:
 
@@ -204,12 +206,18 @@ Rebuild the cache on `<DESTINATION>`:
 drush @<DESTINATION>.prod cr
 ```
 
-Clear Varnish via the Acquia UI or ACLI:
+Clear Varnish via the Acquia UI or ACLI. You can target the environment by ID or by its `humscigryphon.prod` application alias (the alias rarely changes and is easier to remember):
 
 ```bash
-acli api:environments:domain-clear-caches <APP_UUID> <DESTINATION>.stanford.edu
-acli api:environments:domain-clear-caches <APP_UUID> <DESTINATION>-prod.stanford.edu
-acli api:environments:domain-clear-caches <APP_UUID> <SOURCE>-prod.stanford.edu
+# Using an environment ID:
+acli api:environments:domain-clear-caches <PROD_ENV_ID> <DESTINATION>.stanford.edu
+acli api:environments:domain-clear-caches <PROD_ENV_ID> <DESTINATION>-prod.stanford.edu
+acli api:environments:domain-clear-caches <PROD_ENV_ID> <SOURCE>-prod.stanford.edu
+
+# Using the humscigryphon.prod alias:
+acli api:environments:domain-clear-caches humscigryphon.prod <DESTINATION>.stanford.edu
+acli api:environments:domain-clear-caches humscigryphon.prod <DESTINATION>-prod.stanford.edu
+acli api:environments:domain-clear-caches humscigryphon.prod <SOURCE>-prod.stanford.edu
 ```
 
 > **Note:** You may also need to clear the Akamai CDN cache if the site does not update.
@@ -275,15 +283,20 @@ Check for an existing entry pointing the live URL to `<SOURCE>` (e.g., `$sites['
   $sites['<LIVEURL>.stanford.edu'] = '<DESTINATION>';
   ```
 
-Save the file, then rebuild caches and clear Varnish:
+Save the file, then rebuild caches and clear Varnish. You can target the environment by ID or by its `humscigryphon.prod` application alias:
 
 ```bash
 drush @<DESTINATION>.prod cr
 ```
 
 ```bash
-acli api:environments:domain-clear-caches <APP_UUID> <LIVEURL>.stanford.edu
-acli api:environments:domain-clear-caches <APP_UUID> <DESTINATION>-prod.stanford.edu
+# Using an environment ID:
+acli api:environments:domain-clear-caches <PROD_ENV_ID> <LIVEURL>.stanford.edu
+acli api:environments:domain-clear-caches <PROD_ENV_ID> <DESTINATION>-prod.stanford.edu
+
+# Using the humscigryphon.prod alias:
+acli api:environments:domain-clear-caches humscigryphon.prod <LIVEURL>.stanford.edu
+acli api:environments:domain-clear-caches humscigryphon.prod <DESTINATION>-prod.stanford.edu
 ```
 
 Open the live URL and verify the site loads from `<DESTINATION>`. Check the Status Report page at `/admin/reports/status` and confirm the Stanford Site Alias line shows `<DESTINATION>`, not `<SOURCE>`.

--- a/docs/CopySite.md
+++ b/docs/CopySite.md
@@ -44,8 +44,6 @@ If the provision was not done correctly or the URLs are not set up, correct thos
 
 Before starting, notify the H&S web team and/or site owner that there will be brief downtime and they should refrain from editing the site until the copy is complete. Any edits made to the site after the database is copied down locally will not be transferred.
 
-Check the `<DESTINATION>` site's `/admin/content` page to verify there are no recent edits that would be overwritten, and `/admin/users` to verify there are no active editors.
-
 ### Create Database Backups
 
 Create a database backup of both `<SOURCE>` and `<DESTINATION>`. The `<DESTINATION>` backup is especially important because its database and files are about to be dropped and overwritten by the copy.
@@ -110,7 +108,8 @@ mv /tmp/prod-<DESTINATION>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<DESTINATION
 Create a local directory:
 
 ```bash
-mkdir -p ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>
+mkdir -p ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>/files
+mkdir -p ~/site-backups/<DESTINATION>-prod-files-<YYYY-MM-DD>/files-private
 ```
 
 Download the files:
@@ -131,6 +130,8 @@ Upload the archive to Google Drive, then delete the local backup directory and a
 > **Warning:** Complete both the `<DESTINATION>` database and files backups before proceeding. The next steps will drop and overwrite the `<DESTINATION>` database and files. Confirm the backups are uploaded and readable before continuing.
 
 ### Copy the Source Database and Files Locally
+
+Check the `<SOURCE>` site's `/admin/content` page to verify there are no recent edits, and `/admin/users` to verify there are no active editors. Do this now rather than earlier, since the backup steps above can take a long time and an earlier check may be stale by this point. Any edits made to `<SOURCE>` after this point will not be transferred, since the database dump below captures a snapshot at this moment.
 
 Create a working directory in your local environment. Using a consistent parent directory is recommended.
 

--- a/docs/DeleteSite.md
+++ b/docs/DeleteSite.md
@@ -1,11 +1,12 @@
 # H&S Site Decommission and Deletion Guide
 
-This document outlines the workflow for decommissioning and deleting a site in the H&S application. It covers both decommissioning (removing a site from service but retaining data) and full deletion (removing all traces of a site from the platform and Acquia). Follow these steps to ensure a clean and secure process.
+This document outlines the workflow for decommissioning and deleting a site in the HSDP application. It covers both decommissioning (removing a site from service but retaining data) and full deletion (removing all traces of a site from the platform and Acquia). Follow these steps to ensure a clean and secure process.
 
 
 ## Overview
 
-This guide describes the process for decommissioning and deleting a site. It covers:
+This guide describes the process for backing up, decommissioning, and deleting a site. It covers:
+- Backing up a site's database and files
 - Decommissioning a site (removing it from service, but retaining data)
 - Deleting a site (removing all traces from the platform and Acquia)
 
@@ -14,17 +15,19 @@ Follow these steps to ensure a clean and secure process.
 
 ## Decommission vs. Deletion
 
-### Decommission a site (remove from service)
+### Decommission a Site (Remove from Service)
 
-- **Technical steps:** Remove NetDB pointers, remove domains, remove from multi-site, remove from WAF/CDN. Keep database and `docroot/sites/<site>` (site files).
+- **Technical steps:** Remove NetDB pointers, remove domains, remove from multi-site, remove from WAF/CDN. Keep database and `docroot/sites/<SITE>` (site files).
 - **Effects:** Site is inaccessible and no commands are run (no updates, cron, scripts, etc.). Database and files remain on Acquia and in the codebase.
 - **Pros/cons:** Easy to restore; continues to take up storage and may appear in codebase/UI.
 
-### Delete a site (remove in totality)
+### Delete a Site (Remove in Totality)
 
-- **Technical steps:** Decommission the site first, then delete the database and `docroot/sites/<site>` folder.
+- **Technical steps:** Back up the database and files, decommission the site, then delete the database and the `docroot/sites/<SITE>` folder.
 - **Effects:** Site is completely removed from codebase and Acquia.
 - **Pros/cons:** Frees up storage and cleans up codebase/UI; cannot restore unless backups are kept.
+
+> **Note:** Decommissioning without also deleting is rare. It's mainly useful when it isn't yet clear whether a site should be kept, and you want to take it offline while preserving the option to restore it. Most of the time, decommissioning and deletion happen together. When that's the case, perform the codebase changes for both in a single branch and pull request; see the note in [Remove Site Configuration from Codebase](#remove-site-configuration-from-codebase).
 
 > **Recommendation:** Start with decommissioning, then delete later. For sensitive or security-related removals, delete immediately and store backups securely.
 
@@ -34,6 +37,76 @@ Clarify with H&S whether the site should be decommissioned or deleted.
 ## Requirements
 
 See [Development Requirements](DevelopmentRequirements.md)
+
+
+## Back Up the Site
+
+> **Important:** Take these backups before decommissioning. Decommissioning removes the domains and Drush alias that `pull:database` and `drush rsync` depend on, so back up first while access is still live.
+
+### Back Up the Database
+
+Create and download the latest backup, either via ACLI or the Acquia Cloud UI.
+
+**With ACLI:**
+
+Create a backup, then download it without importing it anywhere. You can target the environment by ID or by its `humscigryphon.prod` application alias (the alias rarely changes and is easier to remember):
+
+```bash
+# Using an environment ID:
+acli api:environments:database-backup-create <PROD_ENV_ID> <SITE>
+acli pull:database --no-import <PROD_ENV_ID> <SITE>
+
+# Using the humscigryphon.prod alias:
+acli api:environments:database-backup-create humscigryphon.prod <SITE>
+acli pull:database --no-import humscigryphon.prod <SITE>
+```
+
+The command prints the downloaded file's path in the system temp directory when it finishes. Move it to your backup location and rename it to a clear, dated format:
+
+```bash
+mkdir -p ~/site-backups
+mv <FILEPATH> ~/site-backups/<SITE>-prod-db-<YYYY-MM-DD>.sql.gz
+```
+
+**With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
+
+1. Open the Acquia Cloud UI for the HumSci Gryphon application.
+1. Click on the production environment (Prod).
+1. Click on the Databases tab in the left-side navigation.
+1. Find the database for the site, click its three-dot button, then **Backup**.
+1. Once the backup completes, click the three-dot button again and **Download** it.
+1. Rename the downloaded backup to a clear, dated format such as `<SITE>-prod-db-<YYYY-MM-DD>.sql.gz`.
+
+> **Important:** Whichever method you used above, upload the renamed backup to a secure internal storage location as directed by your team before continuing. Refer to internal documentation for the correct location.
+
+### Back Up Site Files
+
+Replace `<SITE>` with the alias of the site you are backing up.
+
+#### Create a Local Directory
+
+```bash
+mkdir -p ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
+```
+
+#### Download Files via rsync
+
+```bash
+drush rsync @<SITE>.prod:%files/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files
+drush rsync @<SITE>.prod:%private/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files-private
+```
+
+#### Archive the Backup
+
+```bash
+tar -czvf ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>.tar.gz ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
+```
+
+#### Upload and Clean Up
+
+Upload the file backup to a secure internal storage location as directed by your team. Refer to internal documentation for the correct location.
+
+Delete local backups after uploading.
 
 
 ## Decommissioning Steps
@@ -56,6 +129,8 @@ Remove site alias from Lando and DDEV configuration:
 - Edit `lando/default.lando.yml`
 
 Remove any custom domain forwarding from `docroot/sites/sites.php` (if present).
+
+> **Note:** If deleting the site in full rather than only decommissioning, also remove the site directory (see [Remove the Site from the Codebase](#remove-the-site-from-the-codebase)) in this same branch, so both sets of changes ship in a single pull request.
 
 Create a new PR for these changes.
 
@@ -99,14 +174,14 @@ Remove relevant `-dev`, `-stage`, `-prod`, and live domains from the Akamai WAF/
 
 ## Deletion Steps
 
-> **Important:** Perform all decommissioning steps first, then follow these steps to delete the site entirely.
+> **Important:** Backups should already exist from the [Back Up the Site](#back-up-the-site) steps performed at decommissioning time, capturing the site's state before it became inaccessible. No new backup is required before deletion. If unsure whether a backup exists, check the secure storage location for one before proceeding.
 
 
 ### Remove the Site from the Codebase
 
-Create a new branch.
+If you already removed the site directory in the same branch as the [decommissioning codebase changes](#remove-site-configuration-from-codebase), skip this step.
 
-Remove the site directory:
+Otherwise, create a new branch and remove the site directory:
 
 ```bash
 rm -rf docroot/sites/<SITE>
@@ -114,93 +189,33 @@ rm -rf docroot/sites/<SITE>
 
 Create a new PR for these changes.
 
-### Remove the Database from Acquia
 
-Before deleting the database, create and download the latest backup, either via ACLI or the Acquia Cloud UI.
+### Delete the Database from Acquia
 
-**With ACLI:**
-
-Create a backup, then download it without importing it anywhere. You can target the environment by ID or by its `humscigryphon.prod` application alias (the alias rarely changes and is easier to remember):
-
-```bash
-# Using an environment ID:
-acli api:environments:database-backup-create <PROD_ENV_ID> <SITE>
-acli pull:database --no-import <PROD_ENV_ID> <SITE>
-
-# Using the humscigryphon.prod alias:
-acli api:environments:database-backup-create humscigryphon.prod <SITE>
-acli pull:database --no-import humscigryphon.prod <SITE>
-```
-
-The command prints the downloaded file's path in the system temp directory when it finishes. Move it to your backup location and rename it to a clear, dated format:
-
-```bash
-mkdir -p ~/site-backups
-mv /tmp/prod-<SITE>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<SITE>-prod-db-<YYYY-MM-DD>.sql.gz
-```
-
-**With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
-
-1. Open the Acquia Cloud UI for the HumSci Gryphon application.
-1. Click on the production environment (Prod).
-1. Click on the Databases tab in the left-side navigation.
-1. Find the database for the site, click its three-dot button, then **Backup**.
-1. Once the backup completes, click the three-dot button again and **Download** it.
-1. Rename the downloaded backup to a clear, dated format such as `<SITE>-prod-db-<YYYY-MM-DD>.sql.gz`.
-
-> **Important:** Whichever method you used above, upload the renamed backup to a secure internal storage location as directed by your team before continuing. Refer to internal documentation for the correct location.
-
-Once the backup is confirmed, delete the database:
+**With the Acquia Cloud UI:**
 
 1. Open the Acquia Cloud UI for the HumSci Gryphon application.
 1. Click on the production environment (Prod).
 1. Click on the Databases tab in the left-side navigation.
 1. Find the database for the site, click its three-dot button, then **Delete**.
 
-### Backup Site Files
-
-Replace `<SITE>` with the alias of the site you are backing up.
-
-#### Create a Local Directory
+**With ACLI:**
 
 ```bash
-mkdir -p ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
+# Using an application ID:
+acli api:applications:database-delete <APP_ID> <SITE>
+
+# Using the humscigryphon alias (the alias rarely changes and is easier to remember):
+acli api:applications:database-delete humscigryphon <SITE>
 ```
-
-#### Download Files via rsync
-
-If the site has already been decommissioned and the current branch no longer has the site Drush alias, check out an older commit or branch where the alias still exists, then run `drush rsync` from there.
-
-**With drush rsync from an older checkout if needed:**
-
-```bash
-git checkout <commit-or-branch-with-site-alias>
-drush rsync @<SITE>.prod:%files/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files
-drush rsync @<SITE>.prod:%private/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files-private
-```
-
-Return to your working branch after the backup is complete.
-
-
-#### Archive the Backup
-
-```bash
-tar -czvf ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>.tar.gz ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
-```
-
-#### Upload and Clean Up
-
-Upload the file backup to a secure internal storage location as directed by your team. Refer to internal documentation for the correct location.
-
-Delete local backups after uploading.
 
 ---
 
 ## Best Practices & Final Notes
 
 - Always confirm with H&S whether a site should be decommissioned or deleted.
-- Keep backups of both database and files before deletion.
-- Communicate with stakeholders before and after site removal.
+- Back up both the database and files before decommissioning. Decommissioning removes the access that backups depend on.
+- Communicate with the H&S web team before and after site removal.
 - Document any manual steps or exceptions for future reference.
 - For sensitive or security-related removals, prioritize deletion and secure backup storage.
 

--- a/docs/DeleteSite.md
+++ b/docs/DeleteSite.md
@@ -48,7 +48,7 @@ Update Drush multi-sites array:
 Remove the site Drush alias YAML:
 
 ```bash
-git rm drush/sites/SITENAME.site.yml
+git rm drush/sites/<SITENAME>.site.yml
 ```
 
 Remove site alias from Lando and DDEV configuration:
@@ -71,22 +71,24 @@ Remove `-dev`, `-stage`, `-prod`, and live domains from NetDB:
 
 Remove `-dev`, `-stage`, `-prod`, and live domains from Acquia environments:
 1. Open the Acquia Cloud UI for the HumSci Gryphon application.
-2. Click on the production environment (Prod).
-3. Click on the Domain Management tab in the left-side navigation.
-4. Find the relevant domains for the site.
-5. Click the three-dot button for the relevant domains and delete them.
-6. Repeat for staging (Stage) and development (Dev) environments.
+1. Click on the production environment (Prod).
+1. Click on the Domain Management tab in the left-side navigation.
+1. Find the relevant domains for the site.
+1. Click the three-dot button for the relevant domains and delete them.
+1. Repeat for staging (Stage) and development (Dev) environments.
 
-Alternatively, use ACLI if installed:
+Alternatively, use ACLI if installed. You can target each environment by ID or by its `humscigryphon.<env>` application alias (the alias rarely changes and is easier to remember):
 
 ```bash
-# Find the app-id in drush/drush.yml under command.sws.options.app-id.
-# Use that app-id to list environment IDs.
-acli api:applications:environment-list APP_ID
-# Remove domains
-acli api:environments:domain-delete PROD_ENV_ID SITE-prod.stanford.edu
-acli api:environments:domain-delete STAGE_ENV_ID SITE-stage.stanford.edu
-acli api:environments:domain-delete DEV_ENV_ID SITE-dev.stanford.edu
+# Using environment IDs:
+acli api:environments:domain-delete <PROD_ENV_ID> <SITE>-prod.stanford.edu
+acli api:environments:domain-delete <STAGE_ENV_ID> <SITE>-stage.stanford.edu
+acli api:environments:domain-delete <DEV_ENV_ID> <SITE>-dev.stanford.edu
+
+# Using aliases:
+acli api:environments:domain-delete humscigryphon.prod <SITE>-prod.stanford.edu
+acli api:environments:domain-delete humscigryphon.test <SITE>-stage.stanford.edu
+acli api:environments:domain-delete humscigryphon.dev <SITE>-dev.stanford.edu
 ```
 
 
@@ -107,30 +109,62 @@ Create a new branch.
 Remove the site directory:
 
 ```bash
-rm -rf docroot/sites/SITE
+rm -rf docroot/sites/<SITE>
 ```
 
 Create a new PR for these changes.
 
 ### Remove the Database from Acquia
 
+Before deleting the database, create and download the latest backup, either via ACLI or the Acquia Cloud UI.
+
+**With ACLI:**
+
+Create a backup, then download it without importing it anywhere. You can target the environment by ID or by its `humscigryphon.prod` application alias (the alias rarely changes and is easier to remember):
+
+```bash
+# Using an environment ID:
+acli api:environments:database-backup-create <PROD_ENV_ID> <SITE>
+acli pull:database --no-import <PROD_ENV_ID> <SITE>
+
+# Using the humscigryphon.prod alias:
+acli api:environments:database-backup-create humscigryphon.prod <SITE>
+acli pull:database --no-import humscigryphon.prod <SITE>
+```
+
+The command prints the downloaded file's path in the system temp directory when it finishes. Move it to your backup location and rename it to a clear, dated format:
+
+```bash
+mkdir -p ~/site-backups
+mv /tmp/prod-<SITE>-db<ID>-<TIMESTAMP>.sql.gz ~/site-backups/<SITE>-prod-db-<YYYY-MM-DD>.sql.gz
+```
+
+**With the Acquia Cloud UI** (use this if ACLI isn't installed or configured):
+
 1. Open the Acquia Cloud UI for the HumSci Gryphon application.
-2. Click on the production environment (Prod).
-3. Click on the Databases tab in the left-side navigation.
-4. Find the database for the site.
-5. **Download the latest database backup first.**
-   - Rename the backup to a clear, dated format such as `SITE-prod-db-YYYY-MM-DD.sql.gz`.
-   - Upload it to a secure internal storage location as directed by your team. Refer to internal documentation for the correct location.
-6. Delete the database.
+1. Click on the production environment (Prod).
+1. Click on the Databases tab in the left-side navigation.
+1. Find the database for the site, click its three-dot button, then **Backup**.
+1. Once the backup completes, click the three-dot button again and **Download** it.
+1. Rename the downloaded backup to a clear, dated format such as `<SITE>-prod-db-<YYYY-MM-DD>.sql.gz`.
+
+> **Important:** Whichever method you used above, upload the renamed backup to a secure internal storage location as directed by your team before continuing. Refer to internal documentation for the correct location.
+
+Once the backup is confirmed, delete the database:
+
+1. Open the Acquia Cloud UI for the HumSci Gryphon application.
+1. Click on the production environment (Prod).
+1. Click on the Databases tab in the left-side navigation.
+1. Find the database for the site, click its three-dot button, then **Delete**.
 
 ### Backup Site Files
 
-Replace `SITE` with the alias of the site you are backing up.
+Replace `<SITE>` with the alias of the site you are backing up.
 
 #### Create a Local Directory
 
 ```bash
-mkdir ~/site-backups/SITE-prod-files-YYYY-MM-DD
+mkdir -p ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
 ```
 
 #### Download Files via rsync
@@ -141,8 +175,8 @@ If the site has already been decommissioned and the current branch no longer has
 
 ```bash
 git checkout <commit-or-branch-with-site-alias>
-drush rsync @SITE.prod:%files/ ~/site-backups/SITE-prod-files-YYYY-MM-DD/files
-drush rsync @SITE.prod:%private/ ~/site-backups/SITE-prod-files-YYYY-MM-DD/files-private
+drush rsync @<SITE>.prod:%files/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files
+drush rsync @<SITE>.prod:%private/ ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>/files-private
 ```
 
 Return to your working branch after the backup is complete.
@@ -151,7 +185,7 @@ Return to your working branch after the backup is complete.
 #### Archive the Backup
 
 ```bash
-tar -czvf ~/site-backups/SITE-prod-files-YYYY-MM-DD.tar.gz ~/site-backups/SITE-prod-files-YYYY-MM-DD
+tar -czvf ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>.tar.gz ~/site-backups/<SITE>-prod-files-<YYYY-MM-DD>
 ```
 
 #### Upload and Clean Up

--- a/docs/DocumentationStandards.md
+++ b/docs/DocumentationStandards.md
@@ -6,6 +6,7 @@ This document defines the standards for creating and updating documentation in t
 
 - The primary audience for operational documentation is experienced Drupal developers on the H&S team
 - The primary operational stakeholders are the **H&S web team** — use this term when documentation refers to site owners, editors, or operational contacts (e.g., "Notify the H&S web team and/or site owner")
+- Use **HSDP** when referring to the codebase, application, or multi-site platform itself (e.g., "the HSDP application", "the HSDP codebase"). Do not use "the H&S application" or other variants. "H&S" (Humanities and Sciences) refers to the school and its team, not the software.
 - `DocumentationStandards.md` also serves as AI context for Claude Code in this repository — keep it accurate and up to date
 
 ## Language and Tone
@@ -15,7 +16,7 @@ This document defines the standards for creating and updating documentation in t
 - Use active voice
 - Use active voice especially in warnings — "Take a database backup before proceeding" not "Database backups are required"
 - Avoid filler words ("simply", "just", "easily", "very good", etc.)
-- Do not use em dashes (—). Rewrite the sentence to avoid them.
+- Do not use em dashes (—). Rewrite the sentence to avoid them. `DocumentationStandards.md` itself is exempt from this rule: it is primarily read and written by AI tooling to enforce these standards, and em dashes are fine here for density.
 - Avoid meta-notes written to the author (e.g., "update this before publishing") — those belong in PR descriptions or commit messages, not in committed docs
 
 ## Document Types
@@ -36,6 +37,7 @@ Documentation in this repo falls into two categories. Structure each accordingly
 - **No `$` prompt prefix in bash code blocks** — it prevents copying commands directly
 - Use `1.` for every item in a numbered list — Markdown auto-increments, so manual tracking is unnecessary and error-prone
 - No trailing commas in enumerations: `(foo, bar, etc.)` not `(foo, bar, etc.,)`
+- Headings use Title Case: capitalize each major word (e.g., "Remove Domains from NetDB", not "Remove domains from netdb")
 
 ## Callout Style
 
@@ -120,6 +122,19 @@ Acquia's internal name for the staging environment is "test". In all documentati
 - PHPStan binary: `vendor/bin/phpstan` (no `.phar` extension)
 - PHPCS binary: `vendor/bin/phpcs`
 - PHPCBF binary: `vendor/bin/phpcbf`
+
+## ACLI Command Placeholders
+
+- Use `<APP_ID>` for the Acquia application identifier and `<ENV_ID>` (or `<PROD_ENV_ID>`, `<STAGE_ENV_ID>`, `<DEV_ENV_ID>`) for environment identifiers.
+- Application and environment aliases (e.g., `humscigryphon`, `humscigryphon.prod`) rarely change. Pair the ID-placeholder version of an ACLI command with a second example using the real alias, and note that the alias rarely changes:
+  ```bash
+  # Using an environment ID:
+  acli api:environments:domain-delete <PROD_ENV_ID> <SITE>-prod.stanford.edu
+
+  # Using the humscigryphon.prod alias (the alias rarely changes and is easier to remember):
+  acli api:environments:domain-delete humscigryphon.prod <SITE>-prod.stanford.edu
+  ```
+- Do not add real-value examples for placeholders that identify a specific site or other data (e.g., `<SITE>`), especially in destructive commands (delete, drop, etc.). A developer could copy and run the example unmodified with damaging results.
 
 ## Architecture Decision Records (ADRs)
 


### PR DESCRIPTION
# Summary
Reworks `docs/DeleteSite.md` and `docs/CopySite.md` for correctness and consistency, and adds/updates several `docs/DocumentationStandards.md` rules surfaced during the review. Highlights:

- **`DeleteSite.md`:** Moved database and file backups ahead of decommissioning (decommissioning removes the domains and Drush alias that backups depend on, so backing up first avoids needing to check out an old commit just to run `drush rsync`). Added a note that decommission-only is rare and, when doing a full deletion, the codebase changes for decommissioning and deletion should ship in one branch/PR. Simplified the Deletion Steps to rely on the earlier backup instead of re-confirming it. Fixed placeholder syntax (`<SITE>`, `<SITENAME>`), numbered-list formatting, header verb consistency ("Back Up" vs "Backup"), and Title Case headings.
- **`CopySite.md`:** Replaced the unsupported `<APP_UUID>` / `sql-cli` guidance with working `<PROD_ENV_ID>` / alias-based ACLI commands and `sql:connect`. Added missing `<DESTINATION>` file backup steps before the destructive copy, moved the `<SOURCE>` staleness check to right before the copy (instead of before the long backup steps), fixed the mis-nested "Back Up DESTINATION Files" heading, and removed a duplicated cache-rebuild step.
- **`DocumentationStandards.md`:** Standardized on **HSDP** for the codebase/application/platform (replacing inconsistent "H&S application" references, also fixed in `BranchingStrategy.md` and `CodeDeploy.md`), added a Title Case heading rule, and added an ACLI Command Placeholder rule (`<APP_ID>` / `<ENV_ID>` conventions, pairing a placeholder example with a real-alias example, and never showing real values for destructive site-identifying placeholders like `<SITE>`). Also documented that `DocumentationStandards.md` itself is exempt from the no-em-dash rule, since it's primarily AI-consumed reference content.

## Backstory
While reviewing `DeleteSite.md` and `CopySite.md` for accuracy against `DocumentationStandards.md`, several structural and correctness issues surfaced: `CopySite.md` referenced a nonexistent `<APP_UUID>` placeholder and a `sql-cli` command instead of the correct `sql:connect`, and was missing a `<DESTINATION>` file backup step before an operation that drops and overwrites `<DESTINATION>` entirely. `DeleteSite.md` had backups sequenced after decommissioning, which cuts off the very access (domains, Drush alias) the backup commands need, forcing a workaround of checking out an old commit just to run `drush rsync`. Fixing these also surfaced inconsistent terminology for the codebase itself ("H&S application" in some docs vs. the existing "HSDP" glossary term in `README.md`), inconsistent heading casing, and inconsistent ACLI placeholder conventions, so those became new rules in `DocumentationStandards.md` to keep future documentation consistent.

## Need Review By (Date)
asap

## Urgency
low

## Steps to Test
1. Read through `docs/DeleteSite.md` top to bottom as if performing a site deletion for the first time; confirm the backup steps make sense before decommissioning, and that the "do this in one branch" guidance for combined decommission+delete is clear.
2. Read through `docs/CopySite.md` top to bottom; confirm the ACLI commands (`sql:connect`, `domain-clear-caches` with `<PROD_ENV_ID>`/alias) are valid and the `<DESTINATION>` backup steps appear before the database drop/overwrite step.
3. Confirm no remaining references to "H&S application" exist (`grep -rn "H&S application" docs/`).
4. Skim `docs/DocumentationStandards.md` new sections ("ACLI Command Placeholders", Title Case rule, HSDP naming rule) for clarity and correctness.
