### PR TITLE
SHS-6697: Make the Media Library take more space on smaller screens

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -309,3 +309,18 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 .tagify__dropdown__item--active {
   color: var(--gin-color-button-text);
 }
+
+/* Make Media Library Take more space on small screen sizes */
+@media (max-width: 767px) {
+  .ui-dialog {
+    .ui-dialog-title {
+      margin: 0;
+    }
+
+    .ui-dialog-content {
+      max-height: 500px !important;
+      height: 100% !important;
+    }
+  }
+}
+


### PR DESCRIPTION
# Summary
Media Library take more space on smaller screens

## Backstory
[SHS-6697](https://app.clickup.com/t/36718269/SHS-6697)

## Need Review By (Date)
07/21

## Urgency
low

## Steps to Test
1. Log into any tugboat environment ([Colorful](https://hs-colorful-sb1uspvksef1wbxu0kexwder9vfm4ing.tugboatqa.com/user/login), [Traditional](https://hs-traditional-sb1uspvksef1wbxu0kexwder9vfm4ing.tugboatqa.com/user/login)) - these changes don't depend on the frontend theme, so it should work the same for colorful and traditional sites.
2. Confirm that the Media Library modal has a better height and space on smaller screens when adding/editing a "Media" on any component

<img width="563" height="748" alt="Screenshot 2026-07-14 at 3 11 37 PM" src="https://github.com/user-attachments/assets/9302487b-bb49-47c7-8aaa-96c3ab985400" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215950535892633
  - https://app.asana.com/0/0/1216633744259758