### PR TITLE
SHS-6720: HOTFIX | Banner image(s) with partial overlay: subsequent images mispositioned

### DIFF
--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 12.3.1
+version: 12.3.2
 core_version_requirement: ^10.3 || ^11
 dependencies:
   - 'drupal:block'

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.gradient-hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.gradient-hero.scss
@@ -46,6 +46,10 @@
         }
       }
     }
+
+    .hb-media-image {
+      display: block;
+    }
   }
 
   &__text {

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.hero.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.hero.scss
@@ -27,6 +27,10 @@
     &::before {
       background-color: color('primary-hero-overlay');
     }
+
+    .hb-media-image {
+      display: block;
+    }
   }
 
   &__text {


### PR DESCRIPTION
# Summary
- Fix position and size of banner images in carousel

## Backstory
- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6720)
- 
## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Visit the following pages. For each, confirm that each image in a carousel looks as expected (fills it's container width, is correctly sized and positioned). Make sure to check all slides, not only the first one.
    - https://hs-colorful-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/
    - https://hs-colorful-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/components/hero-images-main-region/banner-images-partial-overlay-and-text
    - https://hs-colorful-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/components/hero-images-main-region/banner-images-text-box
    - https://hs-traditional-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/
    - https://hs-traditional-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/components/hero-images-full-width-region-and-main-region/banner-images-partial-overlay-and-text
    - https://hs-traditional-6vgcgyhzxwy1yoqumvrmwi5ufx0mvrs3.tugboatqa.com/components/hero-images-full-width-region-and-main-region/banner-images-text-box
