### PR TITLE
SHS-6741: Review and Update "None" Background Color option

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/style-selector-widgets.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/style-selector-widgets.css
@@ -258,12 +258,20 @@
 
   &[data-drupal-selector*="field-hs-callout-background-style-selector"] {
     .theme-humsci-colorful & {
+      .default input {
+        background-color: var(--color--colorful-global--white);
+      }
+
       .light input {
         background-color: var(--color--colorful-global--gray-light);
       }
     }
 
     .theme-humsci-traditional & {
+      .default input {
+        background-color: var(--color--colorful-global--white);
+      }
+
       .light input {
         background-color: var(--color--traditional-global--gray-light);
       }
@@ -364,6 +372,10 @@
 
   &[data-drupal-selector*="field-hs-collection-background-style-selector"] {
     .theme-humsci-colorful & {
+      .bg-none input {
+        background-color: var(--color--colorful-global--white);
+      }
+
       .default input {
         background-color: var(--color--colorful-pairings--tertiary-highlight);
       }
@@ -378,6 +390,10 @@
     }
 
     .theme-humsci-traditional & {
+      .bg-none input {
+        background-color: var(--color--traditional-global--white);
+      }
+
       .default input {
         background-color: var(--color--traditional-pairings--tertiary-highlight);
       }

--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/style-selector-widgets.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/style-selector-widgets.css
@@ -269,7 +269,7 @@
 
     .theme-humsci-traditional & {
       .default input {
-        background-color: var(--color--colorful-global--white);
+        background-color: var(--color--traditional-global--white);
       }
 
       .light input {


### PR DESCRIPTION
# Summary
- Update button color of "None" options in background color selection widgets

## Backstory
- [ClickUp Ticket](https://fourkitchens.clickup.com/t/36718269/SHS-6741)

## Need Review By (Date)
08/19

## Urgency
medium

## Steps to Test
1. Login into the [Colorful](https://hs-colorful-urqe6zq1arumbx3hwywqrodmrgrdfo7i.tugboatqa.com/user) and [Traditional](https://hs-traditional-urqe6zq1arumbx3hwywqrodmrgrdfo7i.tugboatqa.com/user) tugboat sites
2. Create a new Flexible Page ([Colorful](https://hs-colorful-urqe6zq1arumbx3hwywqrodmrgrdfo7i.tugboatqa.com/node/add/hs_basic_page), [Traditional](https://hs-traditional-urqe6zq1arumbx3hwywqrodmrgrdfo7i.tugboatqa.com/node/add/hs_basic_page))
3. Add both a "Collection" and a "Callout Box" components
4. Confirm that the "None" option in the "Background Color" field of both components is white:

Collection:
<img width="411" height="138" alt="Screenshot 2026-08-15 at 9 14 40 PM" src="https://github.com/user-attachments/assets/a3b6fdf0-84e1-474b-8f8b-566e576fc1bf" />

Callout Box:
<img width="280" height="141" alt="Screenshot 2026-08-15 at 9 14 12 PM" src="https://github.com/user-attachments/assets/f27053e4-8606-4288-8f65-f6c60e0dc307" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217249988557832
  - https://app.asana.com/0/0/1217574233661714