### PR TITLE
SHS-6717: Fix issue in Vertical Button Card when .hb-raised-card is used

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/utilities/_raised-cards.scss
@@ -12,7 +12,7 @@
   &--uniform-height .field-hs-collection-items .ptype-hs-postcard {
     display: flex;
 
-    & div:only-child:not(.hb-card__date-tile, .hb-pill) {
+    & div:only-child:not(.hb-card__date-tile, .hb-pill, .hb-vertical-button-card .hs-button) {
       width: 100%;
     }
   }


### PR DESCRIPTION
# Summary
Fix an issue in Vertical Button Card when the .hb-raised-card is being used. 

## Backstory
[SHS-6717](https://app.clickup.com/t/36718269/SHS-6717)

## Need Review By (Date)
08/04

## Urgency
high

## Steps to Test
1. Please go to the following pages on [Colorful](https://hs-colorful-8k3qasiczxksylg6psrnqtvopf5qyd6g.tugboatqa.com/resources/resource-guide-public/libraries-and-museums-buddhist-collections) and [Traditional](https://hs-traditional-8k3qasiczxksylg6psrnqtvopf5qyd6g.tugboatqa.com/resources/resource-guide-public/libraries-and-museums-buddhist-collections) that replicate the issue
2. Confirm the Vertical Button Cards are not broken at all
3. Now, please go to the list of Vertical Button Cards on [Colorful](https://hs-colorful-8k3qasiczxksylg6psrnqtvopf5qyd6g.tugboatqa.com/components/collections/collections-postcards/vertical-button-cards) and [Traditional](https://hs-traditional-8k3qasiczxksylg6psrnqtvopf5qyd6g.tugboatqa.com/components/collections-0/collections-postcards/vertical-button-cards) (with and without uniform height and raised cards)
4. Confirm nothing is broken there


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216765400325069
  - https://app.asana.com/0/0/1216927380506877