### PR TITLE
SHS-6727: Fix regression with user experience of imported fields

### DIFF
--- a/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
+++ b/docroot/modules/humsci/hs_field_helpers/hs_field_helpers.module
@@ -814,12 +814,12 @@ function _hs_field_helpers_get_imported_fields(NodeInterface $node) : array {
     // fields that are mapped from migration as disabled.
     $field_definition = $field_definitions[$field_name];
     $columns = $field_definition->getFieldStorageDefinition()->getColumns();
-    $processing = !empty($migration->process[$field_name]) || !empty($migration->process["$field_name/0"]);
+    $processing = !empty($migration->getProcess()[$field_name]) || !empty($migration->getProcess()["$field_name/0"]);
 
     // This will check if a migrate process is mapped to a specific column on
     // the field.
     foreach (array_keys($columns) as $column) {
-      $processing = $processing ?: !empty($migration->process["$field_name/$column"]) || !empty($migration->process["$field_name/0/$column"]);
+      $processing = $processing ?: !empty($migration->getProcess()["$field_name/$column"]) || !empty($migration->getProcess()["$field_name/0/$column"]);
     }
 
     // If the migration destination has the `overwrite_properties` configured,


### PR DESCRIPTION
# Summary
Replaces the direct `$migration->process` property reads in `_hs_field_helpers_get_imported_fields()` with calls to the migration plugin's public `getProcess()` method, restoring the "lock imported fields on the node edit form" behavior.

## Backstory
- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6727)

## Need Review By (Date)
TBD

## Urgency
High

## Steps to Test

1. Sign in to the site. ([Colorful](https://hs-colorful-0cutm5q1mlgbikm2qdpyi74hd8pct6so.tugboatqa.com/user/login), [Traditional](https://hs-traditional-0cutm5q1mlgbikm2qdpyi74hd8pct6so.tugboatqa.com/user/login))
2. Go to the following node page form ([Colorful](https://hs-colorful-0cutm5q1mlgbikm2qdpyi74hd8pct6so.tugboatqa.com/node/12516/edit), [Traditional](https://hs-traditional-0cutm5q1mlgbikm2qdpyi74hd8pct6so.tugboatqa.com/node/12516/edit)).
3. Verify that the imported fields are displayed as disabled.
4. Compare the behavior with the approved [Figma design](https://www.figma.com/proto/hOtD5MStjFIavUrWapHKHN/UX-Design-Tickets-Work?node-id=7195-23&t=qRvuYtLkBtEEGI1J-0&scaling=min-zoom&content-scaling=fixed&page-id=7147%3A2062&hide-ui=1).
5. Confirm the regression is resolved.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217006158242457
  - https://app.asana.com/0/0/1217239729873112