### PR TITLE
HSD8-1984: Change views always_live_preview to false

### DIFF
--- a/config/default/views.settings.yml
+++ b/config/default/views.settings.yml
@@ -12,7 +12,7 @@ ui:
       enabled: true
       where: above
     display_embed: true
-  always_live_preview: true
+  always_live_preview: false
   exposed_filter_any_label: old_any
 field_rewrite_elements:
   div: DIV


### PR DESCRIPTION
# Summary
See: https://stanfordits.atlassian.net/browse/HSD8-1984

The auto preview on the view settings page can sometimes be a performance hindrance. Change the default to "disabled" in Views instead of "enabled."