### PR TITLE
HSD8-1977: Fix fatal error breaking revision compare view (address module diff plugin patch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -234,6 +234,9 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
+           "drupal/address": {
+                "https://www.drupal.org/project/address/issues/3460590": "patches/contrib/address-3460590-2-20260731.patch"
+            },
             "drupal/block_class": {
                 "Click JavaScript to close details causes modals to scroll unnecessarily https://www.drupal.org/project/block_class/issues/3497768": "patches/contrib/block_class/60.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8cb6d70b0d70ec6fe46d34cae81fb81",
+    "content-hash": "fb186c30f04986932b1eef1205c0623f",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -27029,5 +27029,5 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 12.4.0
+version: 12.4.1
 core_version_requirement: ^10.3 || ^11
 dependencies:
   - 'drupal:block'

--- a/patches/contrib/address-3460590-2-20260731.patch
+++ b/patches/contrib/address-3460590-2-20260731.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Plugin/diff/Field/AddressFieldBuilder.php b/src/Plugin/diff/Field/AddressFieldBuilder.php
+index eb70567..411247d 100644
+--- a/src/Plugin/diff/Field/AddressFieldBuilder.php
++++ b/src/Plugin/diff/Field/AddressFieldBuilder.php
+@@ -21,7 +21,7 @@ class AddressFieldBuilder extends CoreFieldBuilder {
+   /**
+    * {@inheritdoc}
+    */
+-  public function build(FieldItemListInterface $field_items) {
++  public function build(FieldItemListInterface $field_items): array {
+     $result = [];
+ 
+     foreach ($field_items as $field_key => $field_item) {


### PR DESCRIPTION
# Summary
Hotfix: patch the `drupal/address` module so its Diff plugin's `build()` method return type matches the `diff` module's updated interface, fixing a fatal error that broke the revision "compare" view in production.

## Backstory
The `diff` module was upgraded from 1.x to 2.x as part of the D11.3 upgrade (12.4.0). That release changed `CoreFieldBuilder::build()` to declare an `: array` return type. The `drupal/address` module's `AddressFieldBuilder::build()` (a `diff` field plugin) doesn't declare a matching return type, so any revision comparison touching a field on a content type with an address field throws a fatal "Declaration ... must be compatible" error, surfacing to editors as a 500/502 on `/node/{id}/revisions/view/{a}/{b}/split_fields`.

Confirmed via streaming logs and local reproduction (`suhumsci-music.test`) that this started with the 12.4.0 release (7/29) and is fixed by applying the upstream patch from [drupal.org/project/address/issues/3460590](https://www.drupal.org/project/address/issues/3460590), which adds the missing `: array` return type. Verified locally that revision comparisons work again for multiple content types after applying the patch.

Ticket: [HSD8-1977](https://stanfordits.atlassian.net/browse/HSD8-1977): D11.3 upgrade caused broken "compare revisions"

## Need Review By (Date)
ASAP — hotfix

## Urgency
high

## Steps to Test
1. On an environment with the patch applied (`composer install`), find a node with a revision history where at least one revision touches an address field.
2. Visit `/node/{nid}/revisions` and click "Compare" between two revisions (or navigate directly to `/node/{nid}/revisions/view/{vid1}/{vid2}/split_fields`).
3. Confirm the revision comparison page loads successfully instead of returning a 500/502 error.
4. Spot-check revision comparisons on a couple of other content types/nodes to confirm no regressions.


[HSD8-1977]: https://stanfordits.atlassian.net/browse/HSD8-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ