### PR TITLE
HOTFIX | SHS-6746: Photo Album Visual Widget issue on custom field

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -14,7 +14,8 @@ use Drupal\paragraphs\ParagraphInterface;
  * Implements hook_form_alter().
  */
 function su_humsci_gin_admin_form_alter(&$form, $form_state, $form_id) {
-  // Adds the fe theme admin-preview library on flexible page, private page and event forms.
+  // Adds the fe theme admin-preview library on flexible page,
+  // private page and event forms.
   if (
     preg_match('/node_hs_(basic_page|private_page|event)(_edit)?_form/', $form_id) ||
     preg_match('/paragraph_\w+_entity_edit_form/', $form_id)

--- a/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
+++ b/docroot/themes/humsci/su_humsci_gin_admin/su_humsci_gin_admin.theme
@@ -14,9 +14,9 @@ use Drupal\paragraphs\ParagraphInterface;
  * Implements hook_form_alter().
  */
 function su_humsci_gin_admin_form_alter(&$form, $form_state, $form_id) {
-  // Adds the fe theme admin-preview library on flexible and private page forms.
+  // Adds the fe theme admin-preview library on flexible page, private page and event forms.
   if (
-    preg_match('/node_hs_(basic|private)_page(_edit)?_form/', $form_id) ||
+    preg_match('/node_hs_(basic_page|private_page|event)(_edit)?_form/', $form_id) ||
     preg_match('/paragraph_\w+_entity_edit_form/', $form_id)
   ) {
     $theme = \Drupal::config('system.theme')->get('default');


### PR DESCRIPTION
# Summary
Fix Photo Album Visual Widget issue on custom field

## Backstory
[SHS-6746](https://app.clickup.com/t/36718269/SHS-6746)

## Need Review By (Date)
asap

## Urgency
high

## Steps to Test
1. Log into this [tugboat environment ](https://pr2353-ofngphwhk5vyepa3v4ce1nabt3dbflod.tugboatqa.com/user) - these changes don't depend on the frontend theme, so it should work the same for colorful and traditional sites.
2. Create an Event and confirm there's a new custom field called "Event Photos" that has a "Photo Album" component in the "Event Details" tab. If there isn't, please let me know to add it or add a custom field that references the "Photo Album" paragraph in the Event Content Type.
3. Confirm the visual widget looks like this:

<img width="1024" height="474" alt="Screenshot 2026-08-21 at 10 36 34 PM" src="https://github.com/user-attachments/assets/1e1243a6-4984-45c3-bec3-d64b22ce4007" />

4. Add content and save the Event.
5. Edit it, and confirm the visual widget still looks as expected.

