### PR TITLE
SHS-6730: Issue with 'Remove' Button for Fields in View

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -270,7 +270,7 @@
             },
             "drupal/gin": {
                 "Override entity_subqueue breadcrumb handling": "patches/contrib/gin_entity_subqueue_breadcrumbs.patch",
-                "https://www.drupal.org/project/gin/issues/3598605: Delete button in Views UI - color and background-color are the same": "patches/contrib/gin-3598605-mr-804-20260812.patch"
+                "https://git.drupalcode.org/project/gin/-/work_items/3598605: Delete button in Views UI - color and background-color are the same": "patches/contrib/gin-3598605-mr-804-20260812.patch"
             },
             "drupal/hook_event_dispatcher": {
                 "https://www.drupal.org/project/hook_event_dispatcher/issues/3354751": "https://git.drupalcode.org/project/hook_event_dispatcher/-/merge_requests/133.patch"

--- a/composer.json
+++ b/composer.json
@@ -266,7 +266,8 @@
                 "https://www.drupal.org/project/field_group/issues/2969051": "https://www.drupal.org/files/issues/2024-09-13/2969051-166.patch"
             },
             "drupal/gin": {
-                "Override entity_subqueue breadcrumb handling": "patches/contrib/gin_entity_subqueue_breadcrumbs.patch"
+                "Override entity_subqueue breadcrumb handling": "patches/contrib/gin_entity_subqueue_breadcrumbs.patch",
+                "https://www.drupal.org/project/gin/issues/3598605: Delete button in Views UI - color and background-color are the same": "patches/contrib/gin-3598605-mr-804-20260812.patch"
             },
             "drupal/hook_event_dispatcher": {
                 "https://www.drupal.org/project/hook_event_dispatcher/issues/3354751": "https://git.drupalcode.org/project/hook_event_dispatcher/-/merge_requests/133.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "638d85237af75b95f44d11fd21094f26",
+    "content-hash": "25cadfddceee5b98bbf436570dbf5882",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/patches/contrib/gin-3598605-mr-804-20260812.patch
+++ b/patches/contrib/gin-3598605-mr-804-20260812.patch
@@ -1,0 +1,51 @@
+From 5d1052fb7e0efcedec4d33d43b86a6f075440125 Mon Sep 17 00:00:00 2001
+From: Stefan Korn <drupal@stefan-korn.de>
+Date: Thu, 2 Jul 2026 16:02:30 +0200
+Subject: [PATCH 1/2] fix: #3598605 Delete button in Views UI - color and
+ background-color are the same
+
+---
+ dist/css/components/dialog.css | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dist/css/components/dialog.css b/dist/css/components/dialog.css
+index ce561606..721862c6 100644
+--- a/dist/css/components/dialog.css
++++ b/dist/css/components/dialog.css
+@@ -119,6 +119,7 @@
+ .ui-dialog [data-drupal-selector*=-remove-form] .button.button--danger {
+   border-color: var(--gin-color-danger) !important;
+   background-color: var(--gin-color-danger) !important;
++  color: var(--gin-color-button-text) !important;
+ }
+ 
+ .ui-dialog .ui-dialog-buttonset {
+-- 
+GitLab
+
+
+From 32f171bd19e7e78fb55b9cac57681881be8b6c83 Mon Sep 17 00:00:00 2001
+From: Stefan Korn <drupal@stefan-korn.de>
+Date: Thu, 2 Jul 2026 16:09:04 +0200
+Subject: [PATCH 2/2] fix: #3598605 Delete button in Views UI - color and
+ background-color are the same
+
+---
+ styles/components/dialog.scss | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/styles/components/dialog.scss b/styles/components/dialog.scss
+index 31827327..7dc96f15 100644
+--- a/styles/components/dialog.scss
++++ b/styles/components/dialog.scss
+@@ -118,6 +118,7 @@
+     .button.button--danger {
+       border-color: var(--gin-color-danger) !important;
+       background-color: var(--gin-color-danger) !important;
++      color: var(--gin-color-button-text) !important;
+     }
+   }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
# Summary
Fixes invisible "Remove" button text in Views UI confirmation dialogs by applying an upstream Gin theme patch that sets an explicit text color on the danger button, so the label is no longer the same color as its background.

## Backstory
Ticket: [SHS-6730](https://app.clickup.com/t/36718269/SHS-6730)

## Need Review By (Date)
_[When does this need to be reviewed by? '10/30', 'asap', etc.]_

## Urgency
medium

1. Log in to both the [Colorful](https://hs-colorful-i0ukb2fs5gqowacxpsjw57btfyqf4n4b.tugboatqa.com/user) and [Traditional](https://hs-traditional-i0ukb2fs5gqowacxpsjw57btfyqf4n4b.tugboatqa.com/user) sites.
2. Go to the view page configuration on either the [Colorful](https://hs-colorful-i0ukb2fs5gqowacxpsjw57btfyqf4n4b.tugboatqa.com/admin/structure/views/view/hs_default_courses/edit/list?destination=/node/3896) or [Traditional](https://hs-traditional-i0ukb2fs5gqowacxpsjw57btfyqf4n4b.tugboatqa.com/admin/structure/views/view/hs_default_courses/edit/list?destination=/node/3896) site.
3. Click on a field to open its configuration modal and confirm the `Remove` button text is legible.

<img width="1722" height="831" alt="image" src="https://github.com/user-attachments/assets/ea105781-34ee-4712-9cb7-5ad6fcb1f2a5" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217080834266122