### PR TITLE
SHS-6715: Fix Horizontal Expandable Cards padding

### DIFF
--- a/docroot/modules/humsci/hs_layouts/patterns/horizontal-expandable-card/horizontal-expandable-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/horizontal-expandable-card/horizontal-expandable-card.html.twig
@@ -19,14 +19,14 @@
           {% endif %}
         </div>
       {% endif %}
-      {% if introduction|render|striptags|trim %}
+      {% if introduction|render|striptags('<img><iframe><picture><video>')|trim %}
         <div class="hb-horizontal-expandable-card__introduction">
           {{ introduction }}
         </div>
       {% endif %}
     </div>
 
-    {% if details %}
+    {% if details|render|striptags('<img><iframe><picture><video>')|trim %}
       <div class="hb-horizontal-expandable-card__toggle">
         <button class="hb-horizontal-expandable-card__toggle-button" aria-expanded="false" aria-controls="{{ details_id }}" type="button">
           <span class="visually-hidden">{{ 'Expand'|t }}</span>

--- a/docroot/modules/humsci/hs_layouts/patterns/horizontal-expandable-card/horizontal-expandable-card.html.twig
+++ b/docroot/modules/humsci/hs_layouts/patterns/horizontal-expandable-card/horizontal-expandable-card.html.twig
@@ -19,7 +19,7 @@
           {% endif %}
         </div>
       {% endif %}
-      {% if introduction %}
+      {% if introduction|render|striptags|trim %}
         <div class="hb-horizontal-expandable-card__introduction">
           {{ introduction }}
         </div>

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
@@ -11,7 +11,7 @@
 }
 
 .hb-horizontal-expandable-card__header {
-  padding: hb-calculate-rems(20px) hb-calculate-rems(20px) hb-calculate-rems(24px) hb-calculate-rems(20px);
+  padding: hb-calculate-rems(20px) hb-calculate-rems(20px) hb-calculate-rems(24px);
   justify-content: space-between;
   align-items: center;
   display: flex;

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
@@ -11,7 +11,7 @@
 }
 
 .hb-horizontal-expandable-card__header {
-  padding: hb-calculate-rems(20px) hb-calculate-rems(24px);
+  padding: hb-calculate-rems(20px) hb-calculate-rems(20px) hb-calculate-rems(24px) hb-calculate-rems(20px);
   justify-content: space-between;
   align-items: center;
   display: flex;
@@ -124,6 +124,11 @@
   display: flex;
   flex-direction: column;
   gap: hb-calculate-rems(16px);
-  padding: 0 hb-calculate-rems(30px) hb-calculate-rems(32px);
+  padding-inline: hb-calculate-rems(30px);
   overflow: hidden;
+  min-height: 0;
+
+  > :last-child {
+    margin-bottom: hb-calculate-rems(32px);
+  }
 }

--- a/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
+++ b/docroot/themes/humsci/humsci_basic/src/scss/partials/components/_pattern.horizontal-expandable-card.scss
@@ -30,7 +30,7 @@
   h6 {
     @include hb-heading-3;
 
-    margin: 0 0 hb-calculate-rems(10px);
+    margin: 0;
   }
 
   a {
@@ -57,9 +57,10 @@
     }
   }
 
-  &:has(+ .hb-horizontal-expandable-card__introduction) {
-    margin-bottom: hb-calculate-rems(10px);
-  }
+}
+
+.hb-horizontal-expandable-card__introduction {
+  margin-top: hb-calculate-rems(10px);
 }
 
 .hb-horizontal-expandable-card__toggle {


### PR DESCRIPTION
# Summary
Fix padding for Horizontal Expandable Cards

## Backstory
[SHS-6715](https://app.clickup.com/t/36718269/SHS-6715)

## Need Review By (Date)
08/04

## Urgency
low

## Steps to Test
1. Visit the following example pages on [Colorful](https://hs-colorful-fy3teoxcrgwoycsvwsgddjjbbefleozs.tugboatqa.com/views/news#:~:text=List%20configuration%20options-,List,-Open%20News%20configuration) and [Traditional](https://hs-traditional-fy3teoxcrgwoycsvwsgddjjbbefleozs.tugboatqa.com/views/news#:~:text=List%20configuration%20options-,List,-Open%20News%20configuration)
2. Confirm there's a list with horizontal expandable cards (If there isn't, please let me know to create the examples)
3. Confirm the paddings are as proposed in the [designs](https://www.figma.com/proto/7xoXRIQgSMGlUszWYFbI09/SHS-Library---Traditional?node-id=3564-719&t=9llkEDLQpKue4CuA-0&scaling=min-zoom&content-scaling=fixed&page-id=3451%3A1878&hide-ui=1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216921687338062