### PR TITLE
SHS-6718: Disable editora11y on admin pages

### DIFF
--- a/config/default/editoria11y.settings.yml
+++ b/config/default/editoria11y.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: 1reSE9XKD6Hu5mLg0A3WHgvh_z0e3LMq6SDGafyVLDc
 content_root: ''
 assertiveness: smart
-no_load: body.page-user
+no_load: ''
 ignore_all_if_absent: ''
 ignore_elements: '.hb-secondary-nav, .block--local-tasks, .addtocal-link a'
 panel_no_cover: ''

--- a/config/default/editoria11y.settings.yml
+++ b/config/default/editoria11y.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: 1reSE9XKD6Hu5mLg0A3WHgvh_z0e3LMq6SDGafyVLDc
 content_root: ''
 assertiveness: smart
-no_load: ''
+no_load: body.page-user
 ignore_all_if_absent: ''
 ignore_elements: '.hb-secondary-nav, .block--local-tasks, .addtocal-link a'
 panel_no_cover: ''
@@ -22,7 +22,7 @@ disable_sync: false
 preserve_params: 'search,keys,page,language,language_content_entity'
 redundant_prefix: ''
 custom_tests: 0
-disable_live: false
+disable_live: true
 live_h_inherit: ''
 live_h2: 'form[id^="node-"] #edit-body-wrapper .ck-content'
 live_h3: ''

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -89,12 +89,6 @@ function humsci_basic_preprocess_html(&$vars) {
 
   $route_match = \Drupal::routeMatch();
 
-  // Add custom class when User page.
-  $route_name = $route_match->getRouteName();
-  if ($route_name == 'entity.user.canonical') {
-    $vars['attributes']['class'][] = 'page-user';
-  }
-
   $node = $route_match->getParameter('node');
 
   // Add body classes for full-width / main-region spacing gap detection.

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -89,6 +89,12 @@ function humsci_basic_preprocess_html(&$vars) {
 
   $route_match = \Drupal::routeMatch();
 
+  $route_name = $route_match->getRouteName();
+  if ($route_name == 'entity.user.canonical') {
+    // Add custom class when User page
+    $vars['attributes']['class'][] = 'page-user';
+  }
+
   $node = $route_match->getParameter('node');
 
   // Add body classes for full-width / main-region spacing gap detection.

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -89,9 +89,9 @@ function humsci_basic_preprocess_html(&$vars) {
 
   $route_match = \Drupal::routeMatch();
 
+  // Add custom class when User page.
   $route_name = $route_match->getRouteName();
   if ($route_name == 'entity.user.canonical') {
-    // Add custom class when User page
     $vars['attributes']['class'][] = 'page-user';
   }
 


### PR DESCRIPTION
# Summary
Disable editoria11y on admin pages

## Backstory
[SHS-6718](https://app.clickup.com/t/36718269/SHS-6718)

## Need Review By (Date)
08/04

## Urgency
medium

## Steps to Test
1. Log into any tugboat environment ([Colorful](https://hs-colorful-8fejutohuoygzgkpznbxngtc7iobsdzr.tugboatqa.com/user/login), [Traditional](https://hs-traditional-8fejutohuoygzgkpznbxngtc7iobsdzr.tugboatqa.com/user/login)) 
3. Visit some admin pages (add/edit any content type, paragraphs, views, etc...) and the user page
4. Editoria11y shouldn't be available in any of those pages
5. Visit other normal pages and confirm editoria11y works as expected

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216764032417677