### PR TITLE
SHS-6726: Add patch to fix floating smartdate duration selector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -306,6 +306,9 @@
                 "https://www.drupal.org/project/shield/issues/3479117": "patches/shield-undefined_array_key_explode-3479117.patch",
                 "https://www.drupal.org/project/shield/issues/3277210: Shield middleware invokes hooks before modules are loaded, corrupting module_implements cache": "patches/contrib/shield-3277210-mr-5-20260521.patch"
             },
+            "drupal/smart_date": {
+                "New durations overlay not next to date field in Classic widget https://www.drupal.org/project/smart_date/issues/3485112": "patches/contrib/smart_date-3485112-mr-203.patch"
+            },
             "drupal/ui_patterns": {
                 "Ui Patterns Views Preview": "patches/contrib/ui_patterns_views-preview.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7211a31481cc51ea9b3c69705db85dd9",
+    "content-hash": "8bf83ec4a860d79d2bb7acac1ed720b9",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -330,3 +330,13 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
   }
 }
 
+/* Fix a position issue with the smart date duration list */
+.smartdate--widget div.time-end {
+  position: relative;
+}
+
+.smartdate--widget ul.smart-date--duration-list {
+  left: unset;
+  bottom: -6px;
+}
+

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -329,14 +329,3 @@ form[data-has-imported-fields] .ck.ck-editor__main>.ck-read-only {
     }
   }
 }
-
-/* Fix a position issue with the smart date duration list */
-.smartdate--widget div.time-end {
-  position: relative;
-}
-
-.smartdate--widget ul.smart-date--duration-list {
-  left: unset;
-  bottom: -6px;
-}
-

--- a/patches/contrib/smart_date-3485112-mr-203.patch
+++ b/patches/contrib/smart_date-3485112-mr-203.patch
@@ -1,0 +1,16 @@
+diff --git a/css/smart_date.css b/css/smart_date.css
+index 8afe3f12eaf8a0c7edfc4434a489c369d86be02a..3b6408d15e74dcd6a9008b5e2845e71c762e7cd2 100644
+--- a/css/smart_date.css
++++ b/css/smart_date.css
+@@ -180,6 +180,11 @@ tr.even .smartdate--widget .form-type--select label {
+   position: relative;
+ }
+ 
++/* Fix for durations overlay on Classic widget. */
++.smartdate--widget .time-end div.form-item:nth-child(2) {
++  position: relative;
++}
++
+ /* Styling for duration list overlay. */
+ /* stylelint-disable order/properties-order */
+ :root {


### PR DESCRIPTION
# Summary
Adds a couple of CSS rules to the admin theme so the Smart Date duration dropdown shows up under the End time field instead of in the bottom left corner of the page. Admin CSS only — nothing changes on the front end.

## Backstory
[SHS-6726](https://app.clickup.com/t/36718269/SHS-6726)

Need Review By (Date)
[TBD]

Urgency
medium

Steps to Test

- Go to `/node/add/hs_event` ([Colorful](https://hs-colorful-dqd5xbtg9s8oooajmhnmqp6u7ssakhqy.tugboatqa.com/node/add/hs_event) - [Traditional](https://hs-traditional-dqd5xbtg9s8oooajmhnmqp6u7ssakhqy.tugboatqa.com/node/add/hs_event)) and fill in a Start date and time.
- Click the End time field. The duration list should appear flush under it, not floating off in a corner.
- With the list still open, scroll up and down. It should stay stuck to the field.
- Pick one of the options (e.g. "1 hour"). The End time should update and the list should close.
- Load a front-end page and confirm nothing shifted. This is admin CSS, so nothing should.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217052691622592