### PR TITLE
HSD8-1966: Fix PHPStan errors introduced by dependency update

### DIFF
--- a/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/Plugin/migrate/process/TranslateCourseTag.php
+++ b/docroot/modules/humsci/hs_courses/modules/hs_courses_importer/src/Plugin/migrate/process/TranslateCourseTag.php
@@ -29,11 +29,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class TranslateCourseTag extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Entity Storage Service for hs_course_tag entity type.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $tagTranslation;
+  protected $entityTypeManager;
 
   /**
    * {@inheritdoc}
@@ -52,15 +52,16 @@ class TranslateCourseTag extends ProcessPluginBase implements ContainerFactoryPl
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->tagTranslation = $entity_type_manager->getStorage('hs_course_tag');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
    * {@inheritdoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $tag_storage = $this->entityTypeManager->getStorage('hs_course_tag');
     /** @var \Drupal\hs_courses_importer\Entity\CourseTagInterface $tag_entity */
-    foreach ($this->tagTranslation->loadMultiple() as $tag_entity) {
+    foreach ($tag_storage->loadMultiple() as $tag_entity) {
       if ($value == $tag_entity->label()) {
         return $tag_entity->tag();
       }

--- a/docroot/modules/humsci/hs_entities/src/HsEntityListBuilder.php
+++ b/docroot/modules/humsci/hs_entities/src/HsEntityListBuilder.php
@@ -5,8 +5,8 @@ namespace Drupal\hs_entities;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,13 +26,13 @@ class HsEntityListBuilder extends EntityListBuilder {
    *
    * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
    *   The entity type definition.
-   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
-   *   The entity storage class.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatterInterface $date_formatter) {
-    parent::__construct($entity_type, $storage);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter) {
+    parent::__construct($entity_type, $entity_type_manager->getStorage($entity_type->id()));
     $this->dateFormatter = $date_formatter;
   }
 
@@ -42,7 +42,7 @@ class HsEntityListBuilder extends EntityListBuilder {
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
     return new static(
       $entity_type,
-      $container->get('entity_type.manager')->getStorage($entity_type->id()),
+      $container->get('entity_type.manager'),
       $container->get('date.formatter')
     );
   }

--- a/docroot/modules/humsci/hs_role_description/src/Form/SettingsForm.php
+++ b/docroot/modules/humsci/hs_role_description/src/Form/SettingsForm.php
@@ -27,7 +27,7 @@ class SettingsForm extends ConfigFormBase {
    *
    * @var \Drupal\user\RoleInterface[]
    */
-  private array $roles = [];
+  protected array $roles = [];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# Summary
Fixes 3 PHPStan errors introduced by a PHPStan version bump in the automated dependency update PR (#2324), all related to Drupal's entity storage dependency-injection anti-patterns and one `DependencySerializationTrait` incompatibility.

## Backstory
The weekly automated dependency update ([Automated Dependency Updates 20260717 (#2324)](https://github.com/SU-HSDO/suhumsci/pull/2324)) pulled in a newer PHPStan/phpstan-drupal version, which surfaced 3 new static analysis errors that didn't previously exist. Caught via the [CI run](https://github.com/SU-HSDO/suhumsci/actions/runs/29609409679/job/87980278581). Rather than open a new ticket, these are being fixed under the existing automated updates ticket ([HSD8-1966](https://stanfordits.atlassian.net/browse/HSD8-1966)).

The three issues:
1. `hs_courses_importer/src/Plugin/migrate/process/TranslateCourseTag.php` — stored an entity storage handler as a class property instead of calling `getStorage()` at the point of use. Fixed by storing `EntityTypeManagerInterface` and calling `getStorage('hs_course_tag')` inside `transform()`.
2. `hs_entities/src/HsEntityListBuilder.php` — constructor directly injected `EntityStorageInterface $storage` instead of the entity type manager. Fixed by injecting `EntityTypeManagerInterface` and calling `getStorage()` in the constructor before passing the result to `parent::__construct()`.
3. `hs_role_description/src/Form/SettingsForm.php` — the `$roles` property was `private`, which `DependencySerializationTrait` doesn't support. Fixed by changing it to `protected`.

## Need Review By (Date)
No rush — whenever convenient.

## Urgency
low

## Steps to Test
1. Run `vendor/bin/phpstan analyse` and confirm it passes with no errors (previously reported 3 errors in the files listed above).
2. Spot check that behavior is unchanged: run a course tag migration that uses `translate_course_tag`, view the HumSci entities admin listing (`hs_entities`), and load/save the role description settings form (`/admin/people/role-description`) to confirm no regressions.


[HSD8-1966]: https://stanfordits.atlassian.net/browse/HSD8-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ