### PR TITLE
SHS-6570: Vimeo Livestream Event URLs no longer working for Video media embeds

### DIFF
--- a/docroot/themes/humsci/humsci_basic/src/js/shared/media/lazy-load-video.js
+++ b/docroot/themes/humsci/humsci_basic/src/js/shared/media/lazy-load-video.js
@@ -16,6 +16,7 @@
           let videoId = '';
           let provider = '';
           let isPlaylist = false;
+          let isEvent = false;
 
           // --- Determine provider and video ID ---
           if (videoUrl.includes('youtube.com') || videoUrl.includes('youtu.be')) {
@@ -32,8 +33,15 @@
             }
           } else if (videoUrl.includes('vimeo.com')) {
             provider = 'vimeo';
-            const idMatch = videoUrl.match(/vimeo\.com\/(\d+)/);
-            videoId = idMatch ? idMatch[1] : '';
+            if (videoUrl.includes('/event/')) {
+              // Livestream event, e.g. https://vimeo.com/event/5426148
+              isEvent = true;
+              const idMatch = videoUrl.match(/vimeo\.com\/event\/(\d+)/);
+              videoId = idMatch ? idMatch[1] : '';
+            } else {
+              const idMatch = videoUrl.match(/vimeo\.com\/(\d+)/);
+              videoId = idMatch ? idMatch[1] : '';
+            }
           }
 
           // --- Build final embed URL ---
@@ -42,7 +50,10 @@
               ? `https://www.youtube.com/embed/videoseries?list=${videoId}&autoplay=1`
               : `https://www.youtube.com/embed/${videoId}?autoplay=1`;
           } else if (provider === 'vimeo') {
-            embedUrl = `https://player.vimeo.com/video/${videoId}?autoplay=1`;
+            // Vimeo events are not served from player.vimeo.com/video/{id}.
+            embedUrl = isEvent
+              ? `https://vimeo.com/event/${videoId}/embed?autoplay=1`
+              : `https://player.vimeo.com/video/${videoId}?autoplay=1`;
           }
 
           if (!embedUrl) return;


### PR DESCRIPTION
# Summary
Fixes Vimeo Livestream Event embeds that failed to play

## Backstory
[SHS-6570](https://app.clickup.com/t/36718269/SHS-6570)

## Need Review By (Date)
_[When does this need to be reviewed by? '10/30', 'asap', etc.]_

## Urgency
high

## Steps to Test
- [ ] Navigate to the test page on both multidev environments:
        [Colorful](https://hs-colorful-wiq0rmq8pvnk4zs1o8cofyyli5dpfdfg.tugboatqa.com/test-4)
        [Traditional](https://hs-traditional-wiq0rmq8pvnk4zs1o8cofyyli5dpfdfg.tugboatqa.com/test-2)
- [ ] Click the play button on the embedded Vimeo Event video.
- [ ] Verify that the iframe loads correctly and displays the following Vimeo privacy error (confirming the ID resolves properly, even if playback is restricted by domain settings):

<img width="1728" height="833" alt="image" src="https://github.com/user-attachments/assets/d7c02df1-e4c9-471d-9021-6aa6e7b4a838" />

- [ ] Regression check: Ensure standard Vimeo and YouTube embeds continue to play without issues.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213550149465316
  - https://app.asana.com/0/0/1217655683060596