### PR TITLE
HSD8-1965: Remove media_duplicate_validation guard from UrlToMedia tamper plugin

### DIFF
--- a/docroot/modules/humsci/hs_migrate/src/Plugin/Tamper/UrlToMedia.php
+++ b/docroot/modules/humsci/hs_migrate/src/Plugin/Tamper/UrlToMedia.php
@@ -146,14 +146,6 @@ class UrlToMedia extends TamperBase implements ContainerFactoryPluginInterface {
    * @throws \Drupal\tamper\Exception\TamperException
    */
   public function tamper($data, ?TamperableItemInterface $item = NULL) {
-    // media_duplicate_validation fires on media insert and will block saves for
-    // any image it considers a duplicate, causing imports to fail.
-    if ($this->moduleHandler->moduleExists('media_duplicate_validation')) {
-      $message = 'UrlToMedia tamper plugin cannot run with media_duplicate_validation module enabled. Please disable the module before running migrations.';
-      $this->loggerFactory->get('hs_migrate')->error($message);
-      throw new TamperException($message);
-    }
-
     if (empty($data)) {
       return NULL;
     }


### PR DESCRIPTION
# Summary
Removes the `media_duplicate_validation` module-enabled guard from the `UrlToMedia` Tamper plugin (`docroot/modules/humsci/hs_migrate/src/Plugin/Tamper/UrlToMedia.php`). The plugin no longer throws a `TamperException` and refuses to run when `media_duplicate_validation` is enabled.

## Backstory
[HSD8-1822](https://stanfordits.atlassian.net/browse/HSD8-1822) added the `UrlToMedia` Tamper plugin. The plugin included a guard that refused to run whenever `media_duplicate_validation` was enabled.

Tracing through `media_duplicate_validation`'s code, there's no path where it blocks or throws on a media save, programmatic or otherwise. It only populates its own lookup tables on insert/update/delete, and its one duplicate-detection UI lives entirely in the interactive Media Library upload form, which Feeds/Tamper never touches. Media is also saved programmatically elsewhere on the platform with this module enabled by default without issue. The guard's premise doesn't hold, so it's removed here; see [HSD8-1965](https://stanfordits.atlassian.net/browse/HSD8-1965) for the full investigation.

## Steps to Test
1. On a site with `media_duplicate_validation` enabled (default on all HumSci sites), set up or use an existing Feeds importer with the `url_to_media` Tamper plugin applied to an image URL source field (see [PR #2025](https://github.com/SU-HSDO/suhumsci/pull/2025) for the original setup).
2. Run the import (e.g. the ethicsinsociety Events import from https://politicalscience.stanford.edu/export/poltheoryworkshop).
3. Verify the import completes successfully: images are downloaded, file entities are created, media entities are created and linked to the imported nodes.
4. Check `/admin/reports/dblog` for any errors during import — confirm `media_duplicate_validation` does not error or block any media saves.
5. Confirm `media_duplicate_validation` remains enabled throughout the test (no need to disable it).


[HSD8-1822]: https://stanfordits.atlassian.net/browse/HSD8-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSD8-1965]: https://stanfordits.atlassian.net/browse/HSD8-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ