### PR TITLE
HSD8-1967: Patch Drupal core to fix error deleting users with content reassigned to Anonymous

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -256,7 +256,8 @@
                 "https://www.drupal.org/project/drupal/issues/3202896: Do not display oEmbed resource error to anonymous users": "patches/core/core-3202896-mr-9357-20250410.patch",
                 "Fix oEmbed video thumbnail resolution https://www.drupal.org/project/drupal/issues/3447326": "patches/core/core-3447326-mr-9518-20251104.patch",
                 "Adds bulk operations action to media library that allows site admin to generate new thumbnails https://www.drupal.org/project/drupal/issues/2983456": "patches/core/core-2983456-185-20260713.patch",
-                "Exposed filters get values from url when ajax is on https://www.drupal.org/project/drupal/issues/3121172": "patches/core/core-3121172-56-20260730.patch"
+                "Exposed filters get values from url when ajax is on https://www.drupal.org/project/drupal/issues/3121172": "patches/core/core-3121172-56-20260730.patch",
+                "Prevent error when deleting users and re-assigning content https://www.drupal.org/project/drupal/issues/3576940": "patches/core/core-3576940-mr-16482-20260811.patch"
             },
             "drupal/entity_reference_exposed_filters": {
                 "https://www.drupal.org/project/entity_reference_exposed_filters/issues/3189025": "https://www.drupal.org/files/issues/2023-10-17/entity_reference_exposed_filters-empty_target-3189025-4.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bf83ec4a860d79d2bb7acac1ed720b9",
+    "content-hash": "638d85237af75b95f44d11fd21094f26",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/patches/core/core-3576940-mr-16482-20260811.patch
+++ b/patches/core/core-3576940-mr-16482-20260811.patch
@@ -1,0 +1,15 @@
+diff --git a/core/modules/node/src/NodeBulkUpdate.php b/core/modules/node/src/NodeBulkUpdate.php
+index 16461aae2ff9d92ff97055062527b960c8fd6534..e4af78d777ccd8ed56aa821c8c833e39ea04af1b 100644
+--- a/core/modules/node/src/NodeBulkUpdate.php
++++ b/core/modules/node/src/NodeBulkUpdate.php
+@@ -90,7 +90,9 @@ protected static function processNode(NodeInterface $node, array $updates, strin
+     $langcodes = isset($langcode) ? [$langcode] : array_keys($node->getTranslationLanguages());
+     // For efficiency manually save the original node before applying any
+     // changes.
+-    $node->setOriginal(clone $node);
++    if (!$node->isNew() && !$node->getOriginal() && !$node->wasDefaultRevision()) {
++      $node->setOriginal(clone $node);
++    }
+     foreach ($langcodes as $langcode) {
+       foreach ($updates as $name => $value) {
+         $node->getTranslation($langcode)->$name = $value;


### PR DESCRIPTION
# Summary

Applies a Drupal core patch ([drupal.org #3576940](https://www.drupal.org/project/drupal/issues/3576940), [MR 16482](https://git.drupalcode.org/project/drupal/-/merge_requests/16482)) that fixes an `EntityStorageException` ("An existing default revision of the 'node' entity type can not be changed to a non-default revision") thrown when canceling/deleting a user account using the "Delete the account and make its content belong to the Anonymous user" method. The patch changes `NodeBulkUpdate::processNode()` to only clone the original node onto itself when the node isn't new, has no original set yet, and wasn't previously the default revision, avoiding the bad re-save of stale historical revisions.

## Backstory

[HSD8-1967](https://stanfordits.atlassian.net/browse/HSD8-1967): several sites (music.stanford.edu, publicpolicy.stanford.edu, hs_sandbox_1) were hitting a "Temp Unavailable" error/500 when deleting specific user accounts on Production, and the same error was preventing the automated user-purge cron policy from cleaning up some accounts.

Investigation traced the error to core's user-cancel "reassign to Anonymous" flow (`NodeUserHooks::userCancelReassign()`), which queries `->allRevisions()` for every revision ever authored by the canceled user and re-saves each one via `NodeBulkUpdate::process()`. On sites without Content Moderation, `revision_default` is never cleared back to `FALSE` on old revisions (this is expected core behavior, not corruption. Every revision is saved as `revision_default = 1` and never retroactively updated). When a user has authored more than one revision of the *same* node, the bulk-update loop loads and re-saves a stale, non-current revision that still carries `revision_default = 1`, tripping the core save-guard in `ContentEntityStorageBase` and throwing the exception. This is a long-standing Drupal core bug, not something in our custom code.

An existing, more invasive patch for the same core issue (bypassing the Entity API with raw SQL) was found first but not adopted. It was unreviewed/stalled and changed too much behavior (skips hooks/cache invalidation) for the size of the problem. I created MR 16482 which is a smaller, more targeted fix to the same root cause. It adds the same guards to loading onto the original property that the `preSave()` method uses.

## Urgency
medium

## Steps to Test
1. Find or create a user who has authored more than one revision of the same node (`drush sqlq "SELECT nid, vid FROM node_revision WHERE revision_uid = <uid>;"`. Look for a repeated `nid`).
2. Before applying the patch, cancel that user's account via `/user/<uid>/cancel` using the "Delete the account and make its content belong to the Anonymous user. This action cannot be undone." method. Confirm it fails with an `EntityStorageException` / 500 error, and that a corresponding dblog entry is created (`An existing default revision of the 'node' entity type can not be changed to a non-default revision.`).
3. Apply this patch (`composer install`) and repeat step 2. Confirm the account cancellation now succeeds ("Account [name] has been deleted.") and the node's content is reassigned to the Anonymous user with no error.
4. Confirm the user-purge cron policy (`/admin/config/people/purge-users`) no longer errors out on affected accounts.


[HSD8-1967]: https://stanfordits.atlassian.net/browse/HSD8-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216559778964597