### PR TITLE
SHS-6697: Prevent modal collapse on short viewports

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -311,11 +311,11 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 }
 
 /* Make Media Library Take more space on small screen sizes */
-@media (max-height: 700px) and (orientation: landscape) {
+@media (max-width: 767px), (max-height: 700px) and (orientation: landscape) {
   .ui-dialog.media-library-widget-modal {
     display: flex;
     flex-direction: column;
-    max-height: 90%;
+    max-height: 90dvh;
     top: 5% !important;
 
     .ui-dialog-titlebar,

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -311,15 +311,21 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
 }
 
 /* Make Media Library Take more space on small screen sizes */
-@media (max-width: 767px) {
-  .ui-dialog {
-    .ui-dialog-title {
-      margin: 0;
+@media (max-height: 700px) and (orientation: landscape) {
+  .ui-dialog.media-library-widget-modal {
+    display: flex;
+    flex-direction: column;
+    max-height: 90%;
+    top: 5% !important;
+
+    .ui-dialog-titlebar,
+    .ui-dialog-buttonpane {
+      flex: 0 0 auto;
     }
 
     .ui-dialog-content {
-      max-height: 500px !important;
-      height: 100% !important;
+      flex: 1 1 auto;
+      height: auto !important;
     }
   }
 }


### PR DESCRIPTION
# Summary
Media Library take more space on smaller screens

## Backstory
[SHS-6697](https://app.clickup.com/t/36718269/SHS-6697)

## Need Review By (Date)
08/04

## Urgency
low

## Notes
Checked the issue queues list for existing reports of dialog height collapsing on short viewports. Nothing filed that matches. Fixing in-theme; revisit if an upstream issue appears.

## Steps to Test
1. Log into any tugboat environment ([Colorful](https://hs-colorful-mofbtyxvsscccdrxv10i8tbintslkm2x.tugboatqa.com/user/login), [Traditional](https://hs-traditional-mofbtyxvsscccdrxv10i8tbintslkm2x.tugboatqa.com/user/login)) - these changes don't depend on the frontend theme, so it should work the same for colorful and traditional sites.
2. Confirm that the Media Library modal fits really well on smaller screens when adding/editing a "Media" on any component. (Try it on screen sizes that have a small height ~533px)

<img width="1265" height="721" alt="Screenshot 2026-07-30 at 3 00 42 PM" src="https://github.com/user-attachments/assets/3fb52f00-931b-4593-8b3f-0cae6c823b44" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217158342724333
  - https://app.asana.com/0/0/1215950535892633
  - https://app.asana.com/0/0/1216633744259758