### PR TITLE
Update drupal/paragraphs_browser to 1.4.0, remove obsolete patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,6 @@
                 "Expose drag & drop on toolbar option https://www.drupal.org/project/paragraphs/issues/3470569": "https://git.drupalcode.org/project/paragraphs/-/merge_requests/142.patch"
             },
             "drupal/paragraphs_browser": {
-                "https://www.drupal.org/project/paragraphs_browser/issues/3381981": "https://www.drupal.org/files/issues/2023-08-22/3381981-sort-by-weight-4.patch",
                 "https://www.drupal.org/project/paragraphs_browser/issues/3064852": "https://www.drupal.org/files/issues/2023-11-07/3064852-allow-hiding-browser-12.patch"
             },
             "drupal/paragraphs_features": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15eaa46ec39a241fc38c7dfa98527fcc",
+    "content-hash": "72b618086085f10240f3128c41d1de45",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -9331,27 +9331,27 @@
         },
         {
             "name": "drupal/paragraphs_browser",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs_browser.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs_browser-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "2b154d47f72d2ab3e07e3857fcd4b3501b218f7e"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs_browser-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "19547592c6da8b99c75e09c0cd5f53182360fe61"
             },
             "require": {
-                "drupal/core": "^9.3 | ^10 | ^11",
+                "drupal/core": "^10.2 || ^11",
                 "drupal/paragraphs": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1731442115",
+                    "version": "8.x-1.4",
+                    "datestamp": "1787257228",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -14981,21 +14981,21 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "dc3285537f1832da8ddbbe45f5a007248b6cc00e"
+                "reference": "a0d2c458a2ff6ee8943ac4271b7f57d613529ae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/dc3285537f1832da8ddbbe45f5a007248b6cc00e",
-                "reference": "dc3285537f1832da8ddbbe45f5a007248b6cc00e",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/a0d2c458a2ff6ee8943ac4271b7f57d613529ae0",
+                "reference": "a0d2c458a2ff6ee8943ac4271b7f57d613529ae0",
                 "shasum": ""
             },
             "require": {
                 "pear/pear-core-minimal": "^1.10.0alpha2",
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "*"
@@ -15008,7 +15008,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -15047,7 +15047,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Archive_Tar",
                 "source": "https://github.com/pear/Archive_Tar"
             },
-            "time": "2025-07-19T14:49:16+00:00"
+            "time": "2026-08-19T17:37:49+00:00"
         },
         {
             "name": "pear/console_getopt",


### PR DESCRIPTION
# Summary
Removes a now-obsolete patch for `drupal/paragraphs_browser` (a merged Drupal.org issue was breaking the automated composer dependency update) and updates the module from 1.3.0 to 1.4.0. Also picks up the transitive `pear/archive_tar` bump (1.6.0 → 1.6.1) pulled in by the composer update.

## Backstory
A patch applied to `drupal/paragraphs_browser` in `composer.json` (for [3381981](https://www.drupal.org/project/paragraphs_browser/issues/3381981)) was merged upstream in the 8.x-1.4 release, which broke the automated composer dependency update job since the patch could no longer apply cleanly. Removed the obsolete patch entry and ran `composer update drupal/paragraphs_browser -W` to pick up the new release.

Reviewed the module's [1.3.0...1.4.0 diff](https://git.drupalcode.org/project/paragraphs_browser/-/compare/8.x-1.3...8.x-1.4?from_project_id=52367) and the [release notes](https://www.drupal.org/project/paragraphs_browser/releases/8.x-1.4). Nothing concerning. The experimental widget became stable and the inline widget became legacy (label changes only).

## Need Review By (Date)
asap

## Urgency
low

## Steps to Test
1. `composer install` and confirm the site still builds without errors.
2. Visit a content type/paragraph type that uses the paragraphs browser widget and confirm the widget still renders and functions (add/reorder/remove paragraphs).
3. Spot-check the paragraphs browser widget settings UI (experimental/legacy inline widget labels) for anything unexpected.
