### PR TITLE
SHS-6725: Fix collections content no longer showing in Paragraph preview

### DIFF
--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.info.yml
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.info.yml
@@ -6,3 +6,4 @@ version: 8.2.7
 package: 'Humanities & Sciences'
 dependencies:
   - paragraphs
+  - 'drupal:views'

--- a/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
+++ b/docroot/modules/humsci/hs_paragraph_types/hs_paragraph_types.module
@@ -10,6 +10,67 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\views\Views;
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Determines whether a collection has anything worth rendering, so that an
+ * empty collection doesn't output a stray background/color band.
+ *
+ * This lives in the module rather than in humsci_basic so that it also runs
+ * under the admin theme. Theme preprocess functions only run for the active
+ * theme and its base themes, and su_humsci_gin_admin is based on gin, not on
+ * humsci_basic. Without this, `has_content` was undefined in the paragraphs
+ * widget preview and every collection rendered empty.
+ */
+function hs_paragraph_types_preprocess_paragraph__hs_collection(&$variables) {
+  /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+  $paragraph = $variables['paragraph'];
+  $variables['has_content'] = FALSE;
+
+  // Store referenced entities in a variable and only load once since both loops
+  // use it.
+  $items = $paragraph->get('field_hs_collection_items')->referencedEntities();
+
+  // Check if any of the referenced entities are not hs_view paragraphs and skip
+  // more expensive Views checks if so.
+  $views = [];
+  foreach ($items as $entity) {
+    if ($entity->bundle() !== 'hs_view') {
+      $variables['has_content'] = TRUE;
+      return;
+    }
+    $views[] = $entity;
+  }
+
+  foreach ($views as $entity) {
+    $view_field = $entity->get('field_hs_view')->first();
+
+    if (!$view_field) {
+      continue;
+    }
+    // Load the view and check access.
+    $view = Views::getView($view_field->target_id);
+    if (!$view || !$view->access($view_field->display_id)) {
+      continue;
+    }
+    // Check for a view title and an empty results text or handler.
+    $view->setDisplay($view_field->display_id);
+    $has_empty_handlers = !empty($view->display_handler->getHandlers('empty'));
+    if ($view_field->show_title || $has_empty_handlers) {
+      $variables['has_content'] = TRUE;
+      return;
+    }
+    // Execute the view to check for results.
+    $view->preExecute();
+    $view->execute();
+    if (!empty($view->result)) {
+      $variables['has_content'] = TRUE;
+      return;
+    }
+  }
+}
 
 /**
  * Implements hook_preprocess_HOOK().

--- a/docroot/themes/humsci/humsci_basic/humsci_basic.theme
+++ b/docroot/themes/humsci/humsci_basic/humsci_basic.theme
@@ -12,7 +12,6 @@ use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
-use Drupal\views\Views;
 
 /**
  * Implements hook_preprocess().
@@ -745,54 +744,4 @@ function humsci_basic_preprocess_field(&$variables) {
  */
 function humsci_basic_preprocess_node__hs_event(&$variables) {
   $variables['#attached']['library'][] = 'humsci_basic/addtocal';
-}
-
-/**
- * Implements hook_preprocess_ENTITY__BUNDLE().
- */
-function humsci_basic_preprocess_paragraph__hs_collection(&$variables) {
-  $paragraph = $variables['paragraph'];
-  $variables['has_content'] = FALSE;
-
-  // Store referenced entities in a variable and only load once since both loops
-  // use it.
-  $items = $paragraph->field_hs_collection_items->referencedEntities();
-
-  // Check if any of the referenced entities are not hs_view paragraphs and skip
-  // more expensive Views checks if so.
-  $views = [];
-  foreach ($items as $entity) {
-    if ($entity->bundle() !== 'hs_view') {
-      $variables['has_content'] = TRUE;
-      return;
-    }
-    $views[] = $entity;
-  }
-
-  foreach ($views as $entity) {
-    $view_field = $entity->field_hs_view->first();
-
-    if (!$view_field) {
-      continue;
-    }
-    // Load the view and check access.
-    $view = Views::getView($view_field->target_id);
-    if (!$view || !$view->access($view_field->display_id)) {
-      continue;
-    }
-    // Check for a view title and an empty results text or handler.
-    $view->setDisplay($view_field->display_id);
-    $has_empty_handlers = !empty($view->display_handler->getHandlers('empty'));
-    if ($view_field->show_title || $has_empty_handlers) {
-      $variables['has_content'] = TRUE;
-      return;
-    }
-    // Execute the view to check for results.
-    $view->preExecute();
-    $view->execute();
-    if (!empty($view->result)) {
-      $variables['has_content'] = TRUE;
-      return;
-    }
-  }
 }


### PR DESCRIPTION
# Summary
Collections were showing up as an empty row in the paragraph preview on node edit forms. This moves the `has_content` check from `humsci_basic.theme` into `hs_paragraph_types.module` so it runs in the admin theme too. Nothing changes on the front end.

## Backstory
* [SHS-6725](https://app.clickup.com/t/36718269/SHS-6725)

## Need Review By (Date)
_[TBD]_

## Urgency
medium

## Steps to Test

- Edit a Basic Page with a Collection on it ([Colorfull](https://hs-colorful-a2kvarodmihpmiv1nlixamkmzhjur75v.tugboatqa.com/node/17951/edit) - [Traditional](https://hs-traditional-a2kvarodmihpmiv1nlixamkmzhjur75v.tugboatqa.com/node/17961/edit)). Collapsed in the widget, you should now see its actual content instead of just the "Collection" label.
- Look at the page on the front end, it should look exactly like it did before this branch.
- Keep an eye on dblog for new PHP errors while the edit form loads.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216998363524191
  - https://app.asana.com/0/0/1217374266713147